### PR TITLE
chore(sdlc): enforce AI contract preflight and all-agent feedback-loop linkage

### DIFF
--- a/.github/agents/api-interop-agent.agent.md
+++ b/.github/agents/api-interop-agent.agent.md
@@ -73,6 +73,7 @@ You own the managed side of Banana's native contract in [src/c-sharp/asp.net/Nat
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/api-pipeline-agent.agent.md
+++ b/.github/agents/api-pipeline-agent.agent.md
@@ -73,6 +73,7 @@ You own ASP.NET controllers, services, middleware, dependency injection wiring, 
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/banana-classifier-agent.agent.md
+++ b/.github/agents/banana-classifier-agent.agent.md
@@ -100,6 +100,7 @@ You own the product-specialized objective: a reliable AI that distinguishes what
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/banana-planner.agent.md
+++ b/.github/agents/banana-planner.agent.md
@@ -118,6 +118,7 @@ You produce implementation plans for Banana without editing code.
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/banana-reviewer.agent.md
+++ b/.github/agents/banana-reviewer.agent.md
@@ -92,6 +92,7 @@ Prioritize correctness, regressions, missing tests, environment drift, and relea
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/banana-sdlc.agent.md
+++ b/.github/agents/banana-sdlc.agent.md
@@ -135,6 +135,7 @@ Use this agent when the request spans more than one phase of delivery or more th
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/compose-runtime-agent.agent.md
+++ b/.github/agents/compose-runtime-agent.agent.md
@@ -73,6 +73,7 @@ You own Banana local runtime bring-up through [docker-compose.yml](../../docker-
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/csharp-api-agent.agent.md
+++ b/.github/agents/csharp-api-agent.agent.md
@@ -86,6 +86,7 @@ You own Banana ASP.NET work in [src/c-sharp/asp.net](../../src/c-sharp/asp.net) 
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/electron-agent.agent.md
+++ b/.github/agents/electron-agent.agent.md
@@ -74,6 +74,7 @@ You own the desktop runtime in [src/typescript/electron](../../src/typescript/el
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/infrastructure-agent.agent.md
+++ b/.github/agents/infrastructure-agent.agent.md
@@ -84,6 +84,7 @@ You own Banana's delivery surface: [docker-compose.yml](../../docker-compose.yml
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/integration-agent.agent.md
+++ b/.github/agents/integration-agent.agent.md
@@ -89,6 +89,7 @@ You handle cross-layer validation, test strategy, coverage, and integration tria
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/mobile-runtime-agent.agent.md
+++ b/.github/agents/mobile-runtime-agent.agent.md
@@ -75,6 +75,7 @@ You own Banana mobile runtime launch behavior that combines container channels w
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/native-c-agent.agent.md
+++ b/.github/agents/native-c-agent.agent.md
@@ -89,6 +89,7 @@ You own Banana native C changes in [src/native](../../src/native), [tests/native
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/native-core-agent.agent.md
+++ b/.github/agents/native-core-agent.agent.md
@@ -73,6 +73,7 @@ You own Banana core logic in [src/native/core](../../src/native/core) and the ma
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/native-dal-agent.agent.md
+++ b/.github/agents/native-dal-agent.agent.md
@@ -73,6 +73,7 @@ You own Banana native data access in [src/native/core/dal](../../src/native/core
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/native-wrapper-agent.agent.md
+++ b/.github/agents/native-wrapper-agent.agent.md
@@ -73,6 +73,7 @@ You own Banana's native ABI surface in [src/native/wrapper](../../src/native/wra
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/react-agent.agent.md
+++ b/.github/agents/react-agent.agent.md
@@ -189,6 +189,7 @@ If an existing app uses different conventions, preserve repo conventions and mig
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/react-ui-agent.agent.md
+++ b/.github/agents/react-ui-agent.agent.md
@@ -75,6 +75,7 @@ You own React UI work in [src/typescript/react/src](../../src/typescript/react/s
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/test-triage-agent.agent.md
+++ b/.github/agents/test-triage-agent.agent.md
@@ -79,6 +79,7 @@ You separate Banana validation failures into product defects, harness defects, a
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/workflow-agent.agent.md
+++ b/.github/agents/workflow-agent.agent.md
@@ -75,6 +75,7 @@ You own GitHub Actions and CI automation in [.github/workflows](../workflows), i
 ## Cross-Domain Teaming Protocol
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/skills/banana-build-and-run/entry-points.md
+++ b/.github/skills/banana-build-and-run/entry-points.md
@@ -64,6 +64,7 @@
 - Feedback PR orchestration script: `bash scripts/orchestrate-not-banana-feedback-loop.sh`
 - Feedback PR orchestration workflow: `.github/workflows/orchestrate-not-banana-feedback-loop.yml`
 - Wiki sync script: `bash scripts/workflow-sync-wiki.sh` (supports `BANANA_WIKI_*` env vars)
+- AI contract validation script: `python scripts/validate-ai-contracts.py` (verifies prompt/agent/instruction/skill frontmatter and wiki-sync coverage)
 - Incremental SDLC orchestration script: `bash scripts/workflow-orchestrate-sdlc.sh`
 - Local SDLC dry-run script: `bash scripts/workflow-local-orchestrate-sdlc.sh`
 - Full SDLC orchestration workflow: `.github/workflows/orchestrate-banana-sdlc.yml`

--- a/.github/workflows/orchestrate-banana-sdlc.yml
+++ b/.github/workflows/orchestrate-banana-sdlc.yml
@@ -63,6 +63,14 @@ on:
         options:
           - "true"
           - "false"
+      validate_ai_contracts:
+        description: Validate .github AI customization and wiki-sync contracts before running increments
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
       wiki_dry_run:
         description: Run wiki synchronization in dry-run mode
         required: false
@@ -114,6 +122,7 @@ jobs:
       BANANA_SDLC_SKIP_NO_CHANGES: ${{ github.event.inputs.skip_no_changes || 'true' }}
       BANANA_SDLC_CONTINUE_ON_ERROR: ${{ github.event.inputs.continue_on_error || 'false' }}
       BANANA_SDLC_ENABLE_WIKI_SYNC: ${{ github.event.inputs.sync_wiki || 'true' }}
+      BANANA_SDLC_VALIDATE_AI_CONTRACTS: ${{ github.event.inputs.validate_ai_contracts || 'true' }}
       BANANA_WIKI_DRY_RUN: ${{ github.event.inputs.wiki_dry_run || 'false' }}
       BANANA_WIKI_PUSH: ${{ github.event.inputs.wiki_push || 'true' }}
       BANANA_WIKI_STRICT: ${{ github.event.inputs.wiki_strict || 'false' }}

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Automated SDLC orchestration (incremental PR slices + wiki sync):
 - Run workflow `Orchestrate Banana SDLC` to execute multiple incremental automation slices in one run.
 - Each increment uses the same GH CLI PR engine as `Orchestrate Triaged Item Pull Request`, but with per-slice commands, commit messages, and PR metadata.
 - Inputs support inline `incremental_plan_json` plus global defaults for base branch, labels, reviewers, draft mode, and no-op behavior.
+- AI contract preflight validation runs by default (`validate_ai_contracts=true`) and fails fast if `.github` prompt/agent/instruction/skill or wiki-sync contracts drift.
 - Wiki layer runs after PR orchestration via `scripts/workflow-sync-wiki.sh` and can push commits to the GitHub wiki repo (or run dry-run for validation).
 - Workflow runs on `workflow_dispatch` and on a weekday schedule for unattended incremental automation.
 - Default plan includes:

--- a/scripts/validate-ai-contracts.py
+++ b/scripts/validate-ai-contracts.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Validate Banana AI customization contracts under .github."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+GITHUB_DIR = ROOT / ".github"
+PROMPTS_DIR = GITHUB_DIR / "prompts"
+AGENTS_DIR = GITHUB_DIR / "agents"
+INSTRUCTIONS_DIR = GITHUB_DIR / "instructions"
+SKILLS_DIR = GITHUB_DIR / "skills"
+WORKFLOW_SYNC_WIKI = ROOT / "scripts" / "workflow-sync-wiki.sh"
+
+AGENT_CONTRACT_FRAGMENT = "Feedback Loop And Incremental Branch Contract"
+PROMPT_WIKI_CONTRACT_HEADER = "## Wiki Updater Contract"
+SKILL_NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
+
+
+def parse_frontmatter(path: Path) -> tuple[dict[str, str] | None, str]:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return None, text
+
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return None, text
+
+    frontmatter = text[4:end]
+    body = text[end + 5 :]
+
+    data: dict[str, str] = {}
+    for raw_line in frontmatter.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        data[key.strip()] = value.strip().strip('"\'')
+
+    return data, body
+
+
+def gather_contract_mappings() -> set[str]:
+    """Expected prompt pages written by scripts/workflow-sync-wiki.sh default mapping."""
+    prompt_targets: set[str] = set()
+
+    for prompt_path in sorted(PROMPTS_DIR.glob("*.prompt.md")):
+        prompt_name = prompt_path.name.removesuffix(".prompt.md")
+        prompt_targets.add(f"Auto-Prompts/{prompt_name}.md")
+
+    return prompt_targets
+
+
+def main() -> int:
+    issues: list[str] = []
+    prompt_missing_wiki_contract: list[str] = []
+
+    # Prompts
+    for prompt_path in sorted(PROMPTS_DIR.glob("*.prompt.md")):
+        frontmatter, body = parse_frontmatter(prompt_path)
+        rel = prompt_path.relative_to(ROOT).as_posix()
+
+        if frontmatter is None:
+            issues.append(f"PROMPT missing/invalid frontmatter: {rel}")
+            continue
+
+        for required in ("name", "description", "argument-hint", "agent"):
+            if not frontmatter.get(required):
+                issues.append(f"PROMPT missing {required}: {rel}")
+
+        if PROMPT_WIKI_CONTRACT_HEADER not in body:
+            prompt_missing_wiki_contract.append(rel)
+
+    # Agents
+    for agent_path in sorted(AGENTS_DIR.glob("*.agent.md")):
+        frontmatter, body = parse_frontmatter(agent_path)
+        rel = agent_path.relative_to(ROOT).as_posix()
+
+        if frontmatter is None:
+            issues.append(f"AGENT missing/invalid frontmatter: {rel}")
+            continue
+
+        if not frontmatter.get("description"):
+            issues.append(f"AGENT missing description: {rel}")
+
+        if AGENT_CONTRACT_FRAGMENT not in body:
+            issues.append(f"AGENT missing feedback-loop contract link: {rel}")
+
+    # Instructions
+    for instruction_path in sorted(INSTRUCTIONS_DIR.glob("*.instructions.md")):
+        frontmatter, _ = parse_frontmatter(instruction_path)
+        rel = instruction_path.relative_to(ROOT).as_posix()
+
+        if frontmatter is None:
+            issues.append(f"INSTRUCTION missing/invalid frontmatter: {rel}")
+            continue
+
+        if not frontmatter.get("description"):
+            issues.append(f"INSTRUCTION missing description: {rel}")
+
+    # Skills
+    for skill_path in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+        frontmatter, _ = parse_frontmatter(skill_path)
+        rel = skill_path.relative_to(ROOT).as_posix()
+
+        if frontmatter is None:
+            issues.append(f"SKILL missing/invalid frontmatter: {rel}")
+            continue
+
+        name = frontmatter.get("name", "")
+        folder_name = skill_path.parent.name
+
+        if not name:
+            issues.append(f"SKILL missing name: {rel}")
+        elif name != folder_name:
+            issues.append(f"SKILL name mismatch ({name} != {folder_name}): {rel}")
+        elif not SKILL_NAME_RE.match(name):
+            issues.append(f"SKILL invalid name format: {rel}")
+
+        if not frontmatter.get("description"):
+            issues.append(f"SKILL missing description: {rel}")
+
+    # Ensure prompt auto-sync mapping logic exists
+    workflow_sync_text = WORKFLOW_SYNC_WIKI.read_text(encoding="utf-8")
+    expected_targets = gather_contract_mappings()
+
+    if "find .github/prompts -maxdepth 1 -type f -name \"*.prompt.md\"" not in workflow_sync_text:
+        issues.append("WIKI_SYNC missing dynamic .github/prompts mapping block")
+
+    if "Auto-Prompts/${prompt_name}.md" not in workflow_sync_text:
+        issues.append("WIKI_SYNC missing Auto-Prompts target mapping")
+
+    payload: dict[str, Any] = {
+        "issues": issues,
+        "prompt_missing_wiki_contract": prompt_missing_wiki_contract,
+        "prompt_count": len(list(PROMPTS_DIR.glob("*.prompt.md"))),
+        "expected_prompt_wiki_targets": sorted(expected_targets),
+    }
+
+    print(json.dumps(payload, indent=2))
+
+    if issues or prompt_missing_wiki_contract:
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workflow-orchestrate-sdlc.sh
+++ b/scripts/workflow-orchestrate-sdlc.sh
@@ -26,6 +26,11 @@ SUMMARY_PATH="${BANANA_SDLC_SUMMARY_PATH:-${OUTPUT_DIR}/summary-${RUN_ID}-attemp
 
 mkdir -p "$OUTPUT_DIR"
 
+if [[ "${BANANA_SDLC_VALIDATE_AI_CONTRACTS:-true}" == "true" ]]; then
+  echo "Validating AI customization and wiki-sync contracts..."
+  python scripts/validate-ai-contracts.py > "${OUTPUT_DIR}/ai-contract-report-${RUN_ID}-attempt-${RUN_ATTEMPT}.json"
+fi
+
 PLAN_INPUT_PATH="${OUTPUT_DIR}/plan-${RUN_ID}-attempt-${RUN_ATTEMPT}.json"
 PLAN_ROWS_PATH="${OUTPUT_DIR}/plan-rows-${RUN_ID}-attempt-${RUN_ATTEMPT}.tsv"
 WIKI_REPORT_PATH="${OUTPUT_DIR}/wiki-sync-${RUN_ID}-attempt-${RUN_ATTEMPT}.json"


### PR DESCRIPTION
## Summary\n- propagate feedback-loop incremental branch contract reference across all agent files\n- add scripts/validate-ai-contracts.py to fail fast on AI customization drift\n- run AI contract preflight in scripts/workflow-orchestrate-sdlc.sh by default\n- expose validate_ai_contracts input in orchestrate-banana-sdlc workflow\n- document validator entry point in AI build/run references and README\n\n## Validation\n- python scripts/validate-ai-contracts.py\n- bash -n scripts/workflow-orchestrate-sdlc.sh scripts/workflow-sync-wiki.sh\n- VS Code diagnostics (no errors in touched files)\n\n## Contract impact\n- ties feedback-loop and incremental GH CLI orchestration into all agents as explicit contract guidance\n- enforces wiki-sync and prompt contract integrity before SDLC increments run