### PR TITLE
feat(triage): decompose epic ideas into user stories and tasks

### DIFF
--- a/.github/prompts/triage.prompt.md
+++ b/.github/prompts/triage.prompt.md
@@ -18,6 +18,9 @@ Requirements:
 - Support any static helper agent defined in `.github/agents/*.agent.md` when `banana-target-agent` is provided by a human template.
 - Keep propagated `agent:*` labels on both triage issues and generated PRs for deterministic helper routing.
 - Clear backlog triage issues and triage automation PRs before creating new ones unless backlog cleanup is explicitly disabled.
+- When the idea is epic-like, decompose it into linked `epic`, `user-story`, and `task` issues instead of keeping a 1:1 issue-to-PR shape.
+- Start CI from the first generated task by dispatching triage orchestration for that task with backlog cleanup disabled.
+- Preserve epic/story/task labels on generated PRs so backlog iteration can progress task-by-task until epic completion.
 - Trigger cloud orchestration through workflow `.github/workflows/orchestrate-triage-idea-cloud.yml`.
 - Preserve provenance labels on generated pull requests (`copilot-auto-approve` and `copilot-bypass-vibe-coded` unless overridden).
 - Return concrete outputs: issue URL, workflow run URL, generated PR URL (if created), and any skipped-no-change reason.

--- a/.github/skills/banana-build-and-run/entry-points.md
+++ b/.github/skills/banana-build-and-run/entry-points.md
@@ -81,6 +81,7 @@
 - Cloud triage idea orchestration script: `bash scripts/workflow-triage-idea-cloud.sh`.
 - Cloud triage backlog cleanup defaults: `BANANA_TRIAGE_CLEAR_BACKLOG=true`, `BANANA_TRIAGE_BACKLOG_ISSUE_LABELS=copilot-suggestion,ai-generated`, `BANANA_TRIAGE_BACKLOG_PR_LABELS=automation,triaged-item`, and `BANANA_TRIAGE_BACKLOG_PR_BRANCH_PREFIXES=triage/,triage-copilot/,triage-feedback/`.
 - Cloud triage check-dispatch defaults: `BANANA_TRIAGE_DISPATCH_REQUIRED_CHECKS=true` and `BANANA_TRIAGE_CHECK_WORKFLOWS=copilot-review-triage.yml,require-human-approval.yml`.
+- Cloud triage epic-decomposition defaults: `BANANA_TRIAGE_ENABLE_EPIC_DECOMPOSITION=true` and `BANANA_TRIAGE_EPIC_AUTO_DISPATCH_FIRST_TASK=true` to split epic ideas into story/task issues and bootstrap the first task CI run.
 - Custom triage prompt: `.github/prompts/triage.prompt.md` (use `/triage "idea"` to intake and orchestrate).
 - Backlog iteration prompt: `.github/prompts/iterate-the-backlog.prompt.md` (use `/iterate-the-backlog "scope"` to cycle existing backlog items through incremental orchestration and required-check gating).
 - Human-approval gate workflow: `.github/workflows/require-human-approval.yml` (mark check required in branch protection/rulesets).

--- a/.github/workflows/orchestrate-triage-idea-cloud.yml
+++ b/.github/workflows/orchestrate-triage-idea-cloud.yml
@@ -73,6 +73,22 @@ on:
         description: Comma-separated workflow files to dispatch for PR gate checks
         required: false
         default: "copilot-review-triage.yml,require-human-approval.yml"
+      epic_decomposition:
+        description: Decompose epic-like triage ideas into linked user stories and tasks
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      epic_auto_dispatch_first_task:
+        description: Dispatch triage automation for the first generated epic task
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
       reviewers:
         description: Optional reviewer usernames as comma-separated values or [array] syntax
         required: false
@@ -149,6 +165,8 @@ jobs:
       BANANA_TRIAGE_BACKLOG_PR_BRANCH_PREFIXES: ${{ github.event.inputs.backlog_pr_branch_prefixes || 'triage/,triage-copilot/,triage-feedback/' }}
       BANANA_TRIAGE_DISPATCH_REQUIRED_CHECKS: ${{ github.event.inputs.dispatch_required_checks || 'true' }}
       BANANA_TRIAGE_CHECK_WORKFLOWS: ${{ github.event.inputs.check_workflows || 'copilot-review-triage.yml,require-human-approval.yml' }}
+      BANANA_TRIAGE_ENABLE_EPIC_DECOMPOSITION: ${{ github.event.inputs.epic_decomposition || 'true' }}
+      BANANA_TRIAGE_EPIC_AUTO_DISPATCH_FIRST_TASK: ${{ github.event.inputs.epic_auto_dispatch_first_task || 'true' }}
       BANANA_PR_REVIEWERS: ${{ github.event.inputs.reviewers || '' }}
       BANANA_SKIP_IF_NO_CHANGES: ${{ github.event.inputs.skip_if_no_changes || 'true' }}
       BANANA_SYNC_WIKI: ${{ github.event.inputs.sync_wiki || 'true' }}

