### PR TITLE
feat(docs): add technical writer agent and update all specs

### DIFF
--- a/.github/agents/banana-planner.agent.md
+++ b/.github/agents/banana-planner.agent.md
@@ -18,6 +18,7 @@ agents:
   - electron-agent
   - compose-runtime-agent
   - workflow-agent
+  - technical-writer-agent
   - test-triage-agent
 handoffs:
   - label: Implement Banana Classifier Work
@@ -50,6 +51,9 @@ handoffs:
   - label: Implement Workflow Work
     agent: workflow-agent
     prompt: Implement the planned GitHub Actions or coverage automation changes and validate the nearest local mirror path.
+  - label: Implement Documentation Work
+    agent: technical-writer-agent
+    prompt: Implement the planned wiki or docs structure and tone updates while preserving the human-vs-AI audience split.
   - label: Triage Validation Failure
     agent: test-triage-agent
     prompt: Isolate the failing validation stage, confirm the real owner, and return the narrowest safe fix path.
@@ -72,6 +76,7 @@ You produce implementation plans for Banana without editing code.
 
 - Follow the controller -> service -> pipeline -> native interop flow from [docs/developer-onboarding.md](../../docs/developer-onboarding.md) when backend behavior changes.
 - Treat [docker-compose.yml](../../docker-compose.yml), [scripts](../../scripts), and [.github/workflows/compose-ci.yml](../workflows/compose-ci.yml) as the delivery surface for runtime and CI work.
+- For wiki or docs refactors, preserve explicit human-readable and AI-audit tracks and keep `scripts/workflow-sync-wiki.sh` navigation markers stable.
 - If the task crosses layers, explicitly call out shared contracts such as `BANANA_PG_CONNECTION`, `BANANA_NATIVE_PATH`, and `VITE_BANANA_API_BASE_URL`.
 - If the task touches reusable frontend primitives, plan updates in `src/typescript/shared/ui` and direct consuming-app imports from `@banana/ui` instead of local re-export stubs.
 - If `src/typescript/shared/ui` changes, include validation for both `src/typescript/react` and `src/typescript/electron/renderer`.

--- a/.github/agents/banana-sdlc.agent.md
+++ b/.github/agents/banana-sdlc.agent.md
@@ -29,6 +29,7 @@ agents:
   - compose-runtime-agent
   - mobile-runtime-agent
   - workflow-agent
+  - technical-writer-agent
   - banana-reviewer
 handoffs:
   - label: Plan The Change
@@ -61,6 +62,9 @@ handoffs:
   - label: Implement Workflow Slice
     agent: workflow-agent
     prompt: Implement the scoped workflow or coverage automation changes and validate the nearest local mirror path.
+  - label: Implement Documentation Slice
+    agent: technical-writer-agent
+    prompt: Organize wiki and docs with explicit human-readable and AI-audit tracks, and keep sync automation aligned.
   - label: Triage Failing Tests
     agent: test-triage-agent
     prompt: Isolate the failing validation stage, identify the real owner, and propose the narrowest useful fix path.

--- a/.github/agents/domain-teaming-playbook.md
+++ b/.github/agents/domain-teaming-playbook.md
@@ -7,7 +7,7 @@ Use this playbook when coordinating Banana work across agents so specialists ope
 - Native domain: `native-core-agent`, `native-dal-agent`, `native-wrapper-agent`, coordinated by `native-c-agent`
 - ASP.NET domain: `api-pipeline-agent`, `api-interop-agent`, coordinated by `csharp-api-agent`
 - Frontend domain: `react-ui-agent`, `electron-agent`, coordinated by `react-agent`
-- Runtime and CI domain: `compose-runtime-agent`, `mobile-runtime-agent`, `workflow-agent`, coordinated by `infrastructure-agent`
+- Runtime, CI, and docs domain: `compose-runtime-agent`, `mobile-runtime-agent`, `workflow-agent`, `technical-writer-agent`, coordinated by `infrastructure-agent`
 - Product-specialized classifier domain: `banana-classifier-agent` coordinating banana-vs-not-banana behavior across training, API, and simple frontend slices
 - Cross-domain quality and orchestration: `integration-agent`, `test-triage-agent`, `banana-reviewer`, `banana-planner`, `banana-sdlc`
 

--- a/.github/agents/infrastructure-agent.agent.md
+++ b/.github/agents/infrastructure-agent.agent.md
@@ -13,6 +13,7 @@ agents:
   - compose-runtime-agent
   - mobile-runtime-agent
   - workflow-agent
+  - technical-writer-agent
   - integration-agent
   - banana-reviewer
 handoffs:
@@ -25,6 +26,9 @@ handoffs:
   - label: Implement Workflow Or Coverage Work
     agent: workflow-agent
     prompt: Implement the scoped GitHub Actions or coverage automation change and validate the nearest local mirror path.
+  - label: Implement Documentation Or Wiki Work
+    agent: technical-writer-agent
+    prompt: Implement wiki or docs organization updates, keep the human-vs-AI audience split clear, and preserve sync automation contracts.
   - label: Run Validation
     agent: integration-agent
     prompt: Validate the updated infrastructure path against the relevant tests, compose profiles, or runtime checks.

