### PR TITLE
fix(ci): unblock workflow YAML parsing

### DIFF
--- a/.github/workflows/orchestrate-triaged-item-pr.yml
+++ b/.github/workflows/orchestrate-triaged-item-pr.yml
@@ -60,7 +60,7 @@ jobs:
       BANANA_TRIAGE_CHANGE_COMMAND: ${{ github.event.inputs.change_command }}
       BANANA_BASE_BRANCH: ${{ github.event.inputs.base_branch || 'main' }}
       BANANA_BRANCH_PREFIX: ${{ github.event.inputs.branch_prefix || 'triage' }}
-      BANANA_COMMIT_MESSAGE: ${{ github.event.inputs.commit_message || 'chore(triage): automated triaged change' }}
+      BANANA_COMMIT_MESSAGE: "${{ github.event.inputs.commit_message || 'chore(triage): automated triaged change' }}"
       BANANA_PR_TITLE: ${{ github.event.inputs.pr_title || '' }}
       BANANA_PR_BODY: ${{ github.event.inputs.pr_body || '' }}
       BANANA_DRAFT_PR: ${{ github.event.inputs.draft_pr || 'true' }}

--- a/.github/workflows/train-not-banana-model.yml
+++ b/.github/workflows/train-not-banana-model.yml
@@ -124,12 +124,11 @@ on:
   push:
     paths:
       - data/not-banana/**
+      - '!data/not-banana/model-release-history/**'
       - scripts/train-not-banana-model.py
       - scripts/manage-not-banana-model-image.py
       - scripts/workflow-persist-registry-history-pr.sh
       - .github/workflows/train-not-banana-model.yml
-    paths-ignore:
-      - data/not-banana/model-release-history/**
   schedule:
     - cron: "0 6 * * 1"
 


### PR DESCRIPTION
Fixes GitHub Actions parsing blockers:\n\n- Quote commit-message expression in orchestrate workflow env\n- Replace push paths-ignore with negated paths entry in train workflow\n\nThis unblocks workflow_dispatch for train-not-banana model persistence.