### PR TITLE
chore(sdlc): enforce wiki git sync contract across automation flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,8 @@ BANANA_WIKI_DRY_RUN=true
 BANANA_WIKI_PUSH=false
 BANANA_WIKI_STRICT=false
 BANANA_WIKI_DIR=artifacts/wiki-sync/local-wiki-dry-run
+# Banana canonical wiki remote; override this value when running from a fork.
+BANANA_WIKI_REMOTE_URL=https://github.com/LahkLeKey/Banana.wiki.git
 BANANA_WIKI_SYNC_MAPPING=
 BANANA_WIKI_COMMIT_MESSAGE=docs(wiki): sync automated SDLC documentation snapshots
 

--- a/.github/skills/banana-build-and-run/entry-points.md
+++ b/.github/skills/banana-build-and-run/entry-points.md
@@ -64,6 +64,7 @@
 - Feedback PR orchestration script: `bash scripts/orchestrate-not-banana-feedback-loop.sh`
 - Feedback PR orchestration workflow: `.github/workflows/orchestrate-not-banana-feedback-loop.yml`
 - Wiki sync script: `bash scripts/workflow-sync-wiki.sh` (supports `BANANA_WIKI_*` env vars)
+- Example explicit Banana wiki remote (override for forks): `BANANA_WIKI_REMOTE_URL=https://github.com/LahkLeKey/Banana.wiki.git`
 - AI contract validation script: `python scripts/validate-ai-contracts.py` (verifies prompt/agent/instruction/skill frontmatter and wiki-sync coverage)
 - Incremental SDLC orchestration script: `bash scripts/workflow-orchestrate-sdlc.sh`
 - Local SDLC dry-run script: `bash scripts/workflow-local-orchestrate-sdlc.sh`

--- a/.github/workflows/orchestrate-banana-sdlc.yml
+++ b/.github/workflows/orchestrate-banana-sdlc.yml
@@ -99,6 +99,10 @@ on:
         description: Commit message used for wiki synchronization commits
         required: false
         default: "docs(wiki): sync automated SDLC documentation snapshots"
+      wiki_remote_url:
+        description: Optional explicit wiki git remote URL
+        required: false
+        default: ""
       wiki_sync_mapping:
         description: Optional newline-delimited source|target mapping for wiki sync
         required: false
@@ -125,8 +129,9 @@ jobs:
       BANANA_SDLC_VALIDATE_AI_CONTRACTS: ${{ github.event.inputs.validate_ai_contracts || 'true' }}
       BANANA_WIKI_DRY_RUN: ${{ github.event.inputs.wiki_dry_run || 'false' }}
       BANANA_WIKI_PUSH: ${{ github.event.inputs.wiki_push || 'true' }}
-      BANANA_WIKI_STRICT: ${{ github.event.inputs.wiki_strict || 'false' }}
+      BANANA_WIKI_STRICT: ${{ github.event_name == 'schedule' && 'true' || github.event.inputs.wiki_strict || 'false' }}
       BANANA_WIKI_COMMIT_MESSAGE: ${{ github.event.inputs.wiki_commit_message || 'docs(wiki): sync automated SDLC documentation snapshots' }}
+      BANANA_WIKI_REMOTE_URL: ${{ github.event.inputs.wiki_remote_url || format('https://github.com/{0}.wiki.git', github.repository) }}
       BANANA_WIKI_SYNC_MAPPING: ${{ github.event.inputs.wiki_sync_mapping || '' }}
     steps:
       - name: Checkout

--- a/.github/workflows/orchestrate-not-banana-feedback-loop.yml
+++ b/.github/workflows/orchestrate-not-banana-feedback-loop.yml
@@ -83,6 +83,50 @@ on:
         description: Optional reviewer usernames as comma-separated values or [array] syntax
         required: false
         default: ""
+      sync_wiki:
+        description: Run wiki synchronization after feedback-loop pull request orchestration
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      wiki_dry_run:
+        description: Run wiki synchronization in dry-run mode
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      wiki_push:
+        description: Push wiki commits to remote when wiki sync is not dry-run
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      wiki_strict:
+        description: Fail workflow when wiki repository cannot be cloned or pushed
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      wiki_commit_message:
+        description: Commit message used for wiki synchronization commits
+        required: false
+        default: "docs(wiki): sync automated SDLC documentation snapshots"
+      wiki_remote_url:
+        description: Optional explicit wiki git remote URL
+        required: false
+        default: ""
+      wiki_sync_mapping:
+        description: Optional newline-delimited source|target mapping for wiki sync
+        required: false
+        default: ""
   schedule:
     - cron: "0 8 * * 1-5"
 
