### PR TITLE
feat(github): add /iterate-the-backlog command contract

### DIFF
--- a/.github/prompts/iterate-the-backlog.prompt.md
+++ b/.github/prompts/iterate-the-backlog.prompt.md
@@ -1,0 +1,40 @@
+---
+name: iterate-the-backlog
+description: Iterate through Banana triage and automation backlog with incremental orchestration, required check gating, and deterministic stop conditions.
+argument-hint: Describe backlog scope, iteration cap, and any label or workflow constraints.
+agent: banana-sdlc
+---
+
+Execute this as a backlog-iteration cycle for Banana.
+
+Requirements:
+
+- Treat the prompt argument as backlog-iteration constraints (scope filters, max iterations, labels, workflows).
+- Start by enumerating open triage issues and automation pull requests that match backlog labels.
+- Use incremental slices and existing orchestration entry points only:
+  - `.github/workflows/orchestrate-triage-idea-cloud.yml` with `scripts/workflow-triage-idea-cloud.sh` for triage issue intake and update cycles.
+  - `.github/workflows/orchestrate-banana-sdlc.yml` with `scripts/workflow-orchestrate-sdlc.sh` for multi-slice backlog increments.
+  - `.github/workflows/orchestrate-not-banana-feedback-loop.yml` for approved feedback backlog ingestion.
+- Keep test gating enabled for every generated or updated pull request by dispatching required checks:
+  - `.github/workflows/copilot-review-triage.yml`
+  - `.github/workflows/require-human-approval.yml`
+- Preserve provenance and routing labels across the cycle (`automation`, `triaged-item`, `copilot-auto-approve`, `copilot-bypass-vibe-coded`, plus source and `agent:*` labels when present).
+- Apply smart iteration stop conditions:
+  - Stop when no eligible backlog items remain.
+  - Stop when iteration cap is reached.
+  - Stop early on repeated no-change outcomes or unresolved blocking failures.
+- Do not open duplicate pull requests for backlog items that already have an active PR unless explicitly requested.
+- Return concrete outputs for each iteration: processed issue and PR URLs, workflow run URLs, check-dispatch results, merge or skip decisions, and blocking reasons.
+
+Relevant assets:
+
+- [banana-agent-decomposition](../skills/banana-agent-decomposition/SKILL.md)
+- [banana-build-and-run](../skills/banana-build-and-run/SKILL.md)
+- [banana-test-and-coverage](../skills/banana-test-and-coverage/SKILL.md)
+- [banana-release-readiness](../skills/banana-release-readiness/SKILL.md)
+
+## Wiki Updater Contract
+
+- Treat this prompt as a wiki-synced contract surface: when prompt behavior, scope, assets, or acceptance criteria changes, keep the corresponding wiki snapshot current in the same SDLC run.
+- Use `scripts/workflow-sync-wiki.sh` (or SDLC orchestration wrappers) so prompt updates and wiki docs are delivered together.
+- If a prompt change introduces new automation flow, branch policy, validation step, or contract dependency, update prompt-linked wiki content before closing the change.

--- a/.github/skills/banana-build-and-run/entry-points.md
+++ b/.github/skills/banana-build-and-run/entry-points.md
@@ -82,6 +82,7 @@
 - Cloud triage backlog cleanup defaults: `BANANA_TRIAGE_CLEAR_BACKLOG=true`, `BANANA_TRIAGE_BACKLOG_ISSUE_LABELS=copilot-suggestion,ai-generated`, `BANANA_TRIAGE_BACKLOG_PR_LABELS=automation,triaged-item`, and `BANANA_TRIAGE_BACKLOG_PR_BRANCH_PREFIXES=triage/,triage-copilot/,triage-feedback/`.
 - Cloud triage check-dispatch defaults: `BANANA_TRIAGE_DISPATCH_REQUIRED_CHECKS=true` and `BANANA_TRIAGE_CHECK_WORKFLOWS=copilot-review-triage.yml,require-human-approval.yml`.
 - Custom triage prompt: `.github/prompts/triage.prompt.md` (use `/triage "idea"` to intake and orchestrate).
