### PR TITLE
feat(037): expand local training launch/task surface

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-    "feature_directory": ".specify/specs/036-ripeness-corpus-and-trainer"
+    "feature_directory": ".specify/specs/037-training-launch-surface-expansion"
 }

--- a/.specify/specs/037-training-launch-surface-expansion/README.md
+++ b/.specify/specs/037-training-launch-surface-expansion/README.md
@@ -1,0 +1,20 @@
+# 037 Training Launch Surface Expansion
+
+Status: COMPLETE
+
+## Summary
+
+Adds full F5 and command-palette training launch coverage for not-banana, banana, and ripeness across `ci` and `local` profiles, with explicit artifacts output paths under `artifacts/training/<model>/local`.
+
+## Execution Tracker
+
+- [x] Updated existing not-banana launch entries with explicit `--output` and `--corpus` args.
+- [x] Added banana and ripeness launch entries for `ci` and `local` profiles.
+- [x] Added compound launch entry `Train: all (ci profile)`.
+- [x] Added mirrored `.vscode/tasks.json` entries for all launch commands.
+- [x] Added local training runbook (`analysis/local-training-runbook.md`).
+- [x] Ran AI-contract and spec/tasks parity validators.
+
+## Notes
+
+- Outputs are intentionally directed to `artifacts/training/*` so seed corpora and promoted image registries remain untouched during local training runs.

--- a/.specify/specs/037-training-launch-surface-expansion/analysis/local-training-runbook.md
+++ b/.specify/specs/037-training-launch-surface-expansion/analysis/local-training-runbook.md
@@ -1,0 +1,45 @@
+# Local Training Runbook
+
+This runbook describes the editor-first local model iteration loop.
+
+## 1. Pick a launch entry (F5)
+
+Use one of:
+
+- `Train: not-banana (ci profile)`
+- `Train: banana (ci profile)`
+- `Train: ripeness (ci profile)`
+- or `Train: all (ci profile)`
+
+Each writes artifacts to:
+
+- `artifacts/training/not-banana/local`
+- `artifacts/training/banana/local`
+- `artifacts/training/ripeness/local`
+
+## 2. Review output metrics
+
+Check each model's `metrics.json` in its artifact folder.
+
+## 3. Promote a candidate image
+
+Examples:
+
+```bash
+python scripts/manage-not-banana-model-image.py create --model-dir artifacts/training/not-banana/local --registry-dir data/not-banana --channel candidate
+python scripts/manage-not-banana-model-image.py promote --registry-dir data/not-banana --from-channel candidate --to-channel stable --allow-unsigned --min-f1 0.7 --max-removed-tokens 999
+```
+
+```bash
+python scripts/manage-banana-image.py create --model-dir artifacts/training/banana/local --registry-dir data/banana --channel candidate
+python scripts/manage-banana-image.py promote --registry-dir data/banana --from-channel candidate --to-channel stable --allow-unsigned --min-f1 0.7 --min-signal-score 0.7
+```
+
+```bash
+python scripts/manage-ripeness-image.py create --model-dir artifacts/training/ripeness/local --registry-dir data/ripeness --channel candidate
+python scripts/manage-ripeness-image.py promote --registry-dir data/ripeness --from-channel candidate --to-channel stable --allow-unsigned --min-f1 0.7 --min-signal-score 0.7
+```
+
+## 4. Commit deterministic improvements
+
+Commit only the intended model registry changes and related docs/scripts. Keep generated local artifact directories under `artifacts/training/*` out of source control.

--- a/.specify/specs/037-training-launch-surface-expansion/tasks.md
+++ b/.specify/specs/037-training-launch-surface-expansion/tasks.md
@@ -5,34 +5,34 @@
 
 ## Phase 1 -- Setup
 
-- [ ] T001 Repoint `.specify/feature.json` -> `037-training-launch-surface-expansion`.
-- [ ] T002 Create branch `feature/037-training-launch-surface-expansion`
+- [x] T001 Repoint `.specify/feature.json` -> `037-training-launch-surface-expansion`.
+- [x] T002 Create branch `feature/037-training-launch-surface-expansion`
   from spec 036 head.
 
 ## Phase 2 -- F5 entries
 