--- a/scripts/validate-ai-contracts.py
+++ b/scripts/validate-ai-contracts.py
@@ -228,6 +228,10 @@ def main() -> int:
             "backlog_issue_labels": "WORKFLOW missing backlog issue-label cleanup contract",
             "backlog_pr_labels": "WORKFLOW missing backlog PR-label cleanup contract",
             "backlog_pr_branch_prefixes": "WORKFLOW missing backlog PR-branch cleanup contract",
+            "epic_decomposition": "WORKFLOW missing epic decomposition toggle",
+            "epic_auto_dispatch_first_task": "WORKFLOW missing epic first-task auto-dispatch toggle",
+            "BANANA_TRIAGE_ENABLE_EPIC_DECOMPOSITION": "WORKFLOW missing epic decomposition env wiring",
+            "BANANA_TRIAGE_EPIC_AUTO_DISPATCH_FIRST_TASK": "WORKFLOW missing epic first-task dispatch env wiring",
             "workflow-triage-idea-cloud.sh": "WORKFLOW missing triage idea orchestration script execution",
             "workflow-sync-wiki.sh": "WORKFLOW missing wiki sync step",
             "BANANA_WIKI_REMOTE_URL": "WORKFLOW missing BANANA_WIKI_REMOTE_URL wiring",
@@ -355,6 +359,13 @@ def main() -> int:
             "BANANA_TRIAGE_DISPATCH_REQUIRED_CHECKS": "SCRIPT missing required-check dispatch toggle",
             "BANANA_TRIAGE_CHECK_WORKFLOWS": "SCRIPT missing required-check workflow list contract",
             "actions/workflows/${workflow_file}/dispatches": "SCRIPT missing required-check workflow dispatch path",
+            "BANANA_TRIAGE_ENABLE_EPIC_DECOMPOSITION": "SCRIPT missing epic decomposition toggle",
+            "BANANA_TRIAGE_EPIC_AUTO_DISPATCH_FIRST_TASK": "SCRIPT missing epic first-task auto-dispatch toggle",
+            "scaffold_epic_breakdown_if_requested": "SCRIPT missing epic decomposition execution path",
+            "dispatch_triage_issue_workflow": "SCRIPT missing first-task workflow dispatch helper",
+            "epic-decomposed": "SCRIPT missing epic decomposition label contract",
+            "user-story": "SCRIPT missing user-story label contract",
+            "task": "SCRIPT missing task label contract",
         }
 
         for fragment, message in triage_idea_script_required_fragments.items():

--- a/scripts/workflow-triage-idea-cloud.sh
+++ b/scripts/workflow-triage-idea-cloud.sh
@@ -21,6 +21,8 @@ TRIAGE_BACKLOG_PR_LABELS="${BANANA_TRIAGE_BACKLOG_PR_LABELS:-automation,triaged-
 TRIAGE_BACKLOG_PR_BRANCH_PREFIXES="${BANANA_TRIAGE_BACKLOG_PR_BRANCH_PREFIXES:-triage/,triage-copilot/,triage-feedback/}"
 TRIAGE_DISPATCH_REQUIRED_CHECKS="${BANANA_TRIAGE_DISPATCH_REQUIRED_CHECKS:-true}"
 TRIAGE_CHECK_WORKFLOWS="${BANANA_TRIAGE_CHECK_WORKFLOWS:-copilot-review-triage.yml,require-human-approval.yml}"
+TRIAGE_ENABLE_EPIC_DECOMPOSITION="${BANANA_TRIAGE_ENABLE_EPIC_DECOMPOSITION:-true}"
+TRIAGE_EPIC_AUTO_DISPATCH_FIRST_TASK="${BANANA_TRIAGE_EPIC_AUTO_DISPATCH_FIRST_TASK:-true}"
 PR_REVIEWERS="${BANANA_PR_REVIEWERS:-}"
 SKIP_IF_NO_CHANGES="${BANANA_SKIP_IF_NO_CHANGES:-true}"
 PR_OUTPUT_PATH="${BANANA_PR_OUTPUT_PATH:-artifacts/triage-idea/triage-pr-output-${RUN_ID}-attempt-${RUN_ATTEMPT}.json}"
@@ -28,6 +30,14 @@ HUMAN_TRIAGE_LABEL="human-triage"
 SOURCE_HUMAN_ISSUE_LABEL="source-human-issue"
 AI_GENERATED_LABEL="ai-generated"
 SOURCE_AI_ISSUE_LABEL="source-ai-issue"
