### PR TITLE
feat(github): add /focus-on-open-pull-requests command

### DIFF
--- a/.github/agents/banana-reviewer.agent.md
+++ b/.github/agents/banana-reviewer.agent.md
@@ -93,6 +93,7 @@ Prioritize correctness, regressions, missing tests, environment drift, and relea
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
 - Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
+- Apply the [Open Pull Request Focus Contract](./domain-teaming-playbook.md#open-pull-request-focus-contract-all-agents) when review and merge throughput on open PRs is the primary delivery objective.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/banana-sdlc.agent.md
+++ b/.github/agents/banana-sdlc.agent.md
@@ -136,6 +136,7 @@ Use this agent when the request spans more than one phase of delivery or more th
 
 - Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
 - Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
+- Apply the [Open Pull Request Focus Contract](./domain-teaming-playbook.md#open-pull-request-focus-contract-all-agents) when open PR throughput and merge readiness take priority.
 - Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
 - Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
 - Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.

--- a/.github/agents/domain-teaming-playbook.md
+++ b/.github/agents/domain-teaming-playbook.md
@@ -34,6 +34,22 @@ Use this playbook when coordinating Banana work across agents so specialists ope
    - labels/reviewers
    - expected changed files and validation surface
 
+## Open Pull Request Focus Contract (All Agents)
+
+1. When open pull requests become the priority, run a focused PR cycle before starting new feature slices.
+2. Enumerate open PRs first and classify each as one of:
+   - merge-ready
+   - waiting-checks
+   - waiting-human-review
+   - blocked-conflict-or-rebase
+   - superseded-or-close-candidate
+3. For automation PRs, keep required checks explicit and current by dispatching:
+   - `.github/workflows/copilot-review-triage.yml`
+   - `.github/workflows/require-human-approval.yml`
+4. Do not bypass branch protections or force-merge without explicit human instruction.
+5. Return concrete per-PR actions and blockers with URLs so triage loops can continue incrementally.
+6. Apply duplicate-work safeguards: avoid opening replacement PRs when an equivalent branch and scope are already active.
+
 ## Required Handoff Packet
 
 Every handoff should include:

--- a/.github/prompts/focus-on-open-pull-requests.prompt.md
+++ b/.github/prompts/focus-on-open-pull-requests.prompt.md
@@ -1,0 +1,34 @@
+---
+name: focus-on-open-pull-requests
+description: Focus Banana automation on open pull requests by triaging blockers, dispatching required checks, and returning prioritized merge actions.
+argument-hint: Optional scope filters, label constraints, merge policy, and max PR count for this focus cycle.
+agent: banana-sdlc
+---
+
+Execute this as an open pull request focus cycle for Banana.
+
+Requirements:
+
+- Treat the prompt argument as focus constraints (scope filters, labels, ownership, base branch, max PR count).
+- Start by enumerating open pull requests and classifying each as: `merge-ready`, `waiting-checks`, `waiting-human-review`, `blocked-conflict-or-rebase`, or `superseded-or-close-candidate`.
+- Keep review and gate orchestration on existing entry points only:
+  - `.github/workflows/copilot-review-triage.yml`
+  - `.github/workflows/require-human-approval.yml`
+- For automation PRs, ensure required checks are dispatched and report resulting workflow run URLs.
+- Preserve provenance and routing labels (`automation`, `triaged-item`, `copilot-auto-approve`, `copilot-bypass-vibe-coded`, plus source and `agent:*` labels when present).
+- Do not force-merge or bypass branch protections unless explicitly requested by a human.
+- Do not open duplicate replacement PRs when an equivalent branch and scope are already active.
+- Return concrete outputs for each PR handled: PR URL, current check state, chosen action, run URLs if dispatched, and blocker reason.
+
+Relevant assets:
+
+- [banana-agent-decomposition](../skills/banana-agent-decomposition/SKILL.md)
+- [banana-build-and-run](../skills/banana-build-and-run/SKILL.md)
+- [banana-test-and-coverage](../skills/banana-test-and-coverage/SKILL.md)
+- [banana-release-readiness](../skills/banana-release-readiness/SKILL.md)
+
+## Wiki Updater Contract
+
+- Treat this prompt as a wiki-synced contract surface: when prompt behavior, scope, assets, or acceptance criteria changes, keep the corresponding wiki snapshot current in the same SDLC run.
+- Use `scripts/workflow-sync-wiki.sh` (or SDLC orchestration wrappers) so prompt updates and wiki docs are delivered together.
+- If a prompt change introduces new automation flow, branch policy, validation step, or contract dependency, update prompt-linked wiki content before closing the change.

--- a/.github/skills/banana-build-and-run/entry-points.md
+++ b/.github/skills/banana-build-and-run/entry-points.md
@@ -84,6 +84,7 @@
 - Cloud triage epic-decomposition defaults: `BANANA_TRIAGE_ENABLE_EPIC_DECOMPOSITION=true` and `BANANA_TRIAGE_EPIC_AUTO_DISPATCH_FIRST_TASK=true` to split epic ideas into story/task issues and bootstrap the first task CI run.
 - Custom triage prompt: `.github/prompts/triage.prompt.md` (use `/triage "idea"` to intake and orchestrate).
 - Backlog iteration prompt: `.github/prompts/iterate-the-backlog.prompt.md` (use `/iterate-the-backlog "scope"` to cycle existing backlog items through incremental orchestration and required-check gating).
+- Open PR focus prompt: `.github/prompts/focus-on-open-pull-requests.prompt.md` (use `/focus-on-open-pull-requests "scope"` to prioritize open PR merge readiness and dispatch required checks).
 - Human-approval gate workflow: `.github/workflows/require-human-approval.yml` (mark check required in branch protection/rulesets).
 - Copilot triage-and-approval workflow: `.github/workflows/copilot-review-triage.yml` (tracks unresolved Copilot findings and auto-approves automation PRs, or non-automation PRs with `copilot-auto-approve`).
 - Autonomous continuation labels: `copilot-autonomous-cycle` and `copilot-bypass-vibe-coded` (paired with `copilot-triage-ready` for bot-driven continuation and provenance tagging of vibe-coded integrations).

--- a/scripts/validate-ai-contracts.py
+++ b/scripts/validate-ai-contracts.py
@@ -42,6 +42,15 @@ ITERATE_BACKLOG_PROMPT_REQUIRED_FRAGMENTS = {
     "Stop when no eligible backlog items remain.": "PROMPT missing deterministic no-work stop condition",
     "Return concrete outputs for each iteration": "PROMPT missing iteration output contract",
 }
+FOCUS_OPEN_PRS_PROMPT = PROMPTS_DIR / "focus-on-open-pull-requests.prompt.md"
+FOCUS_OPEN_PRS_PROMPT_REQUIRED_FRAGMENTS = {
+    "open pull requests": "PROMPT missing open pull request focus scope",
+    "copilot-review-triage.yml": "PROMPT missing copilot review triage workflow contract",
+    "require-human-approval.yml": "PROMPT missing human approval workflow contract",
+    "Do not force-merge or bypass branch protections unless explicitly requested by a human.": "PROMPT missing branch-protection safety contract",
+    "Do not open duplicate replacement PRs": "PROMPT missing duplicate PR safeguard contract",
+    "Return concrete outputs for each PR handled": "PROMPT missing per-PR output contract",
+}
 
 
 def parse_frontmatter(path: Path) -> tuple[dict[str, str] | None, str]:
@@ -111,6 +120,18 @@ def main() -> int:
             for fragment, message in ITERATE_BACKLOG_PROMPT_REQUIRED_FRAGMENTS.items():
                 if fragment not in iterate_body:
                     issues.append(f"{message}: {iterate_backlog_rel}")
+
+    focus_open_prs_rel = FOCUS_OPEN_PRS_PROMPT.relative_to(ROOT).as_posix()
+    if not FOCUS_OPEN_PRS_PROMPT.exists():
+        issues.append(f"PROMPT missing open-pr-focus command contract: {focus_open_prs_rel}")
+    else:
+        focus_frontmatter, focus_body = parse_frontmatter(FOCUS_OPEN_PRS_PROMPT)
+        if focus_frontmatter is None:
+            issues.append(f"PROMPT missing/invalid frontmatter: {focus_open_prs_rel}")
+        else:
+            for fragment, message in FOCUS_OPEN_PRS_PROMPT_REQUIRED_FRAGMENTS.items():
+                if fragment not in focus_body:
+                    issues.append(f"{message}: {focus_open_prs_rel}")
 
     # Agents
     for agent_path in sorted(AGENTS_DIR.glob("*.agent.md")):


### PR DESCRIPTION
Adds a new slash command contract to focus Banana automation on open pull request throughput.\n\nIncludes:\n- new prompt: .github/prompts/focus-on-open-pull-requests.prompt.md\n- agent contract updates in domain-teaming playbook and key agents\n- validator enforcement in scripts/validate-ai-contracts.py\n- entry-point docs update for command discovery\n\nValidation:\n- c:/Github/Banana/.venv/Scripts/python.exe scripts/validate-ai-contracts.py