### PR TITLE
feat(github): complete static-agent human intake templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Human agent-target intake templates
+    url: https://github.com/LahkLeKey/Banana/issues/new/choose
+    about: Use a Human Intake template to target a specific static helper agent.
   - name: AI-generated triage queue
     url: https://github.com/LahkLeKey/Banana/issues?q=is%3Aissue+is%3Aopen+label%3Aai-generated
     about: View automation-generated triage issues separately from human issue templates.

--- a/.github/ISSUE_TEMPLATE/human-banana-classifier-agent.yml
+++ b/.github/ISSUE_TEMPLATE/human-banana-classifier-agent.yml
@@ -1,0 +1,41 @@
+name: Human Intake - Banana Classifier Agent
+description: Route classifier behavior, training, inference, and simple frontend classification issues to banana-classifier-agent triage automation.
+title: "[banana-classifier-agent] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: banana-classifier-agent -->
+        Human-authored issue intake for banana-classifier-agent.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Describe classifier behavior, training drift, or inference output problem.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe the expected banana-vs-not-banana behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or reproduction
+      description: Include examples, model artifacts, logs, API payloads, or UI repro steps.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete checks that define done.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/human-banana-planner.yml
+++ b/.github/ISSUE_TEMPLATE/human-banana-planner.yml
@@ -1,0 +1,41 @@
+name: Human Intake - Banana Planner
+description: Route planning-heavy feature/refactor requests to banana-planner triage automation.
+title: "[banana-planner] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: banana-planner -->
+        Human-authored issue intake for banana-planner.
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: Describe the outcome you want and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and constraints
+      description: Include boundaries, impacted domains, and non-goals.
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks or unknowns
+      description: List open questions, blockers, and architecture concerns.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List planning outputs needed (sequence, ownership, validation path).
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/human-banana-reviewer.yml
+++ b/.github/ISSUE_TEMPLATE/human-banana-reviewer.yml
@@ -1,0 +1,41 @@
+name: Human Intake - Banana Reviewer
+description: Route regression-risk or review-focused requests to banana-reviewer triage automation.
+title: "[banana-reviewer] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: banana-reviewer -->
+        Human-authored issue intake for banana-reviewer.
+  - type: textarea
+    id: change_context
+    attributes:
+      label: Change context
+      description: Describe the code paths or PR/workflow areas to review.
+    validations:
+      required: true
+  - type: textarea
+    id: risk_focus
+    attributes:
+      label: Risk focus
+      description: Call out suspected regressions, contract risk, or test gaps.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Include logs, failing checks, or links to relevant changes.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Define what a complete review output must include.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/human-banana-sdlc.yml
+++ b/.github/ISSUE_TEMPLATE/human-banana-sdlc.yml
@@ -1,0 +1,41 @@
+name: Human Intake - Banana SDLC
+description: Route multi-phase, multi-domain orchestration requests to banana-sdlc triage automation.
+title: "[banana-sdlc] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: banana-sdlc -->
+        Human-authored issue intake for banana-sdlc.
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: Describe the end-to-end outcome you want.
+    validations:
+      required: true
+  - type: textarea
+    id: touched_domains
+    attributes:
+      label: Touched domains
+      description: List native, API, frontend, infra, workflow, or docs surfaces involved.
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Include deadlines, environment limits, and risk controls.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete outcomes for discovery, implementation, validation, and review.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/human-csharp-api-agent.yml
+++ b/.github/ISSUE_TEMPLATE/human-csharp-api-agent.yml
@@ -1,0 +1,41 @@
+name: Human Intake - CSharp API Agent
+description: Route broad ASP.NET API work (pipeline plus interop/data access) to csharp-api-agent triage automation.
+title: "[csharp-api-agent] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: csharp-api-agent -->
+        Human-authored issue intake for csharp-api-agent.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Describe API behavior or integration problem.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe expected ASP.NET and contract behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or reproduction
+      description: Include endpoints, payloads, logs, and failing checks.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete checks that define done.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/human-electron-agent.yml
+++ b/.github/ISSUE_TEMPLATE/human-electron-agent.yml
@@ -1,0 +1,41 @@
+name: Human Intake - Electron Agent
+description: Route Electron runtime, preload, bridge, and desktop packaging issues to electron-agent triage automation.
+title: "[electron-agent] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: electron-agent -->
+        Human-authored issue intake for electron-agent.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Describe desktop runtime behavior that is broken.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe expected Electron behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or reproduction
+      description: Include platform details, logs, crash output, and reproduction steps.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete checks that define done.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/human-infrastructure-agent.yml
+++ b/.github/ISSUE_TEMPLATE/human-infrastructure-agent.yml
@@ -1,0 +1,41 @@
+name: Human Intake - Infrastructure Agent
+description: Route combined runtime/compose/workflow delivery issues to infrastructure-agent triage automation.
+title: "[infrastructure-agent] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: infrastructure-agent -->
+        Human-authored issue intake for infrastructure-agent.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Describe delivery/runtime/workflow behavior that is broken.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe expected infrastructure behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or reproduction
+      description: Include compose details, workflow URLs, logs, and runtime environment.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete checks that define done.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/human-integration-agent.yml
+++ b/.github/ISSUE_TEMPLATE/human-integration-agent.yml
@@ -1,0 +1,41 @@
+name: Human Intake - Integration Agent
+description: Route cross-layer validation and test-surface issues to integration-agent triage automation.
+title: "[integration-agent] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: integration-agent -->
+        Human-authored issue intake for integration-agent.
+  - type: textarea
+    id: changed_surface
+    attributes:
+      label: Changed surface
+      description: Describe what changed across domains and why integrated validation is needed.
+    validations:
+      required: true
+  - type: textarea
+    id: failure_mode
+    attributes:
+      label: Failure mode
+      description: Describe test/runtime failures or integration gaps.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Include failing checks, logs, and environment assumptions.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete validation outcomes needed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/human-native-c-agent.yml
+++ b/.github/ISSUE_TEMPLATE/human-native-c-agent.yml
@@ -1,0 +1,41 @@
+name: Human Intake - Native C Agent
+description: Route broad native C changes (core, DAL, wrapper, CMake) to native-c-agent triage automation.
+title: "[native-c-agent] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: native-c-agent -->
+        Human-authored issue intake for native-c-agent.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Describe native-layer behavior or ABI/build issue.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe expected native behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or reproduction
+      description: Include inputs/outputs, failing tests, and build logs.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete checks that define done.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/human-native-dal-agent.yml
+++ b/.github/ISSUE_TEMPLATE/human-native-dal-agent.yml
@@ -1,0 +1,41 @@
+name: Human Intake - Native DAL Agent
+description: Route native PostgreSQL-gated DAL behavior issues to native-dal-agent triage automation.
+title: "[native-dal-agent] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: native-dal-agent -->
+        Human-authored issue intake for native-dal-agent.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Describe DAL query/payload/status behavior that is broken.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe expected native DAL behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or reproduction
+      description: Include DB payload examples, environment settings, and logs.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete checks that define done.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/human-react-agent.yml
+++ b/.github/ISSUE_TEMPLATE/human-react-agent.yml
@@ -1,0 +1,41 @@
+name: Human Intake - React Agent
+description: Route broader frontend React app evolution requests to react-agent triage automation.
+title: "[react-agent] "
+labels:
+  - triage-idea
+  - automation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- banana-intake-source: human -->
+        <!-- banana-target-agent: react-agent -->
+        Human-authored issue intake for react-agent.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Describe frontend behavior or app-level workflow to change.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe expected React app behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or reproduction
+      description: Include route/screen details, API assumptions, and repro steps.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete checks that define done.
+    validations:
+      required: true

