### PR TITLE
chore(wiki+ci): split human/ai wiki navigation and harden coverage test guard

### DIFF
--- a/.github/workflows/compose-ci.yml
+++ b/.github/workflows/compose-ci.yml
@@ -294,9 +294,9 @@ jobs:
 
       - name: Generate integration uncovered-lines artifact
         run: |
-          report_file="$(find .artifacts/coverage/integration-report -maxdepth 1 -type f -name '*.xml' | head -n 1)"
-          if [[ -z "$report_file" ]]; then
-            echo "No integration Cobertura XML report found in .artifacts/coverage/integration-report"
+          report_file=".artifacts/coverage/integration-report/Cobertura.xml"
+          if [[ ! -f "$report_file" ]]; then
+            echo "Expected integration Cobertura XML report not found at $report_file"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Automated SDLC orchestration (incremental PR slices + wiki sync):
 - Wiki layer runs after PR orchestration via `scripts/workflow-sync-wiki.sh` and can push commits to the GitHub wiki repo (or run dry-run for validation).
 - Input `wiki_remote_url` defaults to the canonical Banana wiki target (`https://github.com/LahkLeKey/Banana.wiki.git`).
 - Default wiki sync now mirrors key `.github` contracts (workflows, instructions, and Copilot instructions) so wiki runbooks stay aligned with automation truth.
+- Wiki sync now publishes explicit navigation sections for Human Reading and AI Audit Trails (`Human-Reading-Guide.md`, `AI-Audit-Trails.md`) and updates a navigation block in `Home.md`.
 - Weekday scheduled SDLC runs force strict wiki sync behavior (`BANANA_WIKI_STRICT=true`) so wiki clone/push failures fail the run.
 - Workflow runs on `workflow_dispatch` and on a weekday schedule for unattended incremental automation.
 - Default plan includes:

--- a/scripts/workflow-sync-wiki.sh
+++ b/scripts/workflow-sync-wiki.sh
@@ -227,6 +227,11 @@ for entry in "${mapping_entries[@]}"; do
   expected_targets+=("$target_path")
 done
 
