### PR TITLE
ci: attribute automation PRs to agent contributors

### DIFF
--- a/.github/skills/banana-build-and-run/entry-points.md
+++ b/.github/skills/banana-build-and-run/entry-points.md
@@ -76,6 +76,7 @@
 - CI repository persistence PR controls: `registry_history_pr_base_branch`, `registry_history_open_draft_pr`, `registry_history_pr_labels`, and `registry_history_pr_reviewers`.
 - Push-based corpus persistence: when `data/not-banana/corpus.json` changes, `Train Not-Banana Model` now persists registry history automatically in the same run.
 - Triaged-code PR orchestration workflow: `.github/workflows/orchestrate-triaged-item-pr.yml` via workflow dispatch with `triage_id` + `change_command`.
+- Automation contributor attribution overrides: `BANANA_AGENT_CONTRIBUTOR`, `BANANA_AGENT_CONTRIBUTOR_NAME`, and `BANANA_AGENT_CONTRIBUTOR_EMAIL` (triaged + registry-history PR scripts). If unset, triaged orchestration derives contributor identity from the first `agent:*` PR label and otherwise falls back to `workflow-agent`.
 - Cloud triage idea orchestration workflow: `.github/workflows/orchestrate-triage-idea-cloud.yml` via issue labels `triage-idea`/`copilot-suggestion`/`human-triage` or workflow dispatch with `idea`/`issue_number`.
 - Human agent-target issue templates: `.github/ISSUE_TEMPLATE/human-*.yml` (one template per static helper in `.github/agents/*.agent.md`, each embedding routing markers for source and target agent).
 - Cloud triage idea orchestration script: `bash scripts/workflow-triage-idea-cloud.sh`.

--- a/.github/skills/banana-build-and-run/entry-points.md
+++ b/.github/skills/banana-build-and-run/entry-points.md
@@ -66,7 +66,7 @@
 - Wiki sync script: `bash scripts/workflow-sync-wiki.sh` (supports `BANANA_WIKI_*` env vars)
 - Example explicit Banana wiki remote (override for forks): `BANANA_WIKI_REMOTE_URL=https://github.com/LahkLeKey/Banana.wiki.git`
 - Canonical wiki enforcement toggle: `BANANA_ENFORCE_CANONICAL_WIKI_REMOTE=true`
-- AI contract validation script: `python scripts/validate-ai-contracts.py` (verifies prompt/agent/instruction/skill frontmatter and wiki-sync coverage)
+- AI contract validation script: `python scripts/validate-ai-contracts.py` (verifies prompt/agent/instruction/skill frontmatter, wiki-sync coverage, and blocks legacy terminology regressions)
 - Incremental SDLC orchestration script: `bash scripts/workflow-orchestrate-sdlc.sh`
 - Local SDLC dry-run script: `bash scripts/workflow-local-orchestrate-sdlc.sh`
 - Full SDLC orchestration workflow: `.github/workflows/orchestrate-banana-sdlc.yml`
@@ -87,6 +87,7 @@
 - Open PR focus prompt: `.github/prompts/focus-on-open-pull-requests.prompt.md` (use `/focus-on-open-pull-requests "scope"` to prioritize open PR merge readiness and dispatch required checks).
 - Human-approval gate workflow: `.github/workflows/require-human-approval.yml` (mark check required in branch protection/rulesets).
 - Copilot triage-and-approval workflow: `.github/workflows/copilot-review-triage.yml` (tracks unresolved Copilot findings and auto-approves automation PRs, or non-automation PRs with `copilot-auto-approve`).
+- AI contract guard workflow: `.github/workflows/ai-contract-guard.yml` (runs `scripts/validate-ai-contracts.py` on pull requests, pushes, and manual dispatch).
 - Autonomous continuation labels: `copilot-autonomous-cycle` and `speckit-driven` (paired with `copilot-triage-ready` for bot-driven continuation and provenance tagging of spec-kit-driven integrations).
 - Preserve CI/container prerequisites needed to execute training and drift checks reliably.
 - Treat training drift failures as actionable model/data contract signals, not infrastructure noise.