-- [ ] T003 Update `.vscode/launch.json`: add explicit `--output`
+- [x] T003 Update `.vscode/launch.json`: add explicit `--output`
   args to the existing not-banana entries per the SPIKE 033
   artifacts contract.
-- [ ] T004 Add `Train: banana (ci profile)` and
+- [x] T004 Add `Train: banana (ci profile)` and
   `Train: banana (local profile)` `debugpy` entries.
-- [ ] T005 Add `Train: ripeness (ci profile)` and
+- [x] T005 Add `Train: ripeness (ci profile)` and
   `Train: ripeness (local profile)` `debugpy` entries.
-- [ ] T006 Add a compound `Train: all (ci profile)` entry that
+- [x] T006 Add a compound `Train: all (ci profile)` entry that
   fans out to all three trainers.
 
 ## Phase 3 -- Tasks parity
 
-- [ ] T007 Add `.vscode/tasks.json` entries mirroring the F5 set
+- [x] T007 Add `.vscode/tasks.json` entries mirroring the F5 set
   (no debugger, command-palette runnable).
 
 ## Phase 4 -- Docs + close-out
 
-- [ ] T008 Author `analysis/local-training-runbook.md` -- step by
+- [x] T008 Author `analysis/local-training-runbook.md` -- step by
   step F5 -> promote -> commit loop.
-- [ ] T009 Run `python scripts/validate-ai-contracts.py` and
+- [x] T009 Run `python scripts/validate-ai-contracts.py` and
   `bash scripts/validate-spec-tasks-parity.sh --all`.
-- [ ] T010 Mark all tasks `[x]` and update README to COMPLETE.
+- [x] T010 Mark all tasks `[x]` and update README to COMPLETE.
 
 ## Out of scope
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,16 @@
             "configurations": ["API: Bun dev", "React Native: Expo web"],
             "stopAll": true,
             "presentation": { "group": "frontends", "order": 3 }
+        },
+        {
+            "name": "Train: all (ci profile)",
+            "configurations": [
+                "Train: not-banana (ci profile)",
+                "Train: banana (ci profile)",
+                "Train: ripeness (ci profile)"
+            ],
+            "stopAll": true,
+            "presentation": { "group": "training", "order": 1 }
         }
     ],
     "configurations": [
@@ -76,7 +86,13 @@
             "request": "launch",
             "program": "${workspaceFolder:(Monorepo) Banana}/scripts/train-not-banana-model.py",
             "cwd": "${workspaceFolder:(Monorepo) Banana}",
-            "args": ["--training-profile", "ci", "--session-mode", "single", "--max-sessions", "1"],
+            "args": [
+                "--corpus", "data/not-banana/corpus.json",
+                "--output", "${workspaceFolder:(Monorepo) Banana}/artifacts/training/not-banana/local",
+                "--training-profile", "ci",
+                "--session-mode", "single",
+                "--max-sessions", "1"
+            ],
             "console": "integratedTerminal",
             "presentation": { "group": "training", "order": 20 }
         },
@@ -86,9 +102,73 @@
             "request": "launch",
             "program": "${workspaceFolder:(Monorepo) Banana}/scripts/train-not-banana-model.py",
             "cwd": "${workspaceFolder:(Monorepo) Banana}",
-            "args": ["--training-profile", "local"],
+            "args": [
+                "--corpus", "data/not-banana/corpus.json",
+                "--output", "${workspaceFolder:(Monorepo) Banana}/artifacts/training/not-banana/local",
+                "--training-profile", "local"
+            ],
             "console": "integratedTerminal",
             "presentation": { "group": "training", "order": 21 }