@@ -108,6 +152,12 @@ jobs:
       BANANA_DRAFT_PR: ${{ github.event.inputs.draft_pr || 'true' }}
       BANANA_PR_LABELS: ${{ github.event.inputs.labels || 'automation,triaged-item,requires-human-approval,feedback-loop' }}
       BANANA_PR_REVIEWERS: ${{ github.event.inputs.reviewers || '' }}
+      BANANA_WIKI_DRY_RUN: ${{ github.event.inputs.wiki_dry_run || 'false' }}
+      BANANA_WIKI_PUSH: ${{ github.event.inputs.wiki_push || 'true' }}
+      BANANA_WIKI_STRICT: ${{ github.event_name == 'schedule' && 'true' || github.event.inputs.wiki_strict || 'false' }}
+      BANANA_WIKI_COMMIT_MESSAGE: ${{ github.event.inputs.wiki_commit_message || 'docs(wiki): sync automated SDLC documentation snapshots' }}
+      BANANA_WIKI_REMOTE_URL: ${{ github.event.inputs.wiki_remote_url || format('https://github.com/{0}.wiki.git', github.repository) }}
+      BANANA_WIKI_SYNC_MAPPING: ${{ github.event.inputs.wiki_sync_mapping || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -117,3 +167,8 @@ jobs:
       - name: Apply approved feedback and open pull request
         run: |
           bash scripts/orchestrate-not-banana-feedback-loop.sh
+
+      - name: Sync wiki snapshots for feedback-loop automation
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.sync_wiki != 'false' }}
+        run: |
+          bash scripts/workflow-sync-wiki.sh

--- a/.github/workflows/orchestrate-triaged-item-pr.yml
+++ b/.github/workflows/orchestrate-triaged-item-pr.yml
@@ -57,6 +57,50 @@ on:
         options:
           - "true"
           - "false"
+      sync_wiki:
+        description: Run wiki synchronization after triaged pull request orchestration
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      wiki_dry_run:
+        description: Run wiki synchronization in dry-run mode
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      wiki_push:
+        description: Push wiki commits to remote when wiki sync is not dry-run
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      wiki_strict:
+        description: Fail workflow when wiki repository cannot be cloned or pushed
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      wiki_commit_message:
+        description: Commit message used for wiki synchronization commits
+        required: false
+        default: "docs(wiki): sync automated SDLC documentation snapshots"
+      wiki_remote_url:
+        description: Optional explicit wiki git remote URL
+        required: false
+        default: ""
+      wiki_sync_mapping:
+        description: Optional newline-delimited source|target mapping for wiki sync
+        required: false
+        default: ""
 
 jobs:
   orchestrate-triaged-pr:
@@ -75,6 +119,12 @@ jobs:
       BANANA_PR_LABELS: ${{ github.event.inputs.labels || 'automation,triaged-item,requires-human-approval' }}
       BANANA_PR_REVIEWERS: ${{ github.event.inputs.reviewers || '' }}
       BANANA_SKIP_IF_NO_CHANGES: ${{ github.event.inputs.skip_if_no_changes || 'false' }}
