### PR TITLE
Update NativeLibraryResolverTests.cs

### DIFF
--- a/tests/unit/NativeLibraryResolverTests.cs
+++ b/tests/unit/NativeLibraryResolverTests.cs
@@ -89,15 +89,20 @@ public sealed class NativeLibraryResolverTests
 
         try
         {
-            Environment.SetEnvironmentVariable("BANANA_NATIVE_PATH", tempDir);
             var expectedPath = Path.Combine(tempDir, libraryFile);
             var configuredPath = Path.Combine(tempDir, libraryFile);
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Native:LibraryPath"] = tempDir
+                })
+                .Build();
 
             var result = NativeLibraryResolver.ResolveLibrary(
                 "banana_native",
                 typeof(NativeLibraryResolver).Assembly,
                 null,
-                new ConfigurationBuilder().Build(),
+                configuration,
                 CreateLogger(),
                 path => path == expectedPath,
                 (string path, out nint handle) =>
@@ -116,7 +121,6 @@ public sealed class NativeLibraryResolverTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("BANANA_NATIVE_PATH", null);
             Directory.Delete(tempDir, true);
         }
     }
@@ -130,14 +134,19 @@ public sealed class NativeLibraryResolverTests
 
         try
         {
-            Environment.SetEnvironmentVariable("BANANA_NATIVE_PATH", tempDir);
             var expectedPath = Path.Combine(tempDir, libraryFile);
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Native:LibraryPath"] = tempDir
+                })
+                .Build();
 
             var result = NativeLibraryResolver.ResolveLibrary(
                 "banana_native",
                 typeof(NativeLibraryResolver).Assembly,
                 null,
-                new ConfigurationBuilder().Build(),
+                configuration,
                 CreateLogger(),
                 path => path == expectedPath,
                 static (string _, out nint handle) =>
@@ -156,7 +165,6 @@ public sealed class NativeLibraryResolverTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("BANANA_NATIVE_PATH", null);
             Directory.Delete(tempDir, true);
         }
     }


### PR DESCRIPTION
This pull request updates the way test configuration is handled in the `NativeLibraryResolverTests` by replacing environment variable usage with in-memory configuration. This makes the tests more reliable and less dependent on global state.

**Test configuration improvements:**

* Replaced setting and clearing of the `BANANA_NATIVE_PATH` environment variable with an in-memory configuration using `ConfigurationBuilder` and a dictionary for the `Native:LibraryPath` key in both `ResolveLibrary_WhenCandidatePathLoads_ReturnsPathHandle` and `ResolveLibrary_WhenPathLoadFails_UsesDefaultLoader` tests. [[1]](diffhunk://#diff-bcca06220c0a142ba8ce3239d9c1800671918e1084482eb2b9f622a5cf765445L92-R105) [[2]](diffhunk://#diff-bcca06220c0a142ba8ce3239d9c1800671918e1084482eb2b9f622a5cf765445L119) [[3]](diffhunk://#diff-bcca06220c0a142ba8ce3239d9c1800671918e1084482eb2b9f622a5cf765445L133-R149) [[4]](diffhunk://#diff-bcca06220c0a142ba8ce3239d9c1800671918e1084482eb2b9f622a5cf765445L159)