+        },
+        {
+            "name": "Train: banana (ci profile)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder:(Monorepo) Banana}/scripts/train-banana-model.py",
+            "cwd": "${workspaceFolder:(Monorepo) Banana}",
+            "args": [
+                "--corpus", "data/banana/corpus.json",
+                "--output", "${workspaceFolder:(Monorepo) Banana}/artifacts/training/banana/local",
+                "--training-profile", "ci",
+                "--session-mode", "single",
+                "--max-sessions", "1"
+            ],
+            "console": "integratedTerminal",
+            "presentation": { "group": "training", "order": 22 }
+        },
+        {
+            "name": "Train: banana (local profile)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder:(Monorepo) Banana}/scripts/train-banana-model.py",
+            "cwd": "${workspaceFolder:(Monorepo) Banana}",
+            "args": [
+                "--corpus", "data/banana/corpus.json",
+                "--output", "${workspaceFolder:(Monorepo) Banana}/artifacts/training/banana/local",
+                "--training-profile", "local"
+            ],
+            "console": "integratedTerminal",
+            "presentation": { "group": "training", "order": 23 }
+        },
+        {
+            "name": "Train: ripeness (ci profile)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder:(Monorepo) Banana}/scripts/train-ripeness-model.py",
+            "cwd": "${workspaceFolder:(Monorepo) Banana}",
+            "args": [
+                "--corpus", "data/ripeness/corpus.json",
+                "--output", "${workspaceFolder:(Monorepo) Banana}/artifacts/training/ripeness/local",
+                "--training-profile", "ci",
+                "--session-mode", "single",
+                "--max-sessions", "1"
+            ],
+            "console": "integratedTerminal",
+            "presentation": { "group": "training", "order": 24 }
+        },
+        {
+            "name": "Train: ripeness (local profile)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder:(Monorepo) Banana}/scripts/train-ripeness-model.py",
+            "cwd": "${workspaceFolder:(Monorepo) Banana}",
+            "args": [
+                "--corpus", "data/ripeness/corpus.json",
+                "--output", "${workspaceFolder:(Monorepo) Banana}/artifacts/training/ripeness/local",
+                "--training-profile", "local"
+            ],
+            "console": "integratedTerminal",
+            "presentation": { "group": "training", "order": 25 }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,135 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Train: not-banana (ci profile)",
+      "type": "shell",
+      "command": "${workspaceFolder:(Monorepo) Banana}/.venv/Scripts/python.exe",
+      "args": [
+        "scripts/train-not-banana-model.py",
+        "--corpus",
+        "data/not-banana/corpus.json",
+        "--output",
+        "${workspaceFolder:(Monorepo) Banana}/artifacts/training/not-banana/local",
+        "--training-profile",
+        "ci",
+        "--session-mode",
+        "single",
+        "--max-sessions",
+        "1"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder:(Monorepo) Banana}"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Train: not-banana (local profile)",
+      "type": "shell",
+      "command": "${workspaceFolder:(Monorepo) Banana}/.venv/Scripts/python.exe",
+      "args": [
+        "scripts/train-not-banana-model.py",
+        "--corpus",
+        "data/not-banana/corpus.json",
+        "--output",
+        "${workspaceFolder:(Monorepo) Banana}/artifacts/training/not-banana/local",
+        "--training-profile",
+        "local"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder:(Monorepo) Banana}"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Train: banana (ci profile)",
+      "type": "shell",
+      "command": "${workspaceFolder:(Monorepo) Banana}/.venv/Scripts/python.exe",
+      "args": [
+        "scripts/train-banana-model.py",
+        "--corpus",
+        "data/banana/corpus.json",
+        "--output",
+        "${workspaceFolder:(Monorepo) Banana}/artifacts/training/banana/local",
+        "--training-profile",
+        "ci",
+        "--session-mode",
+        "single",
+        "--max-sessions",
+        "1"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder:(Monorepo) Banana}"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Train: banana (local profile)",
+      "type": "shell",
+      "command": "${workspaceFolder:(Monorepo) Banana}/.venv/Scripts/python.exe",
+      "args": [
+        "scripts/train-banana-model.py",
+        "--corpus",
+        "data/banana/corpus.json",
+        "--output",
+        "${workspaceFolder:(Monorepo) Banana}/artifacts/training/banana/local",
+        "--training-profile",
+        "local"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder:(Monorepo) Banana}"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Train: ripeness (ci profile)",
+      "type": "shell",
+      "command": "${workspaceFolder:(Monorepo) Banana}/.venv/Scripts/python.exe",
+      "args": [
+        "scripts/train-ripeness-model.py",
+        "--corpus",
+        "data/ripeness/corpus.json",
+        "--output",
+        "${workspaceFolder:(Monorepo) Banana}/artifacts/training/ripeness/local",
+        "--training-profile",
+        "ci",
+        "--session-mode",
+        "single",
+        "--max-sessions",
+        "1"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder:(Monorepo) Banana}"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Train: ripeness (local profile)",
+      "type": "shell",
+      "command": "${workspaceFolder:(Monorepo) Banana}/.venv/Scripts/python.exe",
+      "args": [
+        "scripts/train-ripeness-model.py",
+        "--corpus",
+        "data/ripeness/corpus.json",
+        "--output",
+        "${workspaceFolder:(Monorepo) Banana}/artifacts/training/ripeness/local",
+        "--training-profile",
+        "local"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder:(Monorepo) Banana}"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Train: all (ci profile)",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Train: not-banana (ci profile)",
+        "Train: banana (ci profile)",
+        "Train: ripeness (ci profile)"
+      ],
+      "problemMatcher": []
+    }
+  ]
+}