+      BANANA_WIKI_DRY_RUN: ${{ github.event.inputs.wiki_dry_run || 'false' }}
+      BANANA_WIKI_PUSH: ${{ github.event.inputs.wiki_push || 'true' }}
+      BANANA_WIKI_STRICT: ${{ github.event.inputs.wiki_strict || 'false' }}
+      BANANA_WIKI_COMMIT_MESSAGE: ${{ github.event.inputs.wiki_commit_message || 'docs(wiki): sync automated SDLC documentation snapshots' }}
+      BANANA_WIKI_REMOTE_URL: ${{ github.event.inputs.wiki_remote_url || format('https://github.com/{0}.wiki.git', github.repository) }}
+      BANANA_WIKI_SYNC_MAPPING: ${{ github.event.inputs.wiki_sync_mapping || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -83,3 +133,7 @@ jobs:
 
       - name: Generate triaged branch, commit changes, and open PR
         run: bash scripts/workflow-orchestrate-triaged-item-pr.sh
+
+      - name: Sync wiki snapshots for triaged automation
+        if: ${{ github.event.inputs.sync_wiki != 'false' }}
+        run: bash scripts/workflow-sync-wiki.sh

--- a/.github/workflows/require-human-approval.yml
+++ b/.github/workflows/require-human-approval.yml
@@ -64,6 +64,13 @@ jobs:
               return;
             }
 
+            if (pr.draft) {
+              core.notice(
+                "Automation pull request is in draft state. Human-approval enforcement starts when it is ready for review."
+              );
+              return;
+            }
+
             if (labels.includes(soloBypassLabel)) {
               const prAuthor = (pr.user?.login || "").toLowerCase();
               const repoOwner = (context.repo.owner || "").toLowerCase();

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ Automation pull request orchestration for triaged code changes:
   - `change_command`
   - optional branch/label/reviewer overrides
 - The workflow creates a branch, commits generated changes, opens a PR, and labels it with `requires-human-approval` by default.
+- The workflow now runs `scripts/workflow-sync-wiki.sh` in the same run by default (`sync_wiki=true`).
+- Wiki remote defaults to `https://github.com/<owner>/<repo>.wiki.git` and can be overridden with input `wiki_remote_url` (for Banana: `https://github.com/LahkLeKey/Banana.wiki.git`).
 
 Feedback-loop orchestration for classifier improvement:
 
@@ -297,6 +299,8 @@ Feedback-loop orchestration for classifier improvement:
   - open an automation PR labeled `feedback-loop`
 - Workflow inputs `require_human_review` (default `true`) and
   `min_human_reviewers` (default `1`) control this gate.
+- The workflow also runs `scripts/workflow-sync-wiki.sh` by default (`sync_wiki=true`) and supports `wiki_remote_url` when an explicit wiki git remote is required.
+- Weekday scheduled feedback-loop runs force strict wiki sync behavior (`BANANA_WIKI_STRICT=true`) so wiki clone/push failures fail the run.
 - After feedback PR merge, `Train Not-Banana Model` push run automatically persists registry history when `data/not-banana/corpus.json` changes.
 - Loop summary: approved feedback -> corpus PR -> human merge -> train + persisted registry-history PR.
 
@@ -307,6 +311,8 @@ Automated SDLC orchestration (incremental PR slices + wiki sync):
 - Inputs support inline `incremental_plan_json` plus global defaults for base branch, labels, reviewers, draft mode, and no-op behavior.
 - AI contract preflight validation runs by default (`validate_ai_contracts=true`) and fails fast if `.github` prompt/agent/instruction/skill or wiki-sync contracts drift.
 - Wiki layer runs after PR orchestration via `scripts/workflow-sync-wiki.sh` and can push commits to the GitHub wiki repo (or run dry-run for validation).
+- Input `wiki_remote_url` can pin the wiki target when needed (example: `https://github.com/LahkLeKey/Banana.wiki.git`).
+- Weekday scheduled SDLC runs force strict wiki sync behavior (`BANANA_WIKI_STRICT=true`) so wiki clone/push failures fail the run.
 - Workflow runs on `workflow_dispatch` and on a weekday schedule for unattended incremental automation.
 - Default plan includes:
   - feedback ingestion into `data/not-banana/corpus.json`
@@ -330,6 +336,7 @@ Human-approval merge gate:
 
 - Workflow `Require Human Approval (Automation PRs)` blocks automation PRs until at least one non-bot approval is present.
 - Automation PR detection now includes automation labels, known automation branch prefixes, and bot-authored PRs.
+- Draft-aware enforcement: draft automation PRs are allowed to stage changes, and the gate is enforced when the PR becomes ready for review.
 - Add this check as required in your protected-branch ruleset so merge remains blocked until a human review approves.
 - Keep branch settings aligned with `Require a pull request before merging` and reviewer requirements.
 - Solo maintainer option: add label `solo-maintainer-bypass` to an owner-authored automation PR to bypass the gate when no second human reviewer exists.

--- a/scripts/validate-ai-contracts.py
+++ b/scripts/validate-ai-contracts.py
@@ -16,6 +16,10 @@ AGENTS_DIR = GITHUB_DIR / "agents"
 INSTRUCTIONS_DIR = GITHUB_DIR / "instructions"
 SKILLS_DIR = GITHUB_DIR / "skills"
 WORKFLOW_SYNC_WIKI = ROOT / "scripts" / "workflow-sync-wiki.sh"
+WORKFLOW_ORCHESTRATE_SDLC = ROOT / ".github" / "workflows" / "orchestrate-banana-sdlc.yml"
+WORKFLOW_ORCHESTRATE_TRIAGED = ROOT / ".github" / "workflows" / "orchestrate-triaged-item-pr.yml"
+WORKFLOW_ORCHESTRATE_FEEDBACK = ROOT / ".github" / "workflows" / "orchestrate-not-banana-feedback-loop.yml"
+SCRIPT_ORCHESTRATE_SDLC = ROOT / "scripts" / "workflow-orchestrate-sdlc.sh"
 
 AGENT_CONTRACT_FRAGMENT = "Feedback Loop And Incremental Branch Contract"
 PROMPT_WIKI_CONTRACT_HEADER = "## Wiki Updater Contract"
@@ -136,6 +140,42 @@ def main() -> int:
 
     if "Auto-Prompts/${prompt_name}.md" not in workflow_sync_text:
         issues.append("WIKI_SYNC missing Auto-Prompts target mapping")
+
+    workflow_contract_targets = [
+        WORKFLOW_ORCHESTRATE_TRIAGED,
+        WORKFLOW_ORCHESTRATE_FEEDBACK,
+    ]
+    for workflow_path in workflow_contract_targets:
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        workflow_rel = workflow_path.relative_to(ROOT).as_posix()
+
+        if "workflow-sync-wiki.sh" not in workflow_text:
+            issues.append(f"WORKFLOW missing wiki sync step: {workflow_rel}")
+
+        if "BANANA_WIKI_REMOTE_URL" not in workflow_text:
+            issues.append(f"WORKFLOW missing BANANA_WIKI_REMOTE_URL wiring: {workflow_rel}")
+
+        if workflow_path == WORKFLOW_ORCHESTRATE_FEEDBACK:
+            if "github.event_name == 'schedule' && 'true'" not in workflow_text:
+                issues.append(f"WORKFLOW missing schedule-forced wiki strict mode: {workflow_rel}")
+
+    sdlc_workflow_text = WORKFLOW_ORCHESTRATE_SDLC.read_text(encoding="utf-8")
+    sdlc_workflow_rel = WORKFLOW_ORCHESTRATE_SDLC.relative_to(ROOT).as_posix()
+    if "workflow-orchestrate-sdlc.sh" not in sdlc_workflow_text:
+        issues.append(f"WORKFLOW missing SDLC orchestration step: {sdlc_workflow_rel}")
+
+    if "BANANA_WIKI_REMOTE_URL" not in sdlc_workflow_text:
+        issues.append(f"WORKFLOW missing BANANA_WIKI_REMOTE_URL wiring: {sdlc_workflow_rel}")
+
+    if "github.event_name == 'schedule' && 'true'" not in sdlc_workflow_text:
+        issues.append(f"WORKFLOW missing schedule-forced wiki strict mode: {sdlc_workflow_rel}")
+
+    sdlc_script_text = SCRIPT_ORCHESTRATE_SDLC.read_text(encoding="utf-8")
+    if "WIKI_REMOTE_URL=" not in sdlc_script_text:
+        issues.append("SDLC script missing WIKI_REMOTE_URL input wiring")
+
+    if 'export BANANA_WIKI_REMOTE_URL="$WIKI_REMOTE_URL"' not in sdlc_script_text:
+        issues.append("SDLC script missing BANANA_WIKI_REMOTE_URL export")
 
     payload: dict[str, Any] = {
         "issues": issues,

--- a/scripts/workflow-local-orchestrate-triaged-item-pr.sh
+++ b/scripts/workflow-local-orchestrate-triaged-item-pr.sh
@@ -15,5 +15,13 @@ export BANANA_DRAFT_PR="${BANANA_DRAFT_PR:-true}"
 export BANANA_PR_LABELS="${BANANA_PR_LABELS:-automation,triaged-item,requires-human-approval}"
 export BANANA_PR_REVIEWERS="${BANANA_PR_REVIEWERS:-}"
 export BANANA_LOCAL_DRY_RUN="${BANANA_LOCAL_DRY_RUN:-true}"
+export BANANA_ENABLE_WIKI_SYNC="${BANANA_ENABLE_WIKI_SYNC:-true}"
+export BANANA_WIKI_DRY_RUN="${BANANA_WIKI_DRY_RUN:-true}"
+export BANANA_WIKI_PUSH="${BANANA_WIKI_PUSH:-false}"
+export BANANA_WIKI_DIR="${BANANA_WIKI_DIR:-artifacts/wiki-sync/local-wiki-dry-run}"
 
 bash scripts/workflow-orchestrate-triaged-item-pr.sh
+
+if [[ "$BANANA_ENABLE_WIKI_SYNC" == "true" ]]; then
+	bash scripts/workflow-sync-wiki.sh
+fi

--- a/scripts/workflow-orchestrate-sdlc.sh
+++ b/scripts/workflow-orchestrate-sdlc.sh
@@ -21,6 +21,7 @@ WIKI_DRY_RUN="${BANANA_WIKI_DRY_RUN:-false}"
 WIKI_PUSH="${BANANA_WIKI_PUSH:-true}"
 WIKI_STRICT="${BANANA_WIKI_STRICT:-false}"
 WIKI_COMMIT_MESSAGE="${BANANA_WIKI_COMMIT_MESSAGE:-docs(wiki): sync automated SDLC documentation snapshots}"
+WIKI_REMOTE_URL="${BANANA_WIKI_REMOTE_URL:-}"
 OUTPUT_DIR="${BANANA_SDLC_OUTPUT_DIR:-artifacts/sdlc-orchestration}"
 SUMMARY_PATH="${BANANA_SDLC_SUMMARY_PATH:-${OUTPUT_DIR}/summary-${RUN_ID}-attempt-${RUN_ATTEMPT}.json}"
 
@@ -235,6 +236,7 @@ if [[ "$ENABLE_WIKI_SYNC" == "true" ]]; then
   export BANANA_WIKI_PUSH="$WIKI_PUSH"
   export BANANA_WIKI_STRICT="$WIKI_STRICT"
   export BANANA_WIKI_COMMIT_MESSAGE="$WIKI_COMMIT_MESSAGE"
+  export BANANA_WIKI_REMOTE_URL="$WIKI_REMOTE_URL"
   export BANANA_WIKI_OUTPUT_PATH="$WIKI_REPORT_PATH"
   bash scripts/workflow-sync-wiki.sh
 fi

--- a/scripts/workflow-sync-wiki.sh
+++ b/scripts/workflow-sync-wiki.sh
@@ -63,17 +63,62 @@ PY
   exit 0
 fi
 
+extract_repo_slug_from_url() {
+  local remote_url="$1"
+  local normalized="${remote_url%.git}"
+
+  if [[ "$normalized" =~ ^https://github\.com/([^/]+/[^/]+)$ ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  if [[ "$normalized" =~ ^git@github\.com:([^/]+/[^/]+)$ ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  if [[ "$normalized" =~ ^ssh://git@github\.com/([^/]+/[^/]+)$ ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  return 1
+}
+
 if [[ -z "$WIKI_REPOSITORY" ]] && command -v gh >/dev/null 2>&1; then
   if repo_name="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)"; then
     WIKI_REPOSITORY="$repo_name"
   fi
 fi
 
+if [[ -z "$WIKI_REPOSITORY" ]]; then
+  origin_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+  if [[ -n "$origin_url" ]]; then
+    if repo_name="$(extract_repo_slug_from_url "$origin_url")"; then
+      WIKI_REPOSITORY="$repo_name"
+    fi
+  fi
+fi
+
 if [[ ! -d "$WIKI_DIR/.git" ]]; then
   if [[ -z "$WIKI_REMOTE_URL" ]]; then
     if [[ -z "$WIKI_REPOSITORY" ]]; then
-      echo "::error::Cannot determine wiki repository slug. Set BANANA_WIKI_REPOSITORY or BANANA_WIKI_REMOTE_URL."
-      exit 1
+      if [[ "$WIKI_STRICT" == "true" ]]; then
+        echo "::error::Cannot determine wiki repository slug. Set BANANA_WIKI_REPOSITORY or BANANA_WIKI_REMOTE_URL (for example https://github.com/LahkLeKey/Banana.wiki.git)."
+        exit 1
+      fi
+
+      echo "::warning::Cannot determine wiki repository slug. Skipping wiki sync because strict mode is disabled."
+      python - "$WIKI_OUTPUT_PATH" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps({"status": "skipped", "reason": "wiki repository unresolved"}, indent=2) + "\n", encoding="utf-8")
+PY
+      exit 0
     fi
     WIKI_REMOTE_URL="https://github.com/${WIKI_REPOSITORY}.wiki.git"
   fi
@@ -201,11 +246,14 @@ if [[ "$WIKI_DRY_RUN" == "true" ]]; then
   echo "Wiki sync dry-run changes: ${changed_pages[*]}"
   status="dry-run"
   commit_sha=""
+  push_status="dry-run"
 else
   git -C "$WIKI_DIR" config user.name "github-actions[bot]"
   git -C "$WIKI_DIR" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
   git -C "$WIKI_DIR" commit -m "$WIKI_COMMIT_MESSAGE" >/dev/null
   commit_sha="$(git -C "$WIKI_DIR" rev-parse HEAD)"
+
+  push_status="not-requested"
 
   if [[ "$WIKI_PUSH" == "true" ]]; then
     if [[ -n "${GH_TOKEN:-}" ]]; then
@@ -215,10 +263,25 @@ else
       fi
     fi
 
-    git -C "$WIKI_DIR" push origin HEAD >/dev/null
+    if git -C "$WIKI_DIR" push origin HEAD >/dev/null 2>&1; then
+      push_status="pushed"
+    else
+      push_status="push-failed"
+      if [[ "$WIKI_STRICT" == "true" ]]; then
+        echo "::error::Failed to push wiki updates."
+        exit 1
+      fi
+
+      echo "::warning::Failed to push wiki updates. Keeping local wiki commit only."
+    fi
   fi
 
-  status="updated"
+  if [[ "$push_status" == "push-failed" ]]; then
+    status="updated-no-push"
+  else
+    status="updated"
+  fi
+
   echo "Wiki sync committed: ${commit_sha}"
 fi
 
@@ -227,6 +290,7 @@ CHANGED_PAGES_CSV="$(IFS=','; echo "${changed_pages[*]}")"
 WIKI_STATUS="$status" \
 WIKI_COMMIT_SHA="$commit_sha" \
 WIKI_CHANGED_PAGES="$CHANGED_PAGES_CSV" \
+WIKI_PUSH_STATUS="$push_status" \
 WIKI_REPORT_DIR="$WIKI_DIR" \
 WIKI_REPORT_RUN_ID="$RUN_ID" \
 WIKI_REPORT_RUN_ATTEMPT="$RUN_ATTEMPT" \
@@ -242,6 +306,7 @@ changed_csv = os.environ.get("WIKI_CHANGED_PAGES", "")
 payload = {
     "status": os.environ.get("WIKI_STATUS", "unknown"),
     "commit_sha": os.environ.get("WIKI_COMMIT_SHA", ""),
+  "push_status": os.environ.get("WIKI_PUSH_STATUS", ""),
     "changed_pages": [item for item in changed_csv.split(",") if item],
   "wiki_dir": os.environ.get("WIKI_REPORT_DIR", ""),
   "run_id": os.environ.get("WIKI_REPORT_RUN_ID", ""),


### PR DESCRIPTION
## Summary\n- wire wiki sync controls into triaged and feedback orchestration workflows so wiki updates are maintained in the same automation run\n- add explicit wiki remote input propagation (including SDLC) with repo wiki defaults and robust origin-url fallback discovery\n- harden wiki sync behavior: strict-mode fail-fast, non-strict skip/warn paths, push-status reporting, and schedule-forced strict wiki sync for unattended runs\n- make human-approval gate draft-aware so automation draft PRs do not fail until ready-for-review\n- extend AI contract validator to enforce wiki wiring, remote propagation, and schedule strict-mode contract checks\n- update README/.env/entry-point docs for Banana wiki remote and workflow behavior\n\n## Validation\n- python scripts/validate-ai-contracts.py\n- bash -n scripts/workflow-sync-wiki.sh scripts/workflow-orchestrate-sdlc.sh scripts/workflow-local-orchestrate-triaged-item-pr.sh scripts/orchestrate-not-banana-feedback-loop.sh\n- local triaged dry-run with wiki sync: BANANA_LOCAL_DRY_RUN=true BANANA_TRIAGE_ID=wiki-sync-contract-test BANANA_TRIAGE_CHANGE_COMMAND=':' BANANA_WIKI_REMOTE_URL=https://github.com/LahkLeKey/Banana.wiki.git bash scripts/workflow-local-orchestrate-triaged-item-pr.sh\n- VS Code diagnostics on touched files (no errors)\n\n## Contract Impact\n- enforces Banana wiki git maintenance in the same SDLC flow for single-slice and feedback automation\n- preserves strict human oversight while reducing draft-stage false failures\n- keeps wiki-sync contract drift detectable through AI preflight validation