--- a/.github/workflows/ai-contract-guard.yml
+++ b/.github/workflows/ai-contract-guard.yml
@@ -1,0 +1,22 @@
+name: AI Contract Guard
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  validate-ai-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate AI contracts and terminology guard
+        run: |
+          python scripts/validate-ai-contracts.py

--- a/scripts/orchestrate-not-banana-feedback-loop.sh
+++ b/scripts/orchestrate-not-banana-feedback-loop.sh
@@ -26,8 +26,9 @@ PR_TITLE_DEFAULT="triage(not-banana-feedback): apply approved feedback to corpus
 PR_TITLE="${BANANA_PR_TITLE:-$PR_TITLE_DEFAULT}"
 PR_BODY="${BANANA_PR_BODY:-}"
 DRAFT_PR="${BANANA_DRAFT_PR:-true}"
-PR_LABELS="${BANANA_PR_LABELS:-automation,triaged-item,requires-human-approval,copilot-auto-approve,speckit-driven,feedback-loop}"
+PR_LABELS="${BANANA_PR_LABELS:-automation,triaged-item,requires-human-approval,copilot-auto-approve,speckit-driven,feedback-loop,agent:banana-classifier-agent}"
 PR_REVIEWERS="${BANANA_PR_REVIEWERS:-}"
+AGENT_CONTRIBUTOR="${BANANA_AGENT_CONTRIBUTOR:-banana-classifier-agent}"
 
 REPORT_ROOT="artifacts/not-banana-feedback"
 mkdir -p "$REPORT_ROOT"
@@ -152,5 +153,6 @@ export BANANA_PR_BODY="$PR_BODY"
 export BANANA_DRAFT_PR="$DRAFT_PR"
 export BANANA_PR_LABELS="$PR_LABELS"
 export BANANA_PR_REVIEWERS="$PR_REVIEWERS"
+export BANANA_AGENT_CONTRIBUTOR="$AGENT_CONTRIBUTOR"
 
 bash scripts/workflow-orchestrate-triaged-item-pr.sh

--- a/scripts/validate-ai-contracts.py
+++ b/scripts/validate-ai-contracts.py
@@ -28,6 +28,7 @@ SCRIPT_ORCHESTRATE_TRIAGED = ROOT / "scripts" / "workflow-orchestrate-triaged-it
 SCRIPT_ORCHESTRATE_SDLC = ROOT / "scripts" / "workflow-orchestrate-sdlc.sh"
 SCRIPT_ORCHESTRATE_FEEDBACK = ROOT / "scripts" / "orchestrate-not-banana-feedback-loop.sh"
 SCRIPT_ORCHESTRATE_TRIAGE_IDEA = ROOT / "scripts" / "workflow-triage-idea-cloud.sh"
+SCRIPT_PERSIST_REGISTRY_HISTORY = ROOT / "scripts" / "workflow-persist-registry-history-pr.sh"
 SCRIPT_ENSURE_SPECKIT = ROOT / "scripts" / "workflow-ensure-speckit.sh"
 CANONICAL_WIKI_REMOTE_URL = "https://github.com/LahkLeKey/Banana.wiki.git"
 
@@ -497,9 +498,31 @@ def main() -> int:
     if "workflow-ensure-speckit.sh" not in triaged_script_text:
         issues.append("Triaged PR script missing Spec Kit preflight invocation")
 