+- Backlog iteration prompt: `.github/prompts/iterate-the-backlog.prompt.md` (use `/iterate-the-backlog "scope"` to cycle existing backlog items through incremental orchestration and required-check gating).
 - Human-approval gate workflow: `.github/workflows/require-human-approval.yml` (mark check required in branch protection/rulesets).
 - Copilot triage-and-approval workflow: `.github/workflows/copilot-review-triage.yml` (tracks unresolved Copilot findings and auto-approves automation PRs, or non-automation PRs with `copilot-auto-approve`).
 - Autonomous continuation labels: `copilot-autonomous-cycle` and `copilot-bypass-vibe-coded` (paired with `copilot-triage-ready` for bot-driven continuation and provenance tagging of vibe-coded integrations).

--- a/scripts/validate-ai-contracts.py
+++ b/scripts/validate-ai-contracts.py
@@ -30,6 +30,18 @@ CANONICAL_WIKI_REMOTE_URL = "https://github.com/LahkLeKey/Banana.wiki.git"
 AGENT_CONTRACT_FRAGMENT = "Feedback Loop And Incremental Branch Contract"
 PROMPT_WIKI_CONTRACT_HEADER = "## Wiki Updater Contract"
 SKILL_NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
+ITERATE_BACKLOG_PROMPT = PROMPTS_DIR / "iterate-the-backlog.prompt.md"
+ITERATE_BACKLOG_PROMPT_REQUIRED_FRAGMENTS = {
+    "orchestrate-triage-idea-cloud.yml": "PROMPT missing cloud triage workflow contract",
+    "workflow-triage-idea-cloud.sh": "PROMPT missing cloud triage orchestration script contract",
+    "orchestrate-banana-sdlc.yml": "PROMPT missing SDLC workflow contract",
+    "workflow-orchestrate-sdlc.sh": "PROMPT missing SDLC orchestration script contract",
+    "orchestrate-not-banana-feedback-loop.yml": "PROMPT missing feedback-loop workflow contract",
+    "copilot-review-triage.yml": "PROMPT missing copilot triage required-check contract",
+    "require-human-approval.yml": "PROMPT missing human-approval required-check contract",
+    "Stop when no eligible backlog items remain.": "PROMPT missing deterministic no-work stop condition",
+    "Return concrete outputs for each iteration": "PROMPT missing iteration output contract",
+}
 
 
 def parse_frontmatter(path: Path) -> tuple[dict[str, str] | None, str]:
@@ -87,6 +99,18 @@ def main() -> int:
 
         if PROMPT_WIKI_CONTRACT_HEADER not in body:
             prompt_missing_wiki_contract.append(rel)
+
+    iterate_backlog_rel = ITERATE_BACKLOG_PROMPT.relative_to(ROOT).as_posix()
+    if not ITERATE_BACKLOG_PROMPT.exists():
+        issues.append(f"PROMPT missing backlog-iteration command contract: {iterate_backlog_rel}")
+    else:
+        iterate_frontmatter, iterate_body = parse_frontmatter(ITERATE_BACKLOG_PROMPT)
+        if iterate_frontmatter is None:
+            issues.append(f"PROMPT missing/invalid frontmatter: {iterate_backlog_rel}")
+        else:
+            for fragment, message in ITERATE_BACKLOG_PROMPT_REQUIRED_FRAGMENTS.items():
+                if fragment not in iterate_body:
+                    issues.append(f"{message}: {iterate_backlog_rel}")
 
     # Agents
     for agent_path in sorted(AGENTS_DIR.glob("*.agent.md")):


### PR DESCRIPTION
Adds the missing slash command contract for backlog iteration and wires it into docs/validation.\n\nIncludes:\n- new prompt: .github/prompts/iterate-the-backlog.prompt.md\n- validator checks in scripts/validate-ai-contracts.py for iterate-the-backlog required fragments\n- entry-point doc update in .github/skills/banana-build-and-run/entry-points.md\n\nValidation:\n- c:/Github/Banana/.venv/Scripts/python.exe scripts/validate-ai-contracts.py (passes)