--- a/.github/prompts/triage.prompt.md
+++ b/.github/prompts/triage.prompt.md
@@ -15,6 +15,8 @@ Requirements:
 - Include label `copilot-suggestion` when the idea originates from Copilot review findings.
 - Mark AI-originated triage issues with `ai-generated` and avoid applying `source-human-issue`.
 - Preserve human-template routing markers (`banana-intake-source` and `banana-target-agent`) when orchestrating from existing human-created issues.
+- Support any static helper agent defined in `.github/agents/*.agent.md` when `banana-target-agent` is provided by a human template.
+- Keep propagated `agent:*` labels on both triage issues and generated PRs for deterministic helper routing.
 - Clear backlog triage issues and triage automation PRs before creating new ones unless backlog cleanup is explicitly disabled.
 - Trigger cloud orchestration through workflow `.github/workflows/orchestrate-triage-idea-cloud.yml`.
 - Preserve provenance labels on generated pull requests (`copilot-auto-approve` and `copilot-bypass-vibe-coded` unless overridden).

--- a/.github/skills/banana-build-and-run/entry-points.md
+++ b/.github/skills/banana-build-and-run/entry-points.md
@@ -77,7 +77,7 @@
 - Push-based corpus persistence: when `data/not-banana/corpus.json` changes, `Train Not-Banana Model` now persists registry history automatically in the same run.
 - Triaged-code PR orchestration workflow: `.github/workflows/orchestrate-triaged-item-pr.yml` via workflow dispatch with `triage_id` + `change_command`.
 - Cloud triage idea orchestration workflow: `.github/workflows/orchestrate-triage-idea-cloud.yml` via issue labels `triage-idea`/`copilot-suggestion`/`human-triage` or workflow dispatch with `idea`/`issue_number`.
-- Human agent-target issue templates: `.github/ISSUE_TEMPLATE/human-*.yml` (each template embeds routing markers for source and target helper agent).
+- Human agent-target issue templates: `.github/ISSUE_TEMPLATE/human-*.yml` (one template per static helper in `.github/agents/*.agent.md`, each embedding routing markers for source and target agent).
 - Cloud triage idea orchestration script: `bash scripts/workflow-triage-idea-cloud.sh`.
 - Cloud triage backlog cleanup defaults: `BANANA_TRIAGE_CLEAR_BACKLOG=true`, `BANANA_TRIAGE_BACKLOG_ISSUE_LABELS=copilot-suggestion,ai-generated`, `BANANA_TRIAGE_BACKLOG_PR_LABELS=automation,triaged-item`, and `BANANA_TRIAGE_BACKLOG_PR_BRANCH_PREFIXES=triage/,triage-copilot/,triage-feedback/`.
 - Cloud triage check-dispatch defaults: `BANANA_TRIAGE_DISPATCH_REQUIRED_CHECKS=true` and `BANANA_TRIAGE_CHECK_WORKFLOWS=copilot-review-triage.yml,require-human-approval.yml`.


### PR DESCRIPTION
Complete static-agent human intake coverage and related triage command contracts.\n\nIncludes:\n- human intake templates for all static agents under .github/agents\n- triage prompt contract updates for agent-target propagation\n- build/run entry-point docs update for full template coverage\n- issue template config guidance for human and AI intake separation