+EPIC_LABEL="epic"
+EPIC_DECOMPOSED_LABEL="epic-decomposed"
+USER_STORY_LABEL="user-story"
+TASK_LABEL="task"
+EPIC_DECOMPOSITION_PERFORMED="false"
+EPIC_FIRST_TASK_ISSUE_NUMBER=""
+EPIC_FIRST_TASK_ISSUE_URL=""
+EPIC_FIRST_TASK_RUN_URL=""
 
 mkdir -p "$(dirname "$PR_OUTPUT_PATH")"
 
@@ -122,6 +132,121 @@ dispatch_gate_workflow() {
   return 1
 }
 
+label_in_multiline() {
+  local labels_multiline="${1:-}"
+  local expected_label="${2:-}"
+
+  if [[ -z "$labels_multiline" || -z "$expected_label" ]]; then
+    return 1
+  fi
+
+  while IFS= read -r label_name; do
+    if [[ "$label_name" == "$expected_label" ]]; then
+      return 0
+    fi
+  done < <(printf '%s\n' "$labels_multiline")
+
+  return 1
+}
+
+is_epic_like_request() {
+  local title="$1"
+  local body="$2"
+  local labels_multiline="$3"
+  local normalized
+
+  if [[ "$TRIAGE_ENABLE_EPIC_DECOMPOSITION" != "true" ]]; then
+    return 1
+  fi
+
+  if label_in_multiline "$labels_multiline" "$TASK_LABEL" \
+    || label_in_multiline "$labels_multiline" "$USER_STORY_LABEL" \
+    || label_in_multiline "$labels_multiline" "$EPIC_DECOMPOSED_LABEL"; then
+    return 1
+  fi
+
+  normalized="$(printf '%s %s' "$title" "$body" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$normalized" =~ (^|[^a-z0-9])epic(s)?([^a-z0-9]|$) ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+is_backlog_exempt_issue() {
+  local issue_number="$1"
+  local labels_multiline
+
+  labels_multiline="$(gh issue view "$issue_number" --json labels --jq '.labels[].name' || true)"
+  if label_in_multiline "$labels_multiline" "$EPIC_LABEL" \
+    || label_in_multiline "$labels_multiline" "$EPIC_DECOMPOSED_LABEL" \
+    || label_in_multiline "$labels_multiline" "$USER_STORY_LABEL" \
+    || label_in_multiline "$labels_multiline" "$TASK_LABEL"; then
+    return 0
+  fi
+
+  return 1
+}
+
+is_backlog_exempt_pr() {
+  local pr_number="$1"
+  local labels_multiline
+
+  labels_multiline="$(gh pr view "$pr_number" --json labels --jq '.labels[].name' || true)"
+  if label_in_multiline "$labels_multiline" "$EPIC_LABEL" \
+    || label_in_multiline "$labels_multiline" "$USER_STORY_LABEL" \
+    || label_in_multiline "$labels_multiline" "$TASK_LABEL"; then
+    return 0
+  fi
+
+  return 1
+}
+
+dispatch_triage_issue_workflow() {
+  local repo_slug="$1"
+  local issue_number="$2"
+  local issue_labels_csv="$3"
+
+  if gh api -X POST "repos/${repo_slug}/actions/workflows/orchestrate-triage-idea-cloud.yml/dispatches" \
+    -f ref="$BASE_BRANCH" \
+    -f inputs[issue_number]="$issue_number" \
+    -f inputs[issue_labels]="$issue_labels_csv" \
+    -f inputs[pr_labels]="$TRIAGE_PR_LABELS" \
+    -f inputs[base_branch]="$BASE_BRANCH" \
+    -f inputs[branch_prefix]="$BRANCH_PREFIX" \
+    -f inputs[draft_pr]="$DRAFT_PR" \
+    -f inputs[clear_backlog]=false \
+    -f inputs[dispatch_required_checks]="$TRIAGE_DISPATCH_REQUIRED_CHECKS" \
+    -f inputs[check_workflows]="$TRIAGE_CHECK_WORKFLOWS" \
+    -f inputs[epic_decomposition]=false \
+    -f inputs[epic_auto_dispatch_first_task]=false >/dev/null 2>&1; then
+    echo "Dispatched follow-up triage workflow for task issue #${issue_number}."
+    return 0
+  fi
+
+  echo "::warning::Unable to dispatch follow-up triage workflow for task issue #${issue_number}."
+  return 1
+}
+
+create_labeled_issue() {
+  local issue_title="$1"
+  local issue_body="$2"
+  local labels_csv="${3:-}"
+  local issue_url
+  local issue_number
+  local -a labels_to_apply=()
+
+  issue_url="$(gh issue create --title "$issue_title" --body "$issue_body")"
+  issue_number="${issue_url##*/}"
+
+  parse_list_input "$labels_csv" labels_to_apply
+  if [[ ${#labels_to_apply[@]} -gt 0 ]]; then
+    apply_issue_labels "$issue_number" labels_to_apply
+  fi
+
+  printf '%s|%s\n' "$issue_number" "$issue_url"
+}
+
 close_backlog_pull_requests() {
   declare -A seen_pr_numbers=()
   local -a parsed_pr_labels=()
@@ -188,6 +313,11 @@ close_backlog_pull_requests() {
 
   echo "Closing ${#backlog_pr_numbers[@]} backlog triage pull request(s)..."
   for pr_number in "${backlog_pr_numbers[@]}"; do
+    if is_backlog_exempt_pr "$pr_number"; then
+      echo "Skipping backlog cleanup for PR #${pr_number} because it is epic/story/task scoped."
+      continue
+    fi
+
     if gh pr close "$pr_number" --comment "Closed automatically by triage backlog cleanup before run ${RUN_ID} attempt ${RUN_ATTEMPT}." >/dev/null 2>&1; then
       echo "Closed backlog PR #${pr_number}."
     else
@@ -238,6 +368,11 @@ close_backlog_issues() {
 
   echo "Closing ${#backlog_issue_numbers[@]} backlog triage issue(s)..."
   for issue_number in "${backlog_issue_numbers[@]}"; do
+    if is_backlog_exempt_issue "$issue_number"; then
+      echo "Skipping backlog cleanup for issue #${issue_number} because it is epic/story/task scoped."
+      continue
+    fi
+
     if gh issue close "$issue_number" --comment "Closed automatically by triage backlog cleanup before run ${RUN_ID} attempt ${RUN_ATTEMPT}." >/dev/null 2>&1; then
       echo "Closed backlog issue #${issue_number}."
     else
@@ -277,6 +412,10 @@ ensure_issue_label_contract() {
   ensure_label "$SOURCE_HUMAN_ISSUE_LABEL" "0E8A16" "Marks triage intake that originated from a human issue template"
   ensure_label "$AI_GENERATED_LABEL" "5319E7" "Marks triage intake generated by AI automation"
   ensure_label "$SOURCE_AI_ISSUE_LABEL" "6F42C1" "Marks triage intake that originated from AI-generated issue automation"
+  ensure_label "$EPIC_LABEL" "8A2BE2" "Epic-level triage intake that should decompose into user stories and tasks"
+  ensure_label "$EPIC_DECOMPOSED_LABEL" "6A5ACD" "Epic triage issue has generated user stories and task backlog"
+  ensure_label "$USER_STORY_LABEL" "0075CA" "User story generated from an epic triage decomposition"
+  ensure_label "$TASK_LABEL" "5319E7" "Task generated from triage decomposition and ready for incremental automation"
 }
 
 apply_issue_labels() {
@@ -297,7 +436,7 @@ apply_issue_labels() {
       continue
     fi
 
-    if [[ "$label" == "triage-idea" || "$label" == "copilot-suggestion" || "$label" == "copilot-bypass-vibe-coded" || "$label" == "$HUMAN_TRIAGE_LABEL" || "$label" == "$SOURCE_HUMAN_ISSUE_LABEL" || "$label" == "$AI_GENERATED_LABEL" || "$label" == "$SOURCE_AI_ISSUE_LABEL" ]]; then
+    if [[ "$label" == "triage-idea" || "$label" == "copilot-suggestion" || "$label" == "copilot-bypass-vibe-coded" || "$label" == "$HUMAN_TRIAGE_LABEL" || "$label" == "$SOURCE_HUMAN_ISSUE_LABEL" || "$label" == "$AI_GENERATED_LABEL" || "$label" == "$SOURCE_AI_ISSUE_LABEL" || "$label" == "$EPIC_LABEL" || "$label" == "$EPIC_DECOMPOSED_LABEL" || "$label" == "$USER_STORY_LABEL" || "$label" == "$TASK_LABEL" ]]; then
       ensure_issue_label_contract
       gh issue edit "$issue_number" --add-label "$label" >/dev/null 2>&1 || true
       continue
@@ -305,6 +444,437 @@ apply_issue_labels() {
 
     echo "::warning::Unable to add label '$label' to issue #$issue_number."
   done
+}
+
+scaffold_epic_breakdown_if_requested() {
+  local epic_issue_number="$1"
+  local epic_issue_url="$2"
+  local epic_issue_title="$3"
+  local epic_issue_body="$4"
+  local epic_issue_labels_multiline="$5"
+  local issue_source_kind="$6"
+  local source_marker="ai"
+  local source_label="$SOURCE_AI_ISSUE_LABEL"
+  local source_bucket_label="$AI_GENERATED_LABEL"
+  local epic_summary
+  local breakdown_file
+  local story1_meta
+  local story2_meta
+  local story3_meta
+  local story1_number
+  local story1_url
+  local story2_number
+  local story2_url
+  local story3_number
+  local story3_url
+  local task1_meta
+  local task2_meta
+  local task3_meta
+  local task4_meta
+  local task5_meta
+  local task6_meta
+  local task7_meta
+  local task8_meta
+  local task1_number
+  local task1_url
+  local task2_number
+  local task2_url
+  local task3_number
+  local task3_url
+  local task4_number
+  local task4_url
+  local task5_number
+  local task5_url
+  local task6_number
+  local task6_url
+  local task7_number
+  local task7_url
+  local task8_number
+  local task8_url
+  local dispatch_note
+  local dispatch_labels
+  local repo_slug
+  local followup_run_url
+  local story1_body
+  local story2_body
+  local story3_body
+  local task1_body
+  local task2_body
+  local task3_body
+  local task4_body
+  local task5_body
+  local task6_body
+  local task7_body
+  local task8_body
+  local -a epic_labels=()
+
+  if ! is_epic_like_request "$epic_issue_title" "$epic_issue_body" "$epic_issue_labels_multiline"; then
+    return 0
+  fi
+
+  echo "Epic-like triage request detected for issue #${epic_issue_number}; scaffolding stories and tasks..."
+
+  if label_in_multiline "$epic_issue_labels_multiline" "$EPIC_DECOMPOSED_LABEL"; then
+    echo "Epic issue #${epic_issue_number} is already decomposed; skipping duplicate scaffolding."
+    return 0
+  fi
+
+  if [[ "$issue_source_kind" == "human" ]]; then
+    source_marker="human"
+    source_label="$SOURCE_HUMAN_ISSUE_LABEL"
+    source_bucket_label="$HUMAN_TRIAGE_LABEL"
+  fi
+
+  epic_summary="$(normalize_whitespace "$epic_issue_title")"
+  epic_summary="${epic_summary#triage: }"
+  if [[ -z "$epic_summary" ]]; then
+    epic_summary="epic-${epic_issue_number}"
+  fi
+
+  epic_labels=("$EPIC_LABEL" "$EPIC_DECOMPOSED_LABEL" "$source_bucket_label" "$source_label")
+  apply_issue_labels "$epic_issue_number" epic_labels
+
+  story1_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: banana-classifier-agent -->
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Story Outcome
+
+Define the shared chatbot request/response contract and backend classification path for: ${epic_summary}
+
+## Acceptance Criteria
+
+- Arbitrary user question payload schema is defined for chatbot clients.
+- API/native classification response contract is stable and typed.
+- Error, confidence, and provenance fields are documented for downstream clients.
+EOF
+)
+  story1_meta="$(create_labeled_issue "story(epic-${epic_issue_number}): shared chatbot contract and classification path" "$story1_body" "automation,${USER_STORY_LABEL},${source_bucket_label},${source_label},agent:banana-classifier-agent")"
+  story1_number="${story1_meta%%|*}"
+  story1_url="${story1_meta#*|}"
+
+  story2_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: react-ui-agent -->
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Story Outcome
+
+Ship chatbot UX parity across React, Electron, and mobile clients for: ${epic_summary}
+
+## Acceptance Criteria
+
+- React client supports chat input/output banana classification.
+- Electron client supports the same conversation and classification flow.
+- Mobile client supports the same conversation and classification flow.
+EOF
+)
+  story2_meta="$(create_labeled_issue "story(epic-${epic_issue_number}): frontend chatbot parity across clients" "$story2_body" "automation,${USER_STORY_LABEL},${source_bucket_label},${source_label},agent:react-ui-agent")"
+  story2_number="${story2_meta%%|*}"
+  story2_url="${story2_meta#*|}"
+
+  story3_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: integration-agent -->
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Story Outcome
+
+Validate cross-client quality gates and rollout readiness for: ${epic_summary}
+
+## Acceptance Criteria
+
+- Integration coverage validates classifier parity across all clients.
+- Required workflow gates run on each task PR.
+- Wiki and runbook updates capture chatbot delivery behavior.
+EOF
+)
+  story3_meta="$(create_labeled_issue "story(epic-${epic_issue_number}): validation and rollout gates" "$story3_body" "automation,${USER_STORY_LABEL},${source_bucket_label},${source_label},agent:integration-agent")"
+  story3_number="${story3_meta%%|*}"
+  story3_url="${story3_meta#*|}"
+
+  task1_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: api-pipeline-agent -->
+
+## Parent Story
+
+- #${story1_number} (${story1_url})
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Task Objective
+
+Define chatbot request and response DTO contracts for arbitrary banana/not-banana questions.
+EOF
+)
+  task1_meta="$(create_labeled_issue "task(epic-${epic_issue_number}): define chatbot request-response contract" "$task1_body" "automation,${TASK_LABEL},${source_bucket_label},${source_label},agent:api-pipeline-agent")"
+  task1_number="${task1_meta%%|*}"
+  task1_url="${task1_meta#*|}"
+
+  task2_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: csharp-api-agent -->
+
+## Parent Story
+
+- #${story1_number} (${story1_url})
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Task Objective
+
+Wire classification pipeline endpoint so chatbot questions resolve through controller/service/pipeline/native flow.
+EOF
+)
+  task2_meta="$(create_labeled_issue "task(epic-${epic_issue_number}): expose chatbot classification pipeline path" "$task2_body" "automation,${TASK_LABEL},${source_bucket_label},${source_label},agent:csharp-api-agent")"
+  task2_number="${task2_meta%%|*}"
+  task2_url="${task2_meta#*|}"
+
+  task3_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: react-ui-agent -->
+
+## Parent Story
+
+- #${story2_number} (${story2_url})
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Task Objective
+
+Implement React chatbot UI and state flow using shared UI contracts.
+EOF
+)
+  task3_meta="$(create_labeled_issue "task(epic-${epic_issue_number}): build React chatbot experience" "$task3_body" "automation,${TASK_LABEL},${source_bucket_label},${source_label},agent:react-ui-agent")"
+  task3_number="${task3_meta%%|*}"
+  task3_url="${task3_meta#*|}"
+
+  task4_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: electron-agent -->
+
+## Parent Story
+
+- #${story2_number} (${story2_url})
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Task Objective
+
+Implement Electron chatbot client wiring with classification API contract parity.
+EOF
+)
+  task4_meta="$(create_labeled_issue "task(epic-${epic_issue_number}): build Electron chatbot experience" "$task4_body" "automation,${TASK_LABEL},${source_bucket_label},${source_label},agent:electron-agent")"
+  task4_number="${task4_meta%%|*}"
+  task4_url="${task4_meta#*|}"
+
+  task5_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: mobile-runtime-agent -->
+
+## Parent Story
+
+- #${story2_number} (${story2_url})
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Task Objective
+
+Implement mobile chatbot client flow with banana/not-banana response parity.
+EOF
+)
+  task5_meta="$(create_labeled_issue "task(epic-${epic_issue_number}): build mobile chatbot experience" "$task5_body" "automation,${TASK_LABEL},${source_bucket_label},${source_label},agent:mobile-runtime-agent")"
+  task5_number="${task5_meta%%|*}"
+  task5_url="${task5_meta#*|}"
+
+  task6_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: integration-agent -->
+
+## Parent Story
+
+- #${story3_number} (${story3_url})
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Task Objective
+
+Add cross-client integration checks to validate chatbot contract parity and classifier outputs.
+EOF
+)
+  task6_meta="$(create_labeled_issue "task(epic-${epic_issue_number}): add cross-client chatbot integration checks" "$task6_body" "automation,${TASK_LABEL},${source_bucket_label},${source_label},agent:integration-agent")"
+  task6_number="${task6_meta%%|*}"
+  task6_url="${task6_meta#*|}"
+
+  task7_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: workflow-agent -->
+
+## Parent Story
+
+- #${story3_number} (${story3_url})
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Task Objective
+
+Ensure required check workflows and incremental triage orchestration run per task PR.
+EOF
+)
+  task7_meta="$(create_labeled_issue "task(epic-${epic_issue_number}): enforce per-task CI and approval gates" "$task7_body" "automation,${TASK_LABEL},${source_bucket_label},${source_label},agent:workflow-agent")"
+  task7_number="${task7_meta%%|*}"
+  task7_url="${task7_meta#*|}"
+
+  task8_body=$(cat <<EOF
+<!-- banana-intake-source: ${source_marker} -->
+<!-- banana-target-agent: infrastructure-agent -->
+
+## Parent Story
+
+- #${story3_number} (${story3_url})
+
+## Parent Epic
+
+- #${epic_issue_number} (${epic_issue_url})
+
+## Task Objective
+
+Update documentation/wiki and runtime rollout notes for chatbot epic completion criteria.
+EOF
+)
+  task8_meta="$(create_labeled_issue "task(epic-${epic_issue_number}): update rollout docs and wiki contracts" "$task8_body" "automation,${TASK_LABEL},${source_bucket_label},${source_label},agent:infrastructure-agent")"
+  task8_number="${task8_meta%%|*}"
+  task8_url="${task8_meta#*|}"
+
+  gh issue comment "$story1_number" --body "$(cat <<EOF
+Task backlog:
+
+- #${task1_number} (${task1_url})
+- #${task2_number} (${task2_url})
+EOF
+)" >/dev/null 2>&1 || true
+  gh issue comment "$story2_number" --body "$(cat <<EOF
+Task backlog:
+
+- #${task3_number} (${task3_url})
+- #${task4_number} (${task4_url})
+- #${task5_number} (${task5_url})
+EOF
+)" >/dev/null 2>&1 || true
+  gh issue comment "$story3_number" --body "$(cat <<EOF
+Task backlog:
+
+- #${task6_number} (${task6_url})
+- #${task7_number} (${task7_url})
+- #${task8_number} (${task8_url})
+EOF
+)" >/dev/null 2>&1 || true
+
+  EPIC_DECOMPOSITION_PERFORMED="true"
+  EPIC_FIRST_TASK_ISSUE_NUMBER="$task1_number"
+  EPIC_FIRST_TASK_ISSUE_URL="$task1_url"
+
+  dispatch_note="Epic decomposition created user stories and task backlog."
+  if [[ "$TRIAGE_EPIC_AUTO_DISPATCH_FIRST_TASK" == "true" ]]; then
+    gh issue edit "$task1_number" --add-label "triage-idea" --add-label "copilot-bypass-vibe-coded" >/dev/null 2>&1 || true
+    dispatch_labels="triage-idea,automation,${TASK_LABEL},copilot-bypass-vibe-coded,${source_bucket_label},${source_label},agent:api-pipeline-agent"
+    repo_slug="$(get_repo_slug)"
+
+    if dispatch_triage_issue_workflow "$repo_slug" "$task1_number" "$dispatch_labels"; then
+      followup_run_url="$(gh run list --workflow orchestrate-triage-idea-cloud.yml --event workflow_dispatch --limit 1 --json url --jq '.[0].url' 2>/dev/null || true)"
+      if [[ -n "$followup_run_url" && "$followup_run_url" != "null" ]]; then
+        EPIC_FIRST_TASK_RUN_URL="$followup_run_url"
+        dispatch_note="${dispatch_note} First task automation dispatched: ${followup_run_url}"
+      else
+        dispatch_note="${dispatch_note} First task automation dispatched for issue #${task1_number}."
+      fi
+    else
+      dispatch_note="${dispatch_note} First task automation dispatch failed for issue #${task1_number}."
+    fi
+  else
+    dispatch_note="${dispatch_note} First task automation dispatch is disabled by configuration."
+  fi
+
+  breakdown_file="${TRIAGE_INTAKE_DIR}/issue-${epic_issue_number}-epic-breakdown.md"
+  mkdir -p "$TRIAGE_INTAKE_DIR"
+  cat > "$breakdown_file" <<EOF
+# Epic Breakdown: Issue #${epic_issue_number}
+
+- Epic issue: ${epic_issue_url}
+- Source title: ${epic_issue_title}
+
+## User Stories
+
+- #${story1_number}: ${story1_url}
+- #${story2_number}: ${story2_url}
+- #${story3_number}: ${story3_url}
+
+## Task Backlog
+
+- #${task1_number}: ${task1_url}
+- #${task2_number}: ${task2_url}
+- #${task3_number}: ${task3_url}
+- #${task4_number}: ${task4_url}
+- #${task5_number}: ${task5_url}
+- #${task6_number}: ${task6_url}
+- #${task7_number}: ${task7_url}
+- #${task8_number}: ${task8_url}
+
+## CI Bootstrap
+
+${dispatch_note}
+EOF
+
+  gh issue comment "$epic_issue_number" --body "$(cat <<EOF
+Epic decomposition scaffolded.
+
+User stories:
+
+- #${story1_number} (${story1_url})
+- #${story2_number} (${story2_url})
+- #${story3_number} (${story3_url})
+
+Task backlog:
+
+- #${task1_number} (${task1_url})
+- #${task2_number} (${task2_url})
+- #${task3_number} (${task3_url})
+- #${task4_number} (${task4_url})
+- #${task5_number} (${task5_url})
+- #${task6_number} (${task6_url})
+- #${task7_number} (${task7_url})
+- #${task8_number} (${task8_url})
+
+${dispatch_note}
+
+Breakdown artifact: ${breakdown_file}
+EOF
+)" >/dev/null 2>&1 || true
 }
 
 ensure_issue_label_contract