--- a/Banana.code-workspace
+++ b/Banana.code-workspace
@@ -1,17 +1,57 @@
 {
   "folders": [
-    { "name": "(Monorepo) Banana", "path": "." },
-    { "name": "(Monorepo) Tests", "path": "tests" },
-    { "name": "(Monorepo) Docker", "path": "docker" },
-    { "name": "(Monorepo) Scripts", "path": "scripts" },
-    { "name": "(Specify) Specs", "path": ".specify/specs" },
-    { "name": "(C) Native", "path": "src/native" },
-    { "name": "(C#) Api", "path": "src/c-sharp/asp.net" },
-    { "name": "(TS) Api", "path": "src/typescript/api" },
-    { "name": "(TS) Electron", "path": "src/typescript/electron" },
-    { "name": "(TS) React", "path": "src/typescript/react" },
-    { "name": "(TS) React-Native", "path": "src/typescript/react-native" },
-    { "name": "(TS) Shared-UI", "path": "src/typescript/shared/ui" },
+    {
+      "name": "(Monorepo) Banana",
+      "path": "."
+    },
+    {
+      "name": "(Monorepo) Docker",
+      "path": "docker"
+    },
+    {
+      "name": "(Monorepo) Tests",
+      "path": "tests"
+    },
+    {
+      "name": "(Monorepo) Training Data",
+      "path": "data"
+    },
+    {
+      "name": "(Monorepo) Scripts",
+      "path": "scripts"
+    },
+    {
+      "name": "(Specify) Specs",
+      "path": ".specify/specs"
+    },
+    {
+      "name": "(C) Native",
+      "path": "src/native"
+    },
+    {
+      "name": "(C#) Api",
+      "path": "src/c-sharp/asp.net"
+    },
+    {
+      "name": "(TS) Api",
+      "path": "src/typescript/api"
+    },
+    {
+      "name": "(TS) Electron",
+      "path": "src/typescript/electron"
+    },
+    {
+      "name": "(TS) React",
+      "path": "src/typescript/react"
+    },
+    {
+      "name": "(TS) React-Native",
+      "path": "src/typescript/react-native"
+    },
+    {
+      "name": "(TS) Shared-UI",
+      "path": "src/typescript/shared/ui"
+    }
   ],
   "settings": {
     "files.eol": "\n",


### PR DESCRIPTION
## Summary\n- expand .vscode/launch.json with ci/local training entries for not-banana, banana, and ripeness\n- add compound launch: Train: all (ci profile)\n- add mirrored .vscode/tasks.json command-palette tasks\n- add spec 037 runbook + close-out tracker\n\n## Validation\n- python scripts/validate-ai-contracts.py\n- bash scripts/validate-spec-tasks-parity.sh --all\n- python scripts/train-not-banana-model.py --corpus data/not-banana/corpus.json --output artifacts/training/not-banana/local --training-profile ci --session-mode single --max-sessions 1\n- python scripts/train-banana-model.py --corpus data/banana/corpus.json --output artifacts/training/banana/local --training-profile ci --session-mode single --max-sessions 1\n- python scripts/train-ripeness-model.py --corpus data/ripeness/corpus.json --output artifacts/training/ripeness/local --training-profile ci --session-mode single --max-sessions 1