+    triaged_required_fragments = {
+        "BANANA_AGENT_CONTRIBUTOR": "Triaged PR script missing automation contributor override input",
+        "resolve_agent_contributor": "Triaged PR script missing automation contributor resolution",
+        "contributor:${AGENT_CONTRIBUTOR_SLUG}": "Triaged PR script missing contributor label propagation",
+        "git config user.name \"$AGENT_CONTRIBUTOR_NAME\"": "Triaged PR script missing contributor git author name wiring",
+        "git config user.email \"$AGENT_CONTRIBUTOR_EMAIL\"": "Triaged PR script missing contributor git author email wiring",
+        "Automation contributor:": "Triaged PR script missing contributor metadata in PR body",
+    }
+
+    for fragment, message in triaged_required_fragments.items():
+        if fragment not in triaged_script_text:
+            issues.append(message)
+
     feedback_script_text = SCRIPT_ORCHESTRATE_FEEDBACK.read_text(encoding="utf-8")
     if "workflow-ensure-speckit.sh" not in feedback_script_text:
         issues.append("Feedback-loop script missing Spec Kit preflight invocation")
+
+    feedback_required_fragments = {
+        "BANANA_AGENT_CONTRIBUTOR": "Feedback-loop script missing automation contributor override",
+        "agent:banana-classifier-agent": "Feedback-loop script missing classifier agent label default",
+    }
+
+    for fragment, message in feedback_required_fragments.items():
+        if fragment not in feedback_script_text:
+            issues.append(message)
 
     sdlc_script_text = SCRIPT_ORCHESTRATE_SDLC.read_text(encoding="utf-8")
     if "WIKI_REMOTE_URL=" not in sdlc_script_text:
@@ -513,6 +536,25 @@ def main() -> int:
 
     if "workflow-ensure-speckit.sh" not in sdlc_script_text:
         issues.append("SDLC script missing Spec Kit preflight invocation")
+
+    persist_script_rel = SCRIPT_PERSIST_REGISTRY_HISTORY.relative_to(ROOT).as_posix()
+    if not SCRIPT_PERSIST_REGISTRY_HISTORY.exists():
+        issues.append(
+            f"SCRIPT missing registry-history PR orchestration script: {persist_script_rel}"
+        )
+    else:
+        persist_script_text = SCRIPT_PERSIST_REGISTRY_HISTORY.read_text(encoding="utf-8")
+        persist_required_fragments = {
+            "BANANA_AGENT_CONTRIBUTOR": "Registry-history PR script missing automation contributor override input",
+            "contributor:${AGENT_CONTRIBUTOR_SLUG}": "Registry-history PR script missing contributor label propagation",
+            "git config user.name \"$AGENT_CONTRIBUTOR_NAME\"": "Registry-history PR script missing contributor git author name wiring",
+            "git config user.email \"$AGENT_CONTRIBUTOR_EMAIL\"": "Registry-history PR script missing contributor git author email wiring",
+            "Automation contributor:": "Registry-history PR script missing contributor metadata in PR body",
+        }
+
+        for fragment, message in persist_required_fragments.items():
+            if fragment not in persist_script_text:
+                issues.append(f"{message}: {persist_script_rel}")
 
     triage_idea_script_rel = SCRIPT_ORCHESTRATE_TRIAGE_IDEA.relative_to(ROOT).as_posix()
     if not SCRIPT_ORCHESTRATE_TRIAGE_IDEA.exists():

--- a/scripts/validate-ai-contracts.py
+++ b/scripts/validate-ai-contracts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -56,6 +57,64 @@ FOCUS_OPEN_PRS_PROMPT_REQUIRED_FRAGMENTS = {
     "Do not open duplicate replacement PRs": "PROMPT missing duplicate PR safeguard contract",
     "Return concrete outputs for each PR handled": "PROMPT missing per-PR output contract",
 }