+declare -a sorted_expected_targets=()
+if [[ ${#expected_targets[@]} -gt 0 ]]; then
+  mapfile -t sorted_expected_targets < <(printf '%s\n' "${expected_targets[@]}" | awk 'NF && !seen[$0]++' | sort)
+fi
+
 INDEX_PAGE="$WIKI_DIR/Auto-SDLC-Snapshots.md"
 {
   echo "# Automated SDLC Wiki Snapshots"
@@ -238,11 +243,139 @@ INDEX_PAGE="$WIKI_DIR/Auto-SDLC-Snapshots.md"
   echo
   echo "## Synced Pages"
   echo
-  for target in "${expected_targets[@]}"; do
+  for target in "${sorted_expected_targets[@]}"; do
     echo "- [${target}](${target})"
   done
   echo
 } > "$INDEX_PAGE"
+
+AI_AUDIT_PAGE="$WIKI_DIR/AI-Audit-Trails.md"
+{
+  echo "# AI Audit Trails"
+  echo
+  echo "This section indexes pages generated or synced by automation for traceability and diagnostics."
+  echo
+  echo "- Source commit: ${repo_head}"
+  echo "- Synced at (UTC): ${timestamp_utc}"
+  echo
+  echo "## Primary Audit Pages"
+  echo
+  echo "- [Auto-SDLC-Snapshots.md](Auto-SDLC-Snapshots.md)"
+  echo
+  echo "## Auto-Synced Source Mirrors"
+  echo
+  if [[ ${#sorted_expected_targets[@]} -eq 0 ]]; then
+    echo "- No auto-synced pages were generated in this run."
+  else
+    for target in "${sorted_expected_targets[@]}"; do
+      echo "- [${target}](${target})"
+    done
+  fi
+  echo
+} > "$AI_AUDIT_PAGE"
+
+declare -a human_pages=()
+while IFS= read -r wiki_file; do
+  rel_path="${wiki_file#"$WIKI_DIR/"}"
+  if [[ "$rel_path" == .git/* ]]; then
+    continue
+  fi
+
+  if [[ "$rel_path" == Auto-* ]]; then
+    continue
+  fi
+
+  if [[ "$rel_path" == "AI-Audit-Trails.md" || "$rel_path" == "Human-Reading-Guide.md" ]]; then
+    continue
+  fi
+
+  human_pages+=("$rel_path")
+done < <(find "$WIKI_DIR" -type f -name "*.md" | sort)
+
+declare -a sorted_human_pages=()
+if [[ ${#human_pages[@]} -gt 0 ]]; then
+  mapfile -t sorted_human_pages < <(printf '%s\n' "${human_pages[@]}" | awk 'NF && !seen[$0]++' | sort)
+fi
+
+HUMAN_GUIDE_PAGE="$WIKI_DIR/Human-Reading-Guide.md"
+{
+  echo "# Human Reading Guide"
+  echo
+  echo "This section highlights human-oriented wiki pages and operational references."
+  echo
+  echo "## Start Here"
+  echo
+  echo "- [Home.md](Home.md)"
+  echo "- [Architecture-Diagrams.md](Architecture-Diagrams.md)"
+  echo "- [First-Day-Checklist.md](First-Day-Checklist.md)"
+  echo
+  echo "## Human-Curated Pages"
+  echo
+  if [[ ${#sorted_human_pages[@]} -eq 0 ]]; then
+    echo "- No human-curated pages detected yet."
+  else
+    for page in "${sorted_human_pages[@]}"; do
+      echo "- [${page}](${page})"
+    done
+  fi
+  echo
+  echo "## AI Audit Trails"
+  echo
+  echo "- [AI-Audit-Trails.md](AI-Audit-Trails.md)"
+  echo "- [Auto-SDLC-Snapshots.md](Auto-SDLC-Snapshots.md)"
+  echo
+} > "$HUMAN_GUIDE_PAGE"
+
+HOME_PAGE="$WIKI_DIR/Home.md"
+python - "$HOME_PAGE" "$repo_head" "$timestamp_utc" <<'PY'
+import pathlib
+import re
+import sys
+
+home_path = pathlib.Path(sys.argv[1])
+source_commit = sys.argv[2]
+synced_at = sys.argv[3]
+
+start_marker = "<!-- AUTO-SYNC-WIKI-NAV START -->"
+end_marker = "<!-- AUTO-SYNC-WIKI-NAV END -->"
+
+nav_block = "\n".join(
+    [
+        start_marker,
+        "## Wiki Navigation",
+        "",
+        "### Human Reading",
+        "- [Human-Reading-Guide.md](Human-Reading-Guide.md)",
+        "",
+        "### AI Audit Trails",
+        "- [AI-Audit-Trails.md](AI-Audit-Trails.md)",
+        "- [Auto-SDLC-Snapshots.md](Auto-SDLC-Snapshots.md)",
+        "",
+        f"- Source commit: {source_commit}",
+        f"- Synced at (UTC): {synced_at}",
+        end_marker,
+    ]
+)
+
+if home_path.exists():
+    content = home_path.read_text(encoding="utf-8")
+else:
+    content = "# Banana Wiki\n"
+
+pattern = re.compile(
+    re.escape(start_marker) + r".*?" + re.escape(end_marker),
+    flags=re.DOTALL,
+)
+
+if pattern.search(content):
+    updated = pattern.sub(nav_block, content)
+else:
+    if not content.endswith("\n"):
+        content += "\n"
+    updated = content + "\n" + nav_block + "\n"
+
+home_path.write_text(updated, encoding="utf-8")
+PY
 
 git -C "$WIKI_DIR" add -A
 

--- a/tests/unit/NativeLibraryResolverTests.cs
+++ b/tests/unit/NativeLibraryResolverTests.cs
@@ -212,20 +212,20 @@ public sealed class NativeLibraryResolverTests
         var isConfiguredField = typeof(NativeLibraryResolver).GetField("_isConfigured", BindingFlags.NonPublic | BindingFlags.Static);
 
         Assert.NotNull(isConfiguredField);
-
-        NativeLibraryResolver.EnsureConfigured(configuration, logger);
-        isConfiguredField!.SetValue(null, false);
+        var originalIsConfigured = (bool)isConfiguredField!.GetValue(null)!;
 
         try
         {
             NativeLibraryResolver.EnsureConfigured(configuration, logger);
+            isConfiguredField.SetValue(null, false);
+
+            NativeLibraryResolver.EnsureConfigured(configuration, logger);
+            Assert.True((bool)isConfiguredField.GetValue(null)!);
         }
         finally
         {
-            isConfiguredField.SetValue(null, true);
+            isConfiguredField.SetValue(null, originalIsConfigured);
         }
-
-        Assert.True((bool)isConfiguredField.GetValue(null)!);
     }
 
     private static ILogger CreateLogger()


### PR DESCRIPTION
## Summary\n- split wiki sync outputs into clear human-facing and AI audit trail entry pages\n- inject deterministic Home navigation block for those sections\n- make integration uncovered-lines source deterministic by targeting Cobertura.xml\n- fix NativeLibraryResolver static-state test to avoid false positives/leakage\n\n## Validation\n- bash -n scripts/workflow-sync-wiki.sh\n- dotnet test tests/unit/Banana.UnitTests.csproj -c Debug --filter "FullyQualifiedName~NativeLibraryResolverTests"\n