--- a/.github/agents/technical-writer-agent.agent.md
+++ b/.github/agents/technical-writer-agent.agent.md
@@ -1,0 +1,81 @@
+---
+name: technical-writer-agent
+description: Organizes Banana wiki and docs so human-facing entries stay casual and empathetic while AI-facing entries stay technical and verbose.
+argument-hint: Describe the docs or wiki surface, the audience split, and whether you need structure, tone, or automation-sync updates.
+tools:
+  - search
+  - read
+  - edit
+  - execute
+  - todo
+handoffs:
+  - label: Implement Wiki Sync Automation
+    agent: workflow-agent
+    prompt: Update workflow or wiki sync automation paths and validate the documentation publishing contract.
+  - label: Validate Documentation Changes
+    agent: integration-agent
+    prompt: Validate docs and wiki automation changes against the nearest script or workflow mirror and report regressions.
+  - label: Review Documentation Risk
+    agent: banana-reviewer
+    prompt: Review documentation and wiki changes for clarity, contract drift, and release readiness.
+---
+
+# Purpose
+
+You own Banana's documentation information architecture and voice split across human-facing guidance and AI-facing audit trails.
+
+# Use This Helper When
+
+- A request restructures wiki navigation, index pages, or runbook grouping.
+- Human-facing pages should be easier to read and more supportive.
+- AI-facing pages should preserve detailed traces, commands, and machine-friendly structure.
+- `scripts/workflow-sync-wiki.sh`, `README.md`, or wiki index conventions need updates.
+
+# Audience Split Contract
+
+## Human-readable track
+
+- Keep tone casual, empathetic, and action-first.
+- Prefer short sections, plain language, and clear next-step guidance.
+- Reduce jargon; define unavoidable technical terms in-line.
+- Optimize for skimming and confidence under time pressure.
+
+## AI-readable track
+
+- Keep tone technical, explicit, and verbose.
+- Preserve full context: assumptions, command sequences, file paths, run IDs, and status outcomes.
+- Use deterministic structure and stable headings so automation can diff and parse reliably.
+- Avoid omitting failure reasons or triage breadcrumbs.
+
+# Wiki Organization Rules
+
+1. Maintain a clear split between human entry points and AI audit pages.
+2. Keep Home navigation markers stable when modifying auto-managed blocks:
+   - `<!-- AUTO-SYNC-WIKI-NAV START -->`
+   - `<!-- AUTO-SYNC-WIKI-NAV END -->`
+3. Treat `Human-Reading-Guide.md` and `AI-Audit-Trails.md` as primary audience indexes.
+4. Keep `Auto-*` pages in the AI audit lane unless explicitly promoted to human docs.
+5. Update nearby docs when automation behavior changes, not scattered duplicates.
+
+# Validation
+
+- `bash -n scripts/workflow-sync-wiki.sh`
+- `BANANA_WIKI_DRY_RUN=true BANANA_WIKI_PUSH=false bash scripts/workflow-sync-wiki.sh`
+- Verify generated Home navigation and the two audience index pages in the dry-run wiki directory.
+
+# Shared Assets
+
+- Repo guidance: [copilot-instructions.md](../copilot-instructions.md)
+- Infra rules: [infra.instructions.md](../instructions/infra.instructions.md)
+- Helper routing: [banana-agent-decomposition](../skills/banana-agent-decomposition/SKILL.md)
+- Teaming contract: [domain-teaming-playbook.md](./domain-teaming-playbook.md)
+
+## Cross-Domain Teaming Protocol
+
+- Follow [domain-teaming-playbook.md](./domain-teaming-playbook.md) for ownership boundaries, handoff packet format, and validation routing.
+- Apply the [Feedback Loop And Incremental Branch Contract](./domain-teaming-playbook.md#feedback-loop-and-incremental-branch-contract-all-agents) for automation-driven documentation changes: use incremental feature branches, GH CLI PR orchestration, and wiki sync updates in the same SDLC flow.
+- Apply the [Open Pull Request Focus Contract](./domain-teaming-playbook.md#open-pull-request-focus-contract-all-agents) when documentation readiness for open PRs is the delivery priority.
+- Hand off immediately when touched files, contracts, or runtime assumptions move outside this agent's primary ownership.
+- Include objective, owning domain, touched files, contract impacts, validation state, and open risks in every handoff.
+- Accept inbound handoffs by confirming assumptions, preserving context, and either executing or rerouting to the next narrowest owner.
+- Escalate to `banana-sdlc` for multi-domain implementation orchestration and `integration-agent` for multi-domain validation orchestration.

--- a/.github/agents/workflow-agent.agent.md
+++ b/.github/agents/workflow-agent.agent.md
@@ -13,6 +13,9 @@ handoffs:
   - label: Coordinate Local Runtime Mirror
     agent: compose-runtime-agent
     prompt: Update the matching local script or compose runtime path for the workflow change and re-run the relevant validation.
+  - label: Coordinate Wiki Or Docs Update
+    agent: technical-writer-agent
+    prompt: Update wiki and docs structure for the workflow change while preserving human-readable and AI-audit lanes.
   - label: Validate Workflow Change
     agent: integration-agent
     prompt: Validate the workflow change against the nearest local mirror scripts, coverage flow, and runtime assumptions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,7 @@
 - Treat Banana as a multi-language monorepo with four primary domains: native C under `src/native`, ASP.NET under `src/c-sharp/asp.net`, React/Electron/Mobile under `src/typescript`, and delivery/runtime assets under `docker`, `scripts`, and `.github/workflows`.
 - Preserve the controller -> service -> pipeline -> native interop flow documented in `docs/developer-onboarding.md`.
 - Keep changes scoped to the touched domain unless a cross-layer contract actually changes.
-- Break broad work into helper-sized slices and prefer the narrowest helper agent that owns the touched files: banana classifier, native core, native DAL, native wrapper, API pipeline, API interop, React UI, Electron, mobile runtime, compose runtime, workflow, or test triage.
+- Break broad work into helper-sized slices and prefer the narrowest helper agent that owns the touched files: banana classifier, native core, native DAL, native wrapper, API pipeline, API interop, React UI, Electron, mobile runtime, compose runtime, workflow, technical writer, or test triage.
 - Use parent domain agents only when more than one helper in the same domain must move together.
 - Prefer existing entry points over inventing new ones: workspace tasks, `scripts/*.sh`, CMake targets, `dotnet` test projects, Bun scripts, and Docker Compose profiles.
 - For native or integration work, assume `BANANA_PG_CONNECTION` is required whenever PostgreSQL-backed flows are exercised.

--- a/.github/skills/banana-agent-decomposition/helper-matrix.md
+++ b/.github/skills/banana-agent-decomposition/helper-matrix.md
@@ -21,6 +21,7 @@
 - `compose-runtime-agent`: `docker-compose.yml`, `docker`, runtime scripts, local stack bring-up, and health-check behavior
 - `mobile-runtime-agent`: mobile emulator launch scripts, Ubuntu WSL2/WSLg preflight, Android AVD startup, and iOS-preview fallback behavior
 - `workflow-agent`: `.github/workflows`, coverage automation, CI artifact handling, and job structure
+- `technical-writer-agent`: wiki/doc structure and voice split, including `scripts/workflow-sync-wiki.sh`, `README.md`, and audience-specific navigation pages
 - `test-triage-agent`: test failure isolation, harness fixes, validation expansion, and fix-owner routing
 
 ## Parent Agents

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-    "feature_directory": "specs/001-agent-pulse-orchestration"
+    "feature_directory": "specs/002-regression-binary-faker-metrics"
 }

--- a/specs/001-agent-pulse-orchestration/contracts/autonomous-increment-plan.md
+++ b/specs/001-agent-pulse-orchestration/contracts/autonomous-increment-plan.md
@@ -54,3 +54,5 @@ Native deterministic rendering can guide default plan generation when:
 - Each default increment should contain exactly one `agent:*` ownership marker.
 - Default catalog should include multiple agent lanes, not only one agent.
 - Each increment should carry a clear intent summary in `pr_body` for management readability.
+- Default catalog should include a documentation ownership lane (`agent:technical-writer-agent`) when wiki/index audience split updates are required.
+- Management-visible outputs should keep separate human-readable and AI-audit entry points linked from one shared navigation section.

--- a/specs/001-agent-pulse-orchestration/data-model.md
+++ b/specs/001-agent-pulse-orchestration/data-model.md
@@ -40,6 +40,8 @@
   - `run_attempt`: Workflow run attempt number.
   - `recorded_at_utc`: UTC timestamp.
   - `intent_summary`: Human-readable summary of work intent.
+  - `audience_lane`: Output audience lane (`human-readable` or `ai-audit`).
+  - `detail_level`: Expected verbosity (`concise-empathic` or `technical-verbose`).
   - `source_workflow`: Workflow name or file.
 - Relationships:
   - Many activity records can belong to one agent.
@@ -53,6 +55,7 @@
   - `primary_focus`
   - `snapshot_root_path`
   - `snapshot_filename_pattern`
+  - `audience_lane`
 - Relationships:
   - One map references many per-agent snapshot folders.
 
@@ -62,5 +65,5 @@
 2. Native deterministic model rendered -> `AgentDeterministicLane` rows parsed from C CLI JSON.
 3. Deterministic renderer emits final `AgentIncrementDefinition` plan in lane order.
 4. Increment executed -> PR output status determined (`created`, `skipped`, `failed`, or `dry-run`).
-5. Activity recorder runs -> immutable `AgentActivityRecord` snapshot file written under the agent `runs/` folder.
-6. Management deep-dive map in docs links managers to each agent snapshot root.
+5. Activity recorder runs -> immutable `AgentActivityRecord` snapshot files written under audience-specific roots.
+6. Management deep-dive map in docs links managers to human-readable summaries and AI-audit roots for each agent.

--- a/specs/001-agent-pulse-orchestration/plan.md
+++ b/specs/001-agent-pulse-orchestration/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Replace the large inline autonomous increment JSON in the workflow with a repository-managed default plan file, expand the default plan to cover a wider suite of agent-owned increments, and introduce a native C deterministic model that guides per-agent increment ordering and pulse repetition for management-visible commit cadence.
+Replace the large inline autonomous increment JSON in the workflow with a repository-managed default plan file, expand the default plan to cover a wider suite of agent-owned increments (including documentation ownership), and introduce a native C deterministic model that guides per-agent increment ordering and pulse repetition for management-visible commit cadence.
 
 ## Technical Context
 
@@ -16,7 +16,7 @@ Replace the large inline autonomous increment JSON in the workflow with a reposi
 **Target Platform**: GitHub-hosted Ubuntu runners, developer Git Bash/PowerShell on Windows  
 **Project Type**: Delivery automation workflow and scripting  
 **Performance Goals**: Preserve bounded run behavior while handling expanded agent increments in the existing scheduled cadence  
-**Constraints**: Keep `speckit-driven` governance labels, preserve required reviewer flow, keep existing not-banana training increments, and maintain manual `incremental_plan_json` override behavior  
+**Constraints**: Keep `speckit-driven` governance labels, preserve required reviewer flow, keep existing not-banana training increments, maintain manual `incremental_plan_json` override behavior, and preserve human-readable vs AI-audit documentation split for management visibility  
 **Scale/Scope**: Workflow env and script-driven plan parsing, native deterministic model source + CLI + tests, deterministic plan renderer scripts, and management-facing docs index
 
 ## Constitution Check
@@ -67,6 +67,8 @@ docs/
 └── automation/
     └── agent-pulse/
         ├── README.md
+        ├── Human-Reading-Guide.md
+        ├── AI-Audit-Trails.md
         └── agents/
             └── *.md
 

--- a/specs/001-agent-pulse-orchestration/quickstart.md
+++ b/specs/001-agent-pulse-orchestration/quickstart.md
@@ -37,6 +37,8 @@ bash scripts/generate-deterministic-agent-pulse-plan.sh \
 ## 5. Inspect management-facing activity docs
 
 - Index: `docs/automation/agent-pulse/README.md`
+- Human-readable guide: `docs/automation/agent-pulse/Human-Reading-Guide.md`
+- AI audit index: `docs/automation/agent-pulse/AI-Audit-Trails.md`
 - Per-agent roots: `docs/automation/agent-pulse/agents/*/README.md`
 - Per-agent run snapshots: `docs/automation/agent-pulse/agents/*/runs/*.md`
 

--- a/specs/001-agent-pulse-orchestration/research.md
+++ b/specs/001-agent-pulse-orchestration/research.md
@@ -45,3 +45,11 @@
 - Alternatives considered:
   - Keep deterministic logic only in Python. Rejected because the request explicitly requires a custom C native implementation.
   - Move full JSON parsing/rewriting into C. Rejected because this increases native complexity with low value versus a C model + Python renderer split.
+
+## Decision 7: Preserve dual-track documentation outputs for human and AI audiences
+
+- Decision: Keep management-facing outputs split into a concise human-readable guide lane and a verbose AI-audit lane, both linked from a shared navigation entry.
+- Rationale: Managers need empathetic, quick-read summaries while operators and automation need detailed technical traces with deterministic structure.
+- Alternatives considered:
+  - Single mixed-tone documentation lane. Rejected because it compromises readability for humans and completeness for machine/audit consumers.
+  - Human-only summaries with no detailed traces. Rejected because it weakens operational triage and compliance evidence.

--- a/specs/001-agent-pulse-orchestration/spec.md
+++ b/specs/001-agent-pulse-orchestration/spec.md
@@ -19,6 +19,7 @@ A delivery manager can quickly see meaningful agent-attributed autonomous activi
 
 1. **Given** a default autonomous cycle run completes, **When** a manager inspects repository activity and the management summary, **Then** they can identify contributions from multiple distinct agents.
 2. **Given** a manager sees agent-attributed commits, **When** they open the related trace artifact, **Then** they can understand each agent's purpose and affected scope without reading raw workflow internals.
+3. **Given** documentation is published for a run, **When** a manager opens the human reading entry point, **Then** they see concise, empathetic summaries while detailed machine-audit traces remain in AI-focused pages.
 
 ---
 
@@ -72,6 +73,7 @@ An engineer can update the autonomous increment catalog in one management-friend
 - **FR-008**: Existing not-banana feedback and training automation increments MUST remain represented in the default catalog.
 - **FR-009**: The management visibility mechanism MUST avoid requiring direct workflow YAML inspection to answer "which agents did what".
 - **FR-010**: The default autonomous plan rendering path MUST be guided by a custom native C deterministic model when no manual increment override JSON is supplied.
+- **FR-011**: Management documentation outputs MUST preserve an explicit audience split where human-facing pages are concise and empathetic while AI-facing pages retain verbose technical trace detail.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -88,6 +90,7 @@ An engineer can update the autonomous increment catalog in one management-friend
 - **SC-003**: Management can identify the latest activity for any participating agent in under 2 minutes using repository documentation plus run artifacts.
 - **SC-004**: Updating increment orchestration defaults requires editing one catalog file instead of editing a large inline JSON literal in workflow YAML.
 - **SC-005**: The native deterministic model renders at least 15 autonomous increments per default cycle while preserving explicit agent ownership labels for each increment.
+- **SC-006**: For each autonomous cycle, documentation publishing produces both a human-readable summary path and an AI-audit path discoverable from one shared navigation entry in under 2 minutes.
 
 ## Assumptions
 
@@ -95,3 +98,4 @@ An engineer can update the autonomous increment catalog in one management-friend
 - Maintaining existing feedback/training increments is mandatory while extending visibility to additional agents.
 - Activity records stored in repository documentation are acceptable for management auditability.
 - Manual dispatch users may still provide custom increment plans for experiments, but default scheduled runs should rely on the repository-managed catalog.
+- A dedicated documentation ownership lane (`technical-writer-agent`) can participate in autonomous increments when audience-split wiki/index updates are required.

--- a/specs/001-agent-pulse-orchestration/tasks.md
+++ b/specs/001-agent-pulse-orchestration/tasks.md
@@ -40,12 +40,12 @@
 
 **Goal**: Managers can see broad multi-agent autonomous activity with clear ownership.
 
-**Independent Test**: Run local dry-run orchestration and verify at least 6 agent-scoped increments plus updated management index output.
+**Independent Test**: Run local dry-run orchestration and verify at least 7 agent-scoped increments (including `technical-writer-agent`) plus updated management index output.
 
-- [x] T008 [US1] Expand `docs/automation/agent-pulse/autonomous-self-training-default-increments.json` to include at least 6 distinct `agent:*` ownership lanes
+- [x] T008 [US1] Expand `docs/automation/agent-pulse/autonomous-self-training-default-increments.json` to include at least 7 distinct `agent:*` ownership lanes, including `agent:technical-writer-agent`
 - [x] T009 [US1] Implement immutable per-run activity snapshot generation in `scripts/record-agent-pulse-activity.py`
 - [x] T010 [US1] Wire default increment `change_command` entries in `docs/automation/agent-pulse/autonomous-self-training-default-increments.json` to call `scripts/record-agent-pulse-activity.py`
-- [x] T011 [US1] Update `docs/automation/agent-pulse/README.md` to provide management deep-dive links per agent
+- [x] T011 [US1] Update `docs/automation/agent-pulse/README.md` to provide management deep-dive links per agent and explicit pointers to `Human-Reading-Guide.md` and `AI-Audit-Trails.md`
 
 **Checkpoint**: Multi-agent visibility is discoverable without opening workflow internals.
 
@@ -59,7 +59,7 @@
 
 - [x] T012 [US2] Ensure every default increment in `docs/automation/agent-pulse/autonomous-self-training-default-increments.json` includes one explicit `agent:*` label and intent-rich `pr_body`
 - [x] T013 [US2] Ensure recorder command usage in `docs/automation/agent-pulse/autonomous-self-training-default-increments.json` includes agent, increment ID, and intent summary arguments
-- [x] T014 [US2] Document traceability fields and troubleshooting notes in `docs/automation/agent-pulse/README.md`
+- [x] T014 [US2] Document traceability fields, audience-lane conventions, and troubleshooting notes in `docs/automation/agent-pulse/README.md`
 
 **Checkpoint**: Ownership and run traceability are complete and operator-readable.
 
@@ -73,7 +73,7 @@
 
 - [x] T015 [US3] Remove or minimize inline default increment JSON in `.github/workflows/orchestrate-autonomous-self-training-cycle.yml` in favor of repository-managed plan path
 - [x] T016 [US3] Update `specs/001-agent-pulse-orchestration/contracts/autonomous-increment-plan.md` if implementation-level contract deltas emerge
-- [x] T017 [US3] Update `specs/001-agent-pulse-orchestration/quickstart.md` with the final plan-path workflow and override procedure
+- [x] T017 [US3] Update `specs/001-agent-pulse-orchestration/quickstart.md` with the final plan-path workflow, override procedure, and dual-track doc inspection steps
 - [x] T021 [US3] Implement native deterministic lane model in `src/native/core/domain/banana_agent_pulse_model.c` and `src/native/core/domain/banana_agent_pulse_model.h`
 - [x] T022 [US3] Add native model CLI and deterministic renderer bridge in `src/native/core/domain/banana_agent_pulse_model_cli.c`, `scripts/build-deterministic-agent-pulse-plan.py`, and `scripts/generate-deterministic-agent-pulse-plan.sh`
 - [x] T023 [US3] Wire native deterministic planner mode in `.github/workflows/orchestrate-autonomous-self-training-cycle.yml` and `scripts/workflow-orchestrate-sdlc.sh`
@@ -89,7 +89,7 @@
 
 - [x] T018 Run AI governance validation: `python scripts/validate-ai-contracts.py`
 - [x] T019 Run local dry-run orchestration: `bash scripts/workflow-orchestrate-sdlc.sh` with `BANANA_LOCAL_DRY_RUN=true`
-- [x] T020 Review changed files for management readability and ensure `speckit-driven` provenance remains intact
+- [x] T020 Review changed files for management readability across human and AI lanes and ensure `speckit-driven` provenance remains intact
 
 ---
 

--- a/specs/002-regression-binary-faker-metrics/contracts/faker-secondary-dataset.md
+++ b/specs/002-regression-binary-faker-metrics/contracts/faker-secondary-dataset.md
@@ -1,0 +1,35 @@
+# Contract: Faker Secondary Dataset
+
+## Purpose
+
+Define deterministic synthetic dataset generation used as a secondary comparison set for binary evaluation.
+
+## Generation Config Schema
+
+- `run_id` (string, required): Generation run identifier.
+- `seed` (integer, required): Deterministic random seed.
+- `schema_version` (string, required): Shared schema version to target.
+- `locale_set` (array[string], optional): Faker locales.
+- `class_balance` (object, required): Target distribution for labels.
+- `sample_count` (integer, required): Number of records to generate.
+- `generation_profile` (string, required): Named profile for reproducibility.
+
+## Output Schema
+
+Output records MUST conform to `regression-binary-shared-dataset.md` plus:
+
+- `synthetic` (boolean, required): Always `true`.
+- `seed` (integer, required): Echoed seed used for generation.
+- `generation_profile` (string, required): Echoed profile name.
+
+## Validation Rules
+
+- Fixed seed + fixed config MUST produce deterministic equivalent output.
+- Output records MUST satisfy shared schema required fields and enums.
+- Label distribution MUST be within configured tolerance bounds.
+
+## Behavioral Guarantees
+
+- Generation emits a manifest containing config digest, seed, and output counts.
+- Synthetic data is explicitly tagged and never mixed as unlabeled primary data.
+- Runs with missing/invalid config fail before record emission.

--- a/specs/002-regression-binary-faker-metrics/contracts/jaccard-confusion-gates.md
+++ b/specs/002-regression-binary-faker-metrics/contracts/jaccard-confusion-gates.md
@@ -1,0 +1,57 @@
+# Contract: Jaccard and Confusion Matrix Gates
+
+## Purpose
+
+Define metric computation outputs and gate thresholds for comparing primary scraped data and secondary Faker data in binary evaluation.
+
+## Inputs
+
+- Primary dataset: shared projection dataset version.
+- Secondary dataset: Faker-generated dataset version.
+- Prediction output: binary classifier predictions for evaluated records.
+- Gate policy: threshold configuration document.
+
+## Metric Output Schema
+
+- `report_id` (string, required)
+- `run_id` (string, required)
+- `evaluated_at_utc` (string, required)
+- `primary_dataset_version` (string, required)
+- `secondary_dataset_version` (string, required)
+- `jaccard_similarity` (number, required, range 0.0-1.0)
+- `confusion_matrix` (object, required):
+  - `tp` (integer)
+  - `fp` (integer)
+  - `tn` (integer)
+  - `fn` (integer)
+- `derived_metrics` (object, required):
+  - `precision` (number)
+  - `recall` (number)
+  - `f1` (number)
+  - `accuracy` (number)
+- `gate_policy_version` (string, required)
+- `gate_passed` (boolean, required)
+- `gate_failures` (array[string], required)
+- `human_summary_ref` (string, required)
+- `ai_audit_ref` (string, required)
+
+## Threshold Policy Schema
+
+- `jaccard_min` (number, required)
+- `precision_min` (number, required)
+- `recall_min` (number, required)
+- `f1_min` (number, required)
+- `accuracy_min` (number, required)
+
+## Gate Behavior
+
+- If any threshold is unmet, `gate_passed` MUST be `false` and workflow MUST fail.
+- Failures MUST include explicit metric deltas in `gate_failures`.
+- If metrics cannot be computed (for example zero valid labels), evaluation MUST fail with explicit reason.
+
+## Behavioral Guarantees
+
+- Every evaluation run produces one report artifact in a stable schema.
+- Metric computation logic is deterministic for fixed datasets and predictions.
+- Gate decision output is machine-readable and management-readable.
+- Published outputs preserve both human-readable and AI-audit lanes without losing gate trace detail.

--- a/specs/002-regression-binary-faker-metrics/contracts/regression-binary-shared-dataset.md
+++ b/specs/002-regression-binary-faker-metrics/contracts/regression-binary-shared-dataset.md
@@ -1,0 +1,40 @@
+# Contract: Regression-to-Binary Shared Dataset
+
+## Purpose
+
+Define the shared projection schema used to transfer regression-derived records into binary classification workflows.
+
+## Input Requirements
+
+- Source dataset MUST conform to `scraper-regression-corpus.md`.
+- Input dataset MUST include a source dataset version manifest.
+
+## Projection Schema
+
+- `sample_id` (string, required): Unique ID for projected sample.
+- `source_record_id` (string, required): Foreign key to regression corpus `record_id`.
+- `schema_version` (string, required): Semantic version for shared schema.
+- `text` (string, required): Text payload used by binary model.
+- `binary_label` (string, required): Allowed values `banana`, `not-banana`, `unknown`.
+- `label_origin` (string, required): Allowed values `rule`, `human`, `model-proxy`.
+- `shared_features` (object, required): Feature payload agreed by both model paths.
+- `source_dataset_version` (string, required): Version ID of originating regression dataset.
+
+## Compatibility Rules
+
+- MAJOR schema mismatch MUST fail projection.
+- MINOR schema changes MUST remain backward-compatible.
+- `unknown` labels MUST be excluded from binary training split unless explicitly overridden.
+
+## Validation Rules
+
+- Every projected record MUST resolve `source_record_id` in source corpus.
+- `schema_version` MUST match gate policy compatibility matrix.
+- `binary_label` and `label_origin` MUST be from allowed enums.
+- Missing required fields MUST fail projection.
+
+## Behavioral Guarantees
+
+- Projection emits dataset manifest with record counts by label.
+- Coverage statistics (mapped, dropped, rejected) are generated per run.
+- Projection output is deterministic for fixed input dataset and ruleset version.

--- a/specs/002-regression-binary-faker-metrics/contracts/scraper-regression-corpus.md
+++ b/specs/002-regression-binary-faker-metrics/contracts/scraper-regression-corpus.md
@@ -1,0 +1,42 @@
+# Contract: Scraper Regression Corpus
+
+## Purpose
+
+Define the canonical output schema and validation rules for web-scraped regression corpus records.
+
+## Output Format
+
+- File format: JSON Lines (`.jsonl`)
+- One object per line
+- UTF-8 encoding
+
+## Record Schema
+
+- `record_id` (string, required): Stable unique ID for the scraped record.
+- `source_url` (string, required): Absolute source URL.
+- `source_domain` (string, required): Source domain extracted from URL.
+- `fetched_at_utc` (string, required): ISO 8601 UTC timestamp.
+- `raw_text` (string, required): Raw extracted text payload.
+- `normalized_text` (string, required): Normalized text used for feature extraction.
+- `regression_target` (number, optional): Target value when available.
+- `feature_tokens` (array[string], required): Canonicalized token list.
+- `content_hash_sha256` (string, required): SHA-256 hash of normalized payload.
+- `provenance` (object, required):
+  - `policy_id` (string, required)
+  - `license` (string, required)
+  - `crawl_rule` (string, required)
+  - `source_retrieval_method` (string, required)
+
+## Validation Rules
+
+- Source URL domain MUST be allowlisted by active source policy.
+- `normalized_text` MUST be non-empty after sanitation.
+- `content_hash_sha256` MUST be valid hex digest format.
+- Duplicate `content_hash_sha256` values in one dataset version MUST be de-duplicated or rejected.
+- Records missing any required field MUST be rejected.
+
+## Behavioral Guarantees
+
+- Dataset publication emits a deterministic manifest containing run ID, policy ID, and record count.
+- Failed records are written to a reject report with explicit validation reasons.
+- Corpus versions are immutable once published.

--- a/specs/002-regression-binary-faker-metrics/data-model.md
+++ b/specs/002-regression-binary-faker-metrics/data-model.md
@@ -1,0 +1,91 @@
+# Data Model: Regression Corpus Sharing and Evaluation Gates
+
+## Entity: ScraperSourcePolicy
+
+- Purpose: Defines approved source boundaries and crawl governance for corpus ingestion.
+- Fields:
+  - `policy_id`
+  - `allowed_domains`
+  - `path_allow_rules`
+  - `path_block_rules`
+  - `content_license_requirements`
+  - `effective_from_utc`
+  - `effective_to_utc` (optional)
+
+## Entity: RegressionCorpusRecord
+
+- Purpose: Canonical normalized record from scraper ingestion for regression training.
+- Fields:
+  - `record_id`
+  - `source_url`
+  - `source_domain`
+  - `fetched_at_utc`
+  - `raw_text`
+  - `normalized_text`
+  - `regression_target` (optional)
+  - `feature_tokens`
+  - `content_hash_sha256`
+  - `provenance`
+
+## Entity: SharedProjectionRecord
+
+- Purpose: Shared versioned projection consumed by binary classification workflows.
+- Fields:
+  - `sample_id`
+  - `source_record_id`
+  - `schema_version`
+  - `binary_label`
+  - `label_origin`
+  - `shared_features`
+  - `source_dataset_version`
+
+## Entity: FakerSecondaryRecord
+
+- Purpose: Deterministic synthetic sample aligned with shared projection schema.
+- Fields:
+  - `sample_id`
+  - `synthetic` (always `true`)
+  - `seed`
+  - `generation_profile`
+  - `binary_label`
+  - `shared_features`
+  - `schema_version`
+
+## Entity: EvaluationMetricReport
+
+- Purpose: Captures run-scoped quality metrics and gate decisions.
+- Fields:
+  - `report_id`
+  - `run_id`
+  - `evaluated_at_utc`
+  - `dataset_primary_version`
+  - `dataset_secondary_version`
+  - `jaccard_similarity`
+  - `confusion_matrix` (`tp`, `fp`, `tn`, `fn`)
+  - `derived_metrics` (`precision`, `recall`, `f1`, `accuracy`)
+  - `gate_policy_version`
+  - `gate_passed`
+  - `gate_failures`
+  - `human_summary_ref`
+  - `ai_audit_ref`
+
+## Entity: GatePolicy
+
+- Purpose: Versioned threshold configuration for evaluation pass/fail behavior.
+- Fields:
+  - `policy_version`
+  - `jaccard_min`
+  - `precision_min`
+  - `recall_min`
+  - `f1_min`
+  - `accuracy_min`
+  - `enforcement_mode`
+
+## State Transitions
+
+1. Policy loaded -> `ScraperSourcePolicy` validates crawl boundaries.
+2. Scraping run completes -> `RegressionCorpusRecord` dataset version published.
+3. Projection runs -> `SharedProjectionRecord` dataset version emitted.
+4. Faker generation runs -> `FakerSecondaryRecord` dataset emitted with seed/config manifest.
+5. Evaluation runs -> `EvaluationMetricReport` computed against `GatePolicy`.
+6. Gate decision emitted -> workflow succeeds or fails based on threshold policy.

--- a/specs/002-regression-binary-faker-metrics/plan.md
+++ b/specs/002-regression-binary-faker-metrics/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: Regression, Binary Sharing, Faker, and Metric Gates
+
+**Branch**: `002-regression-binary-faker-metrics` | **Date**: 2026-04-24 | **Spec**: `specs/002-regression-binary-faker-metrics/spec.md`
+**Input**: Feature specification from `specs/002-regression-binary-faker-metrics/spec.md`
+
+## Summary
+
+Introduce a governed scraper corpus for regression training, project shared records into the binary classification pipeline, add deterministic Faker secondary dataset generation, enforce Jaccard/confusion-matrix quality gates in evaluation workflows, and preserve dual-track reporting outputs for human-readable summaries and AI-audit detail.
+
+## Technical Context
+
+**Language/Version**: C11 (native ML interop), Python 3.11 (data tooling), Bash (orchestration), JSON/Markdown (contracts and reports)  
+**Primary Dependencies**: Existing workflow orchestration scripts, native ML domain contracts, deterministic Faker generation tooling, metrics computation utilities  
+**Storage**: Repository-managed dataset manifests and artifacts under `data/` and `artifacts/`  
+**Testing**: Native tests (`tests/native`), Python/unit integration checks, `python scripts/validate-ai-contracts.py`, orchestration dry-runs  
+**Target Platform**: GitHub-hosted Ubuntu runners and local Windows + Git Bash workflows  
+**Project Type**: Multi-domain data + model automation enhancement  
+**Performance Goals**: Deterministic dataset generation and bounded evaluation runtime within existing CI windows  
+**Constraints**: Preserve native ML public contract stability unless explicitly approved; keep governance labels and approval paths intact; ensure reproducible synthetic generation; keep documentation/reporting outputs split between concise human-readable and verbose AI-audit paths  
+**Scale/Scope**: Scraper ingestion policy, shared data schema, synthetic data generation, and quality gate enforcement across regression and binary model paths
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Domain Core First**: Pass with explicit native ML scope in `src/native/core/domain/ml/*` and `src/native/wrapper/domain/ml/*`.
+- **Layered Interop Contract**: Pass if shared schema and evaluation contracts remain explicit and versioned.
+- **Spec First Delivery**: Pass. This feature is captured in a dedicated spec set before implementation changes.
+- **Verifiable Quality Gates**: Pass. Jaccard and confusion matrix thresholds become explicit gate contracts.
+- **Documentation and Wiki Parity**: Pass with required runbook updates in docs/wiki during implementation.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-regression-binary-faker-metrics/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── scraper-regression-corpus.md
+│   ├── regression-binary-shared-dataset.md
+│   ├── faker-secondary-dataset.md
+│   └── jaccard-confusion-gates.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+scripts/
+├── scrape-regression-corpus.py
+├── project-shared-regression-binary-dataset.py
+├── generate-faker-secondary-dataset.py
+└── evaluate-regression-binary-quality-gates.py
+
+src/native/core/domain/ml/
+└── [shared and model-specific gate/metric updates]
+
+src/native/wrapper/domain/ml/
+└── [interop surface updates if required]
+
+tests/native/
+└── [metric and gate contract tests]
+
+docs/
+└── [runbook and contract maintenance docs]
+```
+
+**Structure Decision**: Keep contract definitions in Spec-Kit docs and execute implementation across scripts + native ML layers with explicit shared-schema boundaries.
+
+## Complexity Tracking
+
+No constitution violations expected.

--- a/specs/002-regression-binary-faker-metrics/quickstart.md
+++ b/specs/002-regression-binary-faker-metrics/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Regression Corpus Sharing and Evaluation Gates
+
+## 1. Validate workflow and AI contracts
+
+```bash
+cd /c/Github/Banana
+python scripts/validate-ai-contracts.py
+```
+
+## 2. Build scraper-driven regression corpus
+
+```bash
+cd /c/Github/Banana
+python scripts/scrape-regression-corpus.py \
+  --policy specs/002-regression-binary-faker-metrics/contracts/scraper-regression-corpus.md \
+  --output data/regression-corpus/latest.jsonl
+```
+
+## 3. Project shared regression-to-binary dataset
+
+```bash
+cd /c/Github/Banana
+python scripts/project-shared-regression-binary-dataset.py \
+  --input data/regression-corpus/latest.jsonl \
+  --contract specs/002-regression-binary-faker-metrics/contracts/regression-binary-shared-dataset.md \
+  --output artifacts/model-data/shared-binary-dataset.jsonl
+```
+
+## 4. Generate deterministic Faker secondary dataset
+
+```bash
+cd /c/Github/Banana
+python scripts/generate-faker-secondary-dataset.py \
+  --contract specs/002-regression-binary-faker-metrics/contracts/faker-secondary-dataset.md \
+  --seed 22402 \
+  --output artifacts/model-data/faker-secondary-dataset.jsonl
+```
+
+## 5. Evaluate quality gates (Jaccard + confusion matrix)
+
+```bash
+cd /c/Github/Banana
+python scripts/evaluate-regression-binary-quality-gates.py \
+  --primary artifacts/model-data/shared-binary-dataset.jsonl \
+  --secondary artifacts/model-data/faker-secondary-dataset.jsonl \
+  --contract specs/002-regression-binary-faker-metrics/contracts/jaccard-confusion-gates.md \
+  --output artifacts/model-data/evaluation-report.json
+```
+
+## 6. Verify dual-track report outputs
+
+- Human-readable summary path is published and linked from the runbook entry.
+- AI-audit detail path is published with full metric and threshold trace context.

--- a/specs/002-regression-binary-faker-metrics/research.md
+++ b/specs/002-regression-binary-faker-metrics/research.md
@@ -1,0 +1,44 @@
+# Research: Regression Corpus Sharing and Evaluation Gates
+
+## Decision 1: Treat web scraping as a governed primary corpus source for regression
+
+- Decision: Use an allowlisted scraper ingestion contract with strict provenance and normalization requirements.
+- Rationale: Regression training requires traceable and consistent source quality.
+- Alternatives considered:
+  - Manual one-off data pulls. Rejected due to poor reproducibility.
+  - Unrestricted crawling. Rejected due to governance and quality risk.
+
+## Decision 2: Use one shared schema contract for regression-to-binary projection
+
+- Decision: Define one versioned shared dataset projection schema consumed by binary classification paths.
+- Rationale: Prevents duplicated parsers and drift between model pipelines.
+- Alternatives considered:
+  - Separate per-model export formats. Rejected due to contract drift risk.
+
+## Decision 3: Require deterministic Faker generation for secondary dataset
+
+- Decision: Synthetic dataset generation is seed/config driven and produces reproducible manifests.
+- Rationale: Secondary dataset must be replayable for comparisons and auditability.
+- Alternatives considered:
+  - Non-deterministic synthetic data. Rejected due to unreproducible evaluation deltas.
+
+## Decision 4: Gate promotion on Jaccard and confusion matrix thresholds
+
+- Decision: Enforce explicit threshold policy with fail-fast workflow behavior.
+- Rationale: Codifies quality criteria for management and engineering confidence.
+- Alternatives considered:
+  - Informational-only metrics. Rejected because failures could silently pass.
+
+## Decision 5: Keep native ML contracts stable by default
+
+- Decision: Any public contract change in native ML headers requires explicit breaking-change approval.
+- Rationale: Protects upstream/downstream consumers from accidental interface churn.
+- Alternatives considered:
+  - Ad hoc contract changes during implementation. Rejected as too risky.
+
+## Decision 6: Publish evaluation reporting in dual tracks for human and AI audiences
+
+- Decision: Keep one shared reporting payload while publishing two audience-specific views: concise human-readable summaries and verbose AI-audit detail.
+- Rationale: Management needs quick situational understanding while operators and automation require complete technical traceability.
+- Alternatives considered:
+  - Single mixed audience report. Rejected because it either overwhelms human readers or under-specifies audit detail.

--- a/specs/002-regression-binary-faker-metrics/spec.md
+++ b/specs/002-regression-binary-faker-metrics/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: Regression, Binary Sharing, Faker, and Metric Gates
+
+**Feature Branch**: `002-regression-binary-faker-metrics`  
+**Created**: 2026-04-24  
+**Status**: Draft  
+**Input**: User description: "we need to use a web scraper for the regression model and then share that data with the binary classification model using faker to act as a second data set for jaccard simularity and confusion matrix"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Scraper Regression Corpus (Priority: P1)
+
+A model engineer can refresh a governed web-scraped corpus that is valid for regression training and traceable by provenance.
+
+**Why this priority**: Without a deterministic and governed corpus, downstream sharing and evaluation steps have no reliable base.
+
+**Independent Test**: Run one ingestion cycle and confirm regression-ready records are produced with required provenance fields and validation.
+
+**Acceptance Scenarios**:
+
+1. **Given** approved source policies exist, **When** scraping runs, **Then** a normalized regression corpus is produced with source metadata and stable record IDs.
+2. **Given** invalid or blocked sources are encountered, **When** ingestion validates records, **Then** non-compliant records are rejected with actionable reasons.
+
+---
+
+### User Story 2 - Shared Data and Faker Secondary Dataset (Priority: P2)
+
+A model engineer can share regression-derived data with the binary classifier and generate a deterministic Faker dataset as a secondary comparison set.
+
+**Why this priority**: Cross-model reuse plus synthetic augmentation is required before quality comparison metrics can be trusted.
+
+**Independent Test**: Generate a shared dataset projection and a Faker dataset run, then confirm both conform to one shared schema contract.
+
+**Acceptance Scenarios**:
+
+1. **Given** a refreshed regression corpus, **When** projection runs, **Then** binary-ready records are emitted with contract version metadata.
+2. **Given** a fixed Faker seed and config, **When** synthetic generation runs twice, **Then** both runs produce equivalent outputs.
+
+---
+
+### User Story 3 - Jaccard and Confusion Matrix Gates (Priority: P3)
+
+An integration operator can enforce Jaccard similarity and confusion matrix thresholds across scraped and Faker-backed evaluation runs.
+
+**Why this priority**: Management and engineering need explicit quality gates, not ad hoc metric checks.
+
+**Independent Test**: Execute one evaluation run against primary and secondary datasets and confirm thresholds are enforced with pass/fail outputs.
+
+**Acceptance Scenarios**:
+
+1. **Given** evaluation inputs are available, **When** metric computation runs, **Then** Jaccard similarity and confusion matrix outputs are emitted in a standard report schema.
+2. **Given** any threshold is violated, **When** gating evaluates metrics, **Then** workflow status fails with threshold deltas and remediation context.
+3. **Given** reports are published after evaluation, **When** stakeholders inspect outputs, **Then** human-facing summaries remain concise while AI-audit outputs retain full technical details.
+
+---
+
+### Edge Cases
+
+- What happens when scraper output is empty for one or more approved sources?
+- How does the system handle shared-schema version drift between regression and binary pipelines?
+- What happens when Faker class balance cannot be satisfied under configured constraints?
+- How are Jaccard and confusion outputs handled when label coverage is sparse or one class is missing?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST define a governed scraper corpus contract for regression training records.
+- **FR-002**: Scraper outputs MUST include provenance metadata including source, fetch timestamp, and content hash.
+- **FR-003**: Scraper ingestion MUST enforce source allowlist and crawl policy checks.
+- **FR-004**: The system MUST expose a shared dataset projection contract consumable by both regression and binary workflows.
+- **FR-005**: Shared dataset records MUST include contract version metadata and source lineage references.
+- **FR-006**: The system MUST support deterministic Faker-based secondary dataset generation using explicit seed/config.
+- **FR-007**: Faker output MUST conform to the same shared schema consumed by binary evaluation.
+- **FR-008**: The evaluation harness MUST compute Jaccard similarity between primary and secondary dataset feature/label sets.
+- **FR-009**: The evaluation harness MUST compute confusion matrix outputs for binary classification results.
+- **FR-010**: Quality gate thresholds for Jaccard and confusion-matrix-derived metrics MUST be explicit and versioned.
+- **FR-011**: Workflow execution MUST fail when any configured quality threshold is not met.
+- **FR-012**: Generated metric reports MUST be exportable for management-facing review.
+- **FR-013**: The implementation MUST preserve native ML public contracts unless a breaking change is explicitly approved.
+- **FR-014**: Published metric reporting artifacts MUST preserve an audience split with a concise human-readable path and a verbose AI-audit path.
+
+### Key Entities *(include if feature involves data)*
+
+- **Scraper Corpus Record**: A normalized web-derived record for regression training with provenance and feature fields.
+- **Shared Projection Record**: A contract-versioned record mapped from regression corpus into binary-consumable shape.
+- **Faker Secondary Record**: A deterministic synthetic record conforming to shared projection schema.
+- **Evaluation Metric Report**: A run-scoped report containing Jaccard, confusion matrix values, and gate decisions.
+- **Gate Policy**: A versioned threshold configuration for evaluation pass/fail enforcement.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of accepted scraped records include required provenance fields and valid content hash.
+- **SC-002**: Shared regression-to-binary projection succeeds without schema violations for at least 99% of candidate records in a baseline run.
+- **SC-003**: Faker generation with identical seed/config produces deterministic equivalent outputs across repeated runs.
+- **SC-004**: Every evaluation run emits Jaccard and confusion matrix metrics in one standardized report artifact.
+- **SC-005**: Quality gate enforcement blocks promotion whenever threshold policy is violated.
+- **SC-006**: Management and operators can locate both human-readable summary output and AI-audit detail output from one shared runbook entry point in under 2 minutes.
+
+## Assumptions
+
+- Existing repository governance labels and approval requirements remain unchanged.
+- Scraper ingestion policy and legal constraints are provided by existing repo governance inputs.
+- The binary classification workflow can consume shared records when schema version checks pass.
+- Faker is used only for synthetic training/evaluation augmentation and not as a replacement for governed primary corpus data.
+- Documentation publishing follows a dual-track convention so casual stakeholder summaries do not remove technical audit detail needed for automation and triage.

--- a/specs/002-regression-binary-faker-metrics/tasks.md
+++ b/specs/002-regression-binary-faker-metrics/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Regression, Binary Sharing, Faker, and Metric Gates
+
+**Input**: Design documents from `specs/002-regression-binary-faker-metrics/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: Add contract, integration, and deterministic replay checks as part of implementation.
+
+## Phase 1: Setup
+
+- [ ] T001 Create dataset artifact roots under `data/regression-corpus/` and `artifacts/model-data/`
+- [ ] T002 Create script scaffolds:
+  - `scripts/scrape-regression-corpus.py`
+  - `scripts/project-shared-regression-binary-dataset.py`
+  - `scripts/generate-faker-secondary-dataset.py`
+  - `scripts/evaluate-regression-binary-quality-gates.py`
+
+## Phase 2: Foundational Contracts
+
+- [ ] T003 Implement scraper output schema validation against `contracts/scraper-regression-corpus.md`
+- [ ] T004 Implement shared projection schema validation against `contracts/regression-binary-shared-dataset.md`
+- [ ] T005 Implement Faker generation config/output validation against `contracts/faker-secondary-dataset.md`
+- [ ] T006 Implement evaluation report and threshold policy validation against `contracts/jaccard-confusion-gates.md`
+
+## Phase 3: User Story 1 (P1)
+
+- [ ] T007 [US1] Implement governed source policy loading and validation
+- [ ] T008 [US1] Implement normalized scraper ingestion and manifest emission
+- [ ] T009 [US1] Add reject-report path for invalid source/payload records
+
+## Phase 4: User Story 2 (P2)
+
+- [ ] T010 [US2] Implement regression-to-binary projection pipeline
+- [ ] T011 [US2] Implement deterministic Faker secondary dataset generator
+- [ ] T012 [US2] Add compatibility checks for shared schema versioning
+
+## Phase 5: User Story 3 (P3)
+
+- [ ] T013 [US3] Implement Jaccard similarity computation on primary/secondary datasets
+- [ ] T014 [US3] Implement confusion matrix and derived metric computation
+- [ ] T015 [US3] Implement threshold gate enforcement and fail-fast behavior
+
+## Phase 6: Polish
+
+- [ ] T016 Add docs and runbook updates for contract maintenance, including separate human-readable and AI-audit reporting paths
+- [ ] T017 Run validation and deterministic replay checks in CI
+- [ ] T018 Verify native ML public contract stability in touched headers


### PR DESCRIPTION
## Summary
- add a dedicated technical-writer-agent for wiki and docs ownership with explicit human-readable vs AI-audit voice contracts
- wire the new helper into Banana orchestration and routing docs (banana-sdlc, banana-planner, infra/workflow handoffs, helper matrix, teaming playbook, copilot instructions)
- update spec artifacts across both feature bundles (specs/001-agent-pulse-orchestration and specs/002-regression-binary-faker-metrics) to codify audience-split documentation and reporting expectations

## Validation
- python scripts/validate-ai-contracts.py

## Notes
- excluded transient test artifacts under tests/integration/TestResults/