+TERM_GUARD_TOKEN = "vi" + "be"
+TERM_GUARD_TITLE_TOKEN = TERM_GUARD_TOKEN.capitalize()
+TERM_GUARD_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(rf"\bcopilot-bypass-{TERM_GUARD_TOKEN}-coded\b", re.IGNORECASE),
+        "legacy-label-token",
+    ),
+    (re.compile(rf"\b{TERM_GUARD_TOKEN}[- ]coding\b", re.IGNORECASE), "legacy-coding-phrase"),
+    (re.compile(rf"\b{TERM_GUARD_TOKEN}[- ]coded\b", re.IGNORECASE), "legacy-coded-phrase"),
+    (re.compile(rf"\b{TERM_GUARD_TOKEN}bypass\b", re.IGNORECASE), "legacy-bypass-token"),
+    (
+        re.compile(rf"##\s+{TERM_GUARD_TITLE_TOKEN}\s+Code\s+Quickstart", re.IGNORECASE),
+        "legacy-quickstart-heading",
+    ),
+    (
+        re.compile(rf"##\s+{TERM_GUARD_TITLE_TOKEN}\s+Coding\s+Guardrails", re.IGNORECASE),
+        "legacy-guardrails-heading",
+    ),
+)
+TERM_GUARD_EXCLUDED_DIRECTORIES = {
+    ".git",
+    ".idea",
+    ".venv",
+    ".vs",
+    "build",
+    "node_modules",
+    "__pycache__",
+}
+TERM_GUARD_EXCLUDED_SUFFIXES = {
+    ".7z",
+    ".a",
+    ".bin",
+    ".bmp",
+    ".class",
+    ".dll",
+    ".dylib",
+    ".eot",
+    ".exe",
+    ".gif",
+    ".gz",
+    ".ico",
+    ".jar",
+    ".jpeg",
+    ".jpg",
+    ".lib",
+    ".o",
+    ".obj",
+    ".pdf",
+    ".png",
+    ".so",
+    ".tar",
+    ".tgz",
+    ".ttf",
+    ".webp",
+    ".woff",
+    ".woff2",
+    ".zip",
+}
 
 
 def parse_frontmatter(path: Path) -> tuple[dict[str, str] | None, str]:
@@ -92,6 +151,79 @@ def gather_contract_mappings() -> set[str]:
         prompt_targets.add(f"Auto-Prompts/{prompt_name}.md")
 
     return prompt_targets
+
+
+def iter_fallback_guard_files() -> list[Path]:
+    candidates: list[Path] = []
+    for path in ROOT.rglob("*"):
+        if not path.is_file():
+            continue
+
+        rel_path = path.relative_to(ROOT)
+        if any(part in TERM_GUARD_EXCLUDED_DIRECTORIES for part in rel_path.parts):
+            continue
+
+        if path.suffix.lower() in TERM_GUARD_EXCLUDED_SUFFIXES:
+            continue
+
+        candidates.append(path)
+
+    return sorted(candidates)
+
+
+def iter_guard_target_files() -> list[Path]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(ROOT), "ls-files", "-z"],
+            check=True,
+            capture_output=True,
+            text=False,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return iter_fallback_guard_files()
+
+    candidates: list[Path] = []
+    for raw_rel in result.stdout.split(b"\x00"):
+        if not raw_rel:
+            continue
+
+        rel = raw_rel.decode("utf-8", errors="ignore")
+        rel_path = Path(rel)
+
+        if any(part in TERM_GUARD_EXCLUDED_DIRECTORIES for part in rel_path.parts):
+            continue
+
+        abs_path = ROOT / rel_path
+        if not abs_path.is_file():
+            continue
+
+        if abs_path.suffix.lower() in TERM_GUARD_EXCLUDED_SUFFIXES:
+            continue
+
+        candidates.append(abs_path)
+
+    return sorted(candidates)
+
+
+def validate_no_legacy_terms(issues: list[str]) -> None:
+    for file_path in iter_guard_target_files():
+        rel = file_path.relative_to(ROOT).as_posix()
+
+        try:
+            text = file_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            for pattern, label in TERM_GUARD_PATTERNS:
+                if pattern.search(line):
+                    snippet = line.strip()
+                    if len(snippet) > 140:
+                        snippet = snippet[:137] + "..."
+                    issues.append(
+                        f"TERM_GUARD prohibited phrase '{label}' found: {rel}:{line_number} ({snippet})"
+                    )
+                    break
 
 
 def main() -> int:
@@ -421,6 +553,9 @@ def main() -> int:
         for fragment, message in triage_idea_script_required_fragments.items():
             if fragment not in triage_idea_script_text:
                 issues.append(f"{message}: {triage_idea_script_rel}")
+
+    validate_no_legacy_terms(issues)
+
     payload: dict[str, Any] = {
         "issues": issues,
         "prompt_missing_wiki_contract": prompt_missing_wiki_contract,

--- a/scripts/workflow-orchestrate-triaged-item-pr.sh
+++ b/scripts/workflow-orchestrate-triaged-item-pr.sh
@@ -21,6 +21,13 @@ PR_REVIEWERS="${BANANA_PR_REVIEWERS:-}"
 LOCAL_DRY_RUN="${BANANA_LOCAL_DRY_RUN:-false}"
 SKIP_IF_NO_CHANGES="${BANANA_SKIP_IF_NO_CHANGES:-false}"
 PR_OUTPUT_PATH="${BANANA_PR_OUTPUT_PATH:-}"
+AGENT_CONTRIBUTOR_OVERRIDE="${BANANA_AGENT_CONTRIBUTOR:-}"
+AGENT_CONTRIBUTOR_NAME_OVERRIDE="${BANANA_AGENT_CONTRIBUTOR_NAME:-}"
+AGENT_CONTRIBUTOR_EMAIL_OVERRIDE="${BANANA_AGENT_CONTRIBUTOR_EMAIL:-}"
+AGENT_CONTRIBUTOR_SLUG=""
+AGENT_CONTRIBUTOR_NAME=""
+AGENT_CONTRIBUTOR_EMAIL=""
+AGENT_CONTRIBUTOR_LABEL=""
 
 write_pr_output() {
   local status="$1"
@@ -39,6 +46,10 @@ write_pr_output() {
   PR_OUTPUT_BRANCH="$WORK_BRANCH" \
   PR_OUTPUT_TRIAGE_ID="$TRIAGE_ID" \
   PR_OUTPUT_BASE_BRANCH="$BASE_BRANCH" \
+  PR_OUTPUT_AGENT_CONTRIBUTOR_NAME="$AGENT_CONTRIBUTOR_NAME" \
+  PR_OUTPUT_AGENT_CONTRIBUTOR_EMAIL="$AGENT_CONTRIBUTOR_EMAIL" \
+  PR_OUTPUT_AGENT_CONTRIBUTOR_SLUG="$AGENT_CONTRIBUTOR_SLUG" \
+  PR_OUTPUT_AGENT_CONTRIBUTOR_LABEL="$AGENT_CONTRIBUTOR_LABEL" \
   python - "$PR_OUTPUT_PATH" <<'PY'
 import json
 import os
@@ -56,6 +67,10 @@ payload = {
     "pr_url": os.environ.get("PR_OUTPUT_URL", ""),
     "pr_number": os.environ.get("PR_OUTPUT_NUMBER", ""),
     "reason": os.environ.get("PR_OUTPUT_REASON", ""),
+    "automation_contributor_name": os.environ.get("PR_OUTPUT_AGENT_CONTRIBUTOR_NAME", ""),
+    "automation_contributor_email": os.environ.get("PR_OUTPUT_AGENT_CONTRIBUTOR_EMAIL", ""),
+    "automation_contributor_slug": os.environ.get("PR_OUTPUT_AGENT_CONTRIBUTOR_SLUG", ""),
+    "automation_contributor_label": os.environ.get("PR_OUTPUT_AGENT_CONTRIBUTOR_LABEL", ""),
 }
 
 output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
@@ -96,9 +111,81 @@ parse_list_input() {
   done
 }
 
+slugify_agent_contributor() {
+  local raw="${1:-}"
+  local slug
+
+  slug="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/^agent://; s/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+
+  if [[ -z "$slug" ]]; then
+    slug="workflow-agent"
+  fi
+
+  printf '%s' "$slug"
+}
+
+append_csv_item_if_missing() {
+  local csv="${1:-}"
+  local item="${2:-}"
+  local -a parsed_items=()
+  local normalized_item
+  local existing
+
+  normalized_item="$(echo "$item" | xargs)"
+  if [[ -z "$normalized_item" ]]; then
+    printf '%s' "$csv"
+    return 0
+  fi
+
+  parse_list_input "$csv" parsed_items
+  for existing in "${parsed_items[@]}"; do
+    if [[ "${existing,,}" == "${normalized_item,,}" ]]; then
+      printf '%s' "$csv"
+      return 0
+    fi
+  done
+
+  if [[ -z "$csv" ]]; then
+    printf '%s' "$normalized_item"
+  else
+    printf '%s,%s' "$csv" "$normalized_item"
+  fi
+}
+
+resolve_agent_contributor() {
+  local candidate="${AGENT_CONTRIBUTOR_OVERRIDE:-}"
+  local label
+  local -a parsed_labels=()
+
+  if [[ -z "$candidate" ]]; then
+    parse_list_input "${PR_LABELS:-}" parsed_labels
+    for label in "${parsed_labels[@]}"; do
+      if [[ "$label" == agent:* ]]; then
+        candidate="${label#agent:}"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "$candidate" ]]; then
+    candidate="workflow-agent"
+  fi
+
+  AGENT_CONTRIBUTOR_SLUG="$(slugify_agent_contributor "$candidate")"
+  AGENT_CONTRIBUTOR_LABEL="contributor:${AGENT_CONTRIBUTOR_SLUG}"
+
+  AGENT_CONTRIBUTOR_NAME="${AGENT_CONTRIBUTOR_NAME_OVERRIDE:-banana-${AGENT_CONTRIBUTOR_SLUG}[bot]}"
+  AGENT_CONTRIBUTOR_EMAIL="${AGENT_CONTRIBUTOR_EMAIL_OVERRIDE:-banana+${AGENT_CONTRIBUTOR_SLUG}@users.noreply.github.com}"
+
+  PR_LABELS="$(append_csv_item_if_missing "$PR_LABELS" "$AGENT_CONTRIBUTOR_LABEL")"
+}
+
 declare -a parsed_reviewers=()
 parse_list_input "${PR_REVIEWERS:-}" parsed_reviewers
 PARSED_REVIEWERS_CSV="$(IFS=','; echo "${parsed_reviewers[*]:-}")"
+
+resolve_agent_contributor
+echo "Using automation contributor: ${AGENT_CONTRIBUTOR_NAME} <${AGENT_CONTRIBUTOR_EMAIL}>"
 
 TRIAGE_ID_SLUG="$(echo "$TRIAGE_ID" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
 if [[ -z "$TRIAGE_ID_SLUG" ]]; then
@@ -134,6 +221,9 @@ if [[ "$LOCAL_DRY_RUN" == "true" ]]; then
   "base_branch": "${BASE_BRANCH}",
   "commit_message": "${COMMIT_MESSAGE}",
   "labels": "${PR_LABELS}",
+  "automation_contributor_name": "${AGENT_CONTRIBUTOR_NAME}",
+  "automation_contributor_email": "${AGENT_CONTRIBUTOR_EMAIL}",
+  "automation_contributor_label": "${AGENT_CONTRIBUTOR_LABEL}",
   "reviewers": "${PARSED_REVIEWERS_CSV}",
   "open_draft": "${DRAFT_PR}",
   "changed_files_csv": "${CHANGED_FILES}",
@@ -166,8 +256,8 @@ if git diff --cached --quiet; then
   exit 1
 fi
 
-git config user.name "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config user.name "$AGENT_CONTRIBUTOR_NAME"
+git config user.email "$AGENT_CONTRIBUTOR_EMAIL"
 git commit -m "$COMMIT_MESSAGE"
 git push -u origin "$WORK_BRANCH"
 
@@ -185,6 +275,7 @@ This pull request was orchestrated for a triaged item and requires human approva
 - Run ID: ${RUN_ID}
 - Attempt: ${RUN_ATTEMPT}
 - Source branch: ${WORK_BRANCH}
+- Automation contributor: ${AGENT_CONTRIBUTOR_NAME} <${AGENT_CONTRIBUTOR_EMAIL}>
 
 Command executed:
 ${CHANGE_COMMAND}
@@ -193,6 +284,11 @@ EOF
 
 if [[ -n "$PR_BODY_OVERRIDE" ]]; then
   PR_BODY="$PR_BODY_OVERRIDE"
+  if [[ "$PR_BODY" != *"Automation contributor:"* ]]; then
+    PR_BODY="${PR_BODY}
+
+- Automation contributor: ${AGENT_CONTRIBUTOR_NAME} <${AGENT_CONTRIBUTOR_EMAIL}>"
+  fi
 else
   PR_BODY="$DEFAULT_PR_BODY"
 fi

--- a/scripts/workflow-persist-registry-history-pr.sh
+++ b/scripts/workflow-persist-registry-history-pr.sh
@@ -14,6 +14,13 @@ OPEN_DRAFT_PR="${BANANA_REGISTRY_OPEN_DRAFT_PR:-true}"
 PR_LABELS="${BANANA_REGISTRY_PR_LABELS:-automation,model-training,requires-human-approval}"
 PR_REVIEWERS="${BANANA_REGISTRY_PR_REVIEWERS:-}"
 LOCAL_DRY_RUN="${BANANA_LOCAL_DRY_RUN:-false}"
+AGENT_CONTRIBUTOR_OVERRIDE="${BANANA_AGENT_CONTRIBUTOR:-banana-classifier-agent}"
+AGENT_CONTRIBUTOR_NAME_OVERRIDE="${BANANA_AGENT_CONTRIBUTOR_NAME:-}"
+AGENT_CONTRIBUTOR_EMAIL_OVERRIDE="${BANANA_AGENT_CONTRIBUTOR_EMAIL:-}"
+AGENT_CONTRIBUTOR_SLUG=""
+AGENT_CONTRIBUTOR_NAME=""
+AGENT_CONTRIBUTOR_EMAIL=""
+AGENT_CONTRIBUTOR_LABEL=""
 
 parse_list_input() {
   local raw="${1:-}"
@@ -49,9 +56,63 @@ parse_list_input() {
   done
 }
 
+slugify_agent_contributor() {
+  local raw="${1:-}"
+  local slug
+
+  slug="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/^agent://; s/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+
+  if [[ -z "$slug" ]]; then
+    slug="workflow-agent"
+  fi
+
+  printf '%s' "$slug"
+}
+
+append_csv_item_if_missing() {
+  local csv="${1:-}"
+  local item="${2:-}"
+  local -a parsed_items=()
+  local normalized_item
+  local existing
+
+  normalized_item="$(echo "$item" | xargs)"
+  if [[ -z "$normalized_item" ]]; then
+    printf '%s' "$csv"
+    return 0
+  fi
+
+  parse_list_input "$csv" parsed_items
+  for existing in "${parsed_items[@]}"; do
+    if [[ "${existing,,}" == "${normalized_item,,}" ]]; then
+      printf '%s' "$csv"
+      return 0
+    fi
+  done
+
+  if [[ -z "$csv" ]]; then
+    printf '%s' "$normalized_item"
+  else
+    printf '%s,%s' "$csv" "$normalized_item"
+  fi
+}
+
+resolve_agent_contributor() {
+  AGENT_CONTRIBUTOR_SLUG="$(slugify_agent_contributor "$AGENT_CONTRIBUTOR_OVERRIDE")"
+  AGENT_CONTRIBUTOR_LABEL="contributor:${AGENT_CONTRIBUTOR_SLUG}"
+
+  AGENT_CONTRIBUTOR_NAME="${AGENT_CONTRIBUTOR_NAME_OVERRIDE:-banana-${AGENT_CONTRIBUTOR_SLUG}[bot]}"
+  AGENT_CONTRIBUTOR_EMAIL="${AGENT_CONTRIBUTOR_EMAIL_OVERRIDE:-banana+${AGENT_CONTRIBUTOR_SLUG}@users.noreply.github.com}"
+
+  PR_LABELS="$(append_csv_item_if_missing "$PR_LABELS" "$AGENT_CONTRIBUTOR_LABEL")"
+}
+
 declare -a parsed_reviewers=()
 parse_list_input "${PR_REVIEWERS:-}" parsed_reviewers
 PARSED_REVIEWERS_CSV="$(IFS=','; echo "${parsed_reviewers[*]:-}")"
+
+resolve_agent_contributor
+echo "Using automation contributor: ${AGENT_CONTRIBUTOR_NAME} <${AGENT_CONTRIBUTOR_EMAIL}>"
 
 if [[ ! -d "$RELEASE_ARTIFACTS_SOURCE" ]]; then
   echo "::error::Release artifacts source does not exist: $RELEASE_ARTIFACTS_SOURCE"
@@ -86,6 +147,9 @@ if [[ "$LOCAL_DRY_RUN" == "true" ]]; then
   "base_branch": "${BASE_BRANCH}",
   "history_path": "${HISTORY_PATH}",
   "labels": "${PR_LABELS}",
+  "automation_contributor_name": "${AGENT_CONTRIBUTOR_NAME}",
+  "automation_contributor_email": "${AGENT_CONTRIBUTOR_EMAIL}",
+  "automation_contributor_label": "${AGENT_CONTRIBUTOR_LABEL}",
   "reviewers": "${PARSED_REVIEWERS_CSV}",
   "open_draft": "${OPEN_DRAFT_PR}",
   "simulated_pr_url": "https://example.invalid/${WORK_BRANCH}"
@@ -131,8 +195,8 @@ latest_path.parent.mkdir(parents=True, exist_ok=True)
 latest_path.write_text(json.dumps(latest, indent=2) + "\n", encoding="utf-8")
 PY
 
-git config user.name "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config user.name "$AGENT_CONTRIBUTOR_NAME"
+git config user.email "$AGENT_CONTRIBUTOR_EMAIL"
 git add "$HISTORY_PATH"
 
 if git diff --cached --quiet; then
@@ -151,6 +215,7 @@ This pull request was orchestrated by the not-banana training workflow and requi
 - Attempt: ${RUN_ATTEMPT}
 - Snapshot path: ${HISTORY_PATH}/${STAMP}
 - Source branch: ${WORK_BRANCH}
+- Automation contributor: ${AGENT_CONTRIBUTOR_NAME} <${AGENT_CONTRIBUTOR_EMAIL}>
 EOF
 )
 


### PR DESCRIPTION
## Summary
- attribute automation commit authors to agent-specific contributor identities in triaged and registry-history PR orchestration scripts
- propagate contributor labels (for example: contributor:api-pipeline-agent) and include automation contributor metadata in PR bodies and dry-run outputs
- set classifier-specific contributor defaults for feedback and model-release-history automation flows
- enforce this contract in scripts/validate-ai-contracts.py and document contributor override env vars in entry points

## Why
This enables contributor-level tracking by agent for automation-originated work, supporting velocity and ownership analysis in GitHub.

## Validation
- c:/Github/Banana/.venv/Scripts/python.exe scripts/validate-ai-contracts.py