@@ -380,6 +950,14 @@ else
   gh issue edit "$TRIAGE_ISSUE_NUMBER" --remove-label "$SOURCE_HUMAN_ISSUE_LABEL" >/dev/null 2>&1 || true
 fi
 
+issue_source_kind="ai"
+if [[ "$issue_source_marker" == "human" ]]; then
+  issue_source_kind="human"
+fi
+
+issue_labels_multiline="$(gh issue view "$TRIAGE_ISSUE_NUMBER" --json labels --jq '.labels[].name' || true)"
+scaffold_epic_breakdown_if_requested "$TRIAGE_ISSUE_NUMBER" "$issue_url" "$issue_title" "$issue_body" "$issue_labels_multiline" "$issue_source_kind"
+
 issue_labels_multiline="$(gh issue view "$TRIAGE_ISSUE_NUMBER" --json labels --jq '.labels[].name' || true)"
 if [[ -n "$issue_labels_multiline" ]]; then
   issue_labels_csv="$(printf '%s\n' "$issue_labels_multiline" | paste -sd ',' -)"
@@ -387,17 +965,12 @@ else
   issue_labels_csv=""
 fi
 
-issue_source_kind="ai"
-if [[ "$issue_source_marker" == "human" ]]; then
-  issue_source_kind="human"
-fi
-
 declare -a parsed_pr_labels=()
 parse_list_input "$TRIAGE_PR_LABELS" parsed_pr_labels
 
 if [[ -n "$issue_labels_multiline" ]]; then
   while IFS= read -r issue_label; do
