### PR TITLE
e2e runner contract

### DIFF
--- a/.specify/specs/000-api-rehydration/spec.md
+++ b/.specify/specs/000-api-rehydration/spec.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Define a pre-sprint API realignment baseline with practical, arbitrary contract checks to ensure we did not vibe code into unstable behavior. This rehydration spec covers ASP.NET and TypeScript API contract continuity, typed failures, and model-metadata consistency.
+Define a pre-sprint API realignment baseline with practical, arbitrary contract checks to ensure ad-hoc changes did not introduce unstable behavior. This rehydration spec covers ASP.NET and TypeScript API contract continuity, typed failures, and model-metadata consistency.
 
 ## In Scope
 

--- a/.specify/specs/000-native-rehydration/spec.md
+++ b/.specify/specs/000-native-rehydration/spec.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Define a pre-sprint native realignment baseline with intentionally pragmatic, arbitrary stability checks that reduce the risk of unreviewed vibe-coded drift. This rehydration spec verifies native ABI continuity, deterministic behavior, and safety envelopes before sprint implementation expands scope.
+Define a pre-sprint native realignment baseline with intentionally pragmatic, arbitrary stability checks that reduce the risk of unreviewed contract drift. This rehydration spec verifies native ABI continuity, deterministic behavior, and safety envelopes before sprint implementation expands scope.
 
 ## In Scope
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
     build:
       context: .
       dockerfile: docker/react-native.Dockerfile
-    command: ["bash", "-lc", "cd src/typescript/react-native && bun run web"]
+    command: ["bash", "-lc", "bun run web"]
     ports:
       - "19006:19006"
     profiles: ["apps"]

--- a/docker/react-native.Dockerfile
+++ b/docker/react-native.Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /workspace
 COPY src/typescript/shared/ui/package.json ./src/typescript/shared/ui/
 RUN bun install --cwd /workspace/src/typescript/shared/ui || true
 COPY src/typescript/shared ./src/typescript/shared
+COPY src/typescript/tsconfig.base.json ./src/typescript/tsconfig.base.json
 COPY src/typescript/react-native/package.json ./src/typescript/react-native/
 RUN cd src/typescript/react-native && bun install
 COPY src/typescript/react-native ./src/typescript/react-native

--- a/scripts/run-tests-with-coverage.sh
+++ b/scripts/run-tests-with-coverage.sh
@@ -9,4 +9,4 @@ mkdir -p "$OUT"
 dotnet test Banana.sln \
   --collect:"XPlat Code Coverage" \
   --results-directory "$OUT" \
-  /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+  -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura

--- a/src/typescript/react-native/package.json
+++ b/src/typescript/react-native/package.json
@@ -10,9 +10,12 @@
     },
     "dependencies": {
         "@banana/ui": "file:../shared/ui",
+        "@expo/metro-runtime": "~4.0.1",
         "expo": "~52.0.0",
         "expo-status-bar": "~2.0.0",
         "react": "18.3.1",
-        "react-native": "0.76.0"
+        "react-dom": "18.3.1",
+        "react-native": "0.76.0",
+        "react-native-web": "~0.19.13"
     }
 }

--- a/tests/e2e/E2eRunnerContractTests.cs
+++ b/tests/e2e/E2eRunnerContractTests.cs
@@ -8,7 +8,7 @@ namespace Banana.E2eTests;
 public sealed class E2eRunnerContractTests
 {
     [Fact]
-    public void CriticalJourneys_UsesStableDeterministicScenarioOrder()
+    public void CriticalJourneysUsesStableDeterministicScenarioOrder()
     {
         var contract = E2eRunnerContracts.CriticalJourneys();
 
@@ -19,7 +19,7 @@ public sealed class E2eRunnerContractTests
     }
 
     [Fact]
-    public void E2eRunSettings_UsesDefaultRuntimeContractsWhenEnvironmentIsUnset()
+    public void E2eRunSettingsUsesDefaultRuntimeContractsWhenEnvironmentIsUnset()
     {
         Environment.SetEnvironmentVariable("BANANA_E2E_COMPOSE_PROJECT", null);
         Environment.SetEnvironmentVariable("BANANA_E2E_BOOTSTRAP_SCRIPT", null);
@@ -37,7 +37,7 @@ public sealed class E2eRunnerContractTests
     }
 
     [Fact]
-    public void Validator_RejectsDuplicateScenarioIdentifiers()
+    public void ValidatorRejectsDuplicateScenarioIdentifiers()
     {
         var contract = new E2eRunnerContract(
             Name: "duplicate-case",
@@ -56,7 +56,7 @@ public sealed class E2eRunnerContractTests
     }
 
     [Fact]
-    public void Validator_AcceptsScaffoldContractWhenScriptPresenceChecksAreDisabled()
+    public void ValidatorAcceptsScaffoldContractWhenScriptPresenceChecksAreDisabled()
     {
         var contract = E2eRunnerContracts.CriticalJourneys();
         var settings = E2eRunSettings.FromEnvironment() with { RequireScriptFiles = false };
@@ -65,7 +65,7 @@ public sealed class E2eRunnerContractTests
     }
 
     [Fact]
-    public void Validator_AcceptsScaffoldContractWhenScriptPresenceChecksAreEnabled()
+    public void ValidatorAcceptsScaffoldContractWhenScriptPresenceChecksAreEnabled()
     {
         var contract = E2eRunnerContracts.CriticalJourneys();
         var settings = E2eRunSettings.FromEnvironment() with { RequireScriptFiles = true };


### PR DESCRIPTION
This pull request focuses on minor improvements to developer experience and code clarity, particularly around test naming conventions, container setup, and dependency management for the React Native app. The most important changes are summarized below:

**Test Naming Consistency:**

* Renamed test methods in `E2eRunnerContractTests.cs` to use a consistent, camel-case naming convention for better readability and adherence to C# standards. [[1]](diffhunk://#diff-215f201fd933d30adec302a0060f6ad7397a0229fe1b0513d52dd09e0e0fd763L11-R11) [[2]](diffhunk://#diff-215f201fd933d30adec302a0060f6ad7397a0229fe1b0513d52dd09e0e0fd763L22-R22) [[3]](diffhunk://#diff-215f201fd933d30adec302a0060f6ad7397a0229fe1b0513d52dd09e0e0fd763L40-R40) [[4]](diffhunk://#diff-215f201fd933d30adec302a0060f6ad7397a0229fe1b0513d52dd09e0e0fd763L59-R59) [[5]](diffhunk://#diff-215f201fd933d30adec302a0060f6ad7397a0229fe1b0513d52dd09e0e0fd763L68-R68)

**React Native App and Docker Improvements:**

* Updated the `docker-compose.yml` command for the React Native service to run from the correct directory, simplifying the startup process.
* Added a missing `tsconfig.base.json` copy step in `docker/react-native.Dockerfile` to ensure TypeScript builds succeed in Docker.
* Added new dependencies (`@expo/metro-runtime`, `react-dom`, `react-native-web`) to `src/typescript/react-native/package.json` to support web builds and improve compatibility.

**Documentation and Script Fixes:**

* Clarified summary language in API and native rehydration spec markdown files for better intent communication. [[1]](diffhunk://#diff-d8decde07ca422f4ecf62bdb5c3d48676536b1c5d71c280f5b416598234bdcfaL10-R10) [[2]](diffhunk://#diff-100bd298e52b3e99aa8a31418f58bfdbfb8c4d61202a5291a2ec9791fd91acfcL10-R10)
* Fixed a minor CLI flag typo in `scripts/run-tests-with-coverage.sh` for consistency with dotnet conventions.