-    if [[ "$issue_label" == agent:* || "$issue_label" == "$SOURCE_HUMAN_ISSUE_LABEL" || "$issue_label" == "$SOURCE_AI_ISSUE_LABEL" ]]; then
+    if [[ "$issue_label" == agent:* || "$issue_label" == "$SOURCE_HUMAN_ISSUE_LABEL" || "$issue_label" == "$SOURCE_AI_ISSUE_LABEL" || "$issue_label" == "$EPIC_LABEL" || "$issue_label" == "$USER_STORY_LABEL" || "$issue_label" == "$TASK_LABEL" ]]; then
       parsed_pr_labels+=("$issue_label")
     fi
   done < <(printf '%s\n' "$issue_labels_multiline")
@@ -438,6 +1011,21 @@ ${issue_body}
 - Base branch: ${BASE_BRANCH}
 - Branch prefix: ${BRANCH_PREFIX}
 EOF
+
+if [[ "$EPIC_DECOMPOSITION_PERFORMED" == "true" ]]; then
+  {
+    echo ""
+    echo "## Epic Decomposition"
+    echo ""
+    echo "- Decomposed: true"
+    if [[ -n "$EPIC_FIRST_TASK_ISSUE_NUMBER" && -n "$EPIC_FIRST_TASK_ISSUE_URL" ]]; then
+      echo "- First task issue: #${EPIC_FIRST_TASK_ISSUE_NUMBER} (${EPIC_FIRST_TASK_ISSUE_URL})"
+    fi
+    if [[ -n "$EPIC_FIRST_TASK_RUN_URL" ]]; then
+      echo "- First task workflow run: ${EPIC_FIRST_TASK_RUN_URL}"
+    fi
+  } >> "$intake_file"
+fi
 
 title_summary="$(normalize_whitespace "$issue_title")"
 if [[ ${#title_summary} -gt 72 ]]; then
@@ -542,6 +1130,15 @@ if [[ -n "$pr_url" ]]; then
   gh issue comment "$TRIAGE_ISSUE_NUMBER" --body "Automation PR opened for this triage idea: ${pr_url}" >/dev/null 2>&1 || true
 elif [[ "$pr_status" == "skipped" ]]; then
   gh issue comment "$TRIAGE_ISSUE_NUMBER" --body "Cloud triage orchestration found no effective repository change and skipped PR creation." >/dev/null 2>&1 || true
+fi
+
+if [[ "$EPIC_DECOMPOSITION_PERFORMED" == "true" && -n "$EPIC_FIRST_TASK_ISSUE_NUMBER" ]]; then
+  followup_comment="Epic decomposition scaffolded user stories/tasks and queued first task issue #${EPIC_FIRST_TASK_ISSUE_NUMBER}: ${EPIC_FIRST_TASK_ISSUE_URL}"
+  if [[ -n "$EPIC_FIRST_TASK_RUN_URL" ]]; then
+    followup_comment+=$'\n\n'
+    followup_comment+="First task workflow run: ${EPIC_FIRST_TASK_RUN_URL}"
+  fi
+  gh issue comment "$TRIAGE_ISSUE_NUMBER" --body "$followup_comment" >/dev/null 2>&1 || true
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then


### PR DESCRIPTION
Implements epic-aware cloud triage intake so epic ideas no longer stay in a 1:1 issue-to-PR shape.\n\nIncludes:\n- epic decomposition controls in orchestrate-triage-idea-cloud workflow inputs\n- triage script scaffolding for linked epic/user-story/task issues\n- automatic first-task triage workflow dispatch to bootstrap task-level CI\n- backlog cleanup exemptions for epic/story/task items\n- prompt and validator contract updates\n\nValidation:\n- bash -n scripts/workflow-triage-idea-cloud.sh\n- c:/Github/Banana/.venv/Scripts/python.exe scripts/validate-ai-contracts.py