### PR TITLE
feat(050): Wave C — neuro forgetting-guard enforcement + docs/wiki/release-notes/QA

### DIFF
--- a/.github/workflows/orchestrate-neuro-consolidation.yml
+++ b/.github/workflows/orchestrate-neuro-consolidation.yml
@@ -79,12 +79,20 @@ jobs:
             --replay-buffer artifacts/training/${{ matrix.model }}/replay/buffer.jsonl \
             --output-root artifacts/training/${{ matrix.model }}/consolidation \
             --phase ${{ steps.phase.outputs.phase }}
-      - name: Forgetting guard (informational)
+      - name: Forgetting guard
+        env:
+          BANANA_NEURO_MODEL: ${{ matrix.model }}
         run: |
+          anchor="data/${BANANA_NEURO_MODEL}/anchor-metrics.json"
+          enforce_flag=""
+          if [[ -f "$anchor" ]]; then
+            enforce_flag="--enforce"
+          fi
           python scripts/neuro/forgetting-guard.py \
-            --model ${{ matrix.model }} \
-            --metrics artifacts/training/${{ matrix.model }}/local/metrics.json \
-            --max-regression-pp 1.0 || true
+            --model "${BANANA_NEURO_MODEL}" \
+            --metrics "artifacts/training/${BANANA_NEURO_MODEL}/local/metrics.json" \
+            --anchor "$anchor" \
+            --max-regression-pp 1.0 $enforce_flag
       - name: Upload consolidation snapshot
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/orchestrate-neuro-git-event-training.yml
+++ b/.github/workflows/orchestrate-neuro-git-event-training.yml
@@ -125,13 +125,19 @@ jobs:
             --max-sessions 1 \
             --neuro-profile "$BANANA_NEURO_PROFILE"
       - name: Forgetting guard
+        env:
+          BANANA_NEURO_MODEL: ${{ matrix.model }}
         run: |
+          anchor="data/${BANANA_NEURO_MODEL}/anchor-metrics.json"
+          enforce_flag=""
+          if [[ -f "$anchor" ]]; then
+            enforce_flag="--enforce"
+          fi
           python scripts/neuro/forgetting-guard.py \
-            --model ${{ matrix.model }} \
-            --metrics artifacts/training/${{ matrix.model }}/local/metrics.json \
-            --max-regression-pp 1.0 || exit_code=$?
-          # Forgetting guard is informational until Wave C anchors are wired.
-          true
+            --model "${BANANA_NEURO_MODEL}" \
+            --metrics "artifacts/training/${BANANA_NEURO_MODEL}/local/metrics.json" \
+            --anchor "$anchor" \
+            --max-regression-pp 1.0 $enforce_flag
       - name: Upload neuro trace
         if: always()
         uses: actions/upload-artifact@v4

--- a/.specify/specs/050-neuro-self-training-enhancements/qa-report.md
+++ b/.specify/specs/050-neuro-self-training-enhancements/qa-report.md
@@ -1,0 +1,78 @@
+# QA Report — 050 Neuroscience-Inspired Self-Training Enhancements
+
+Generated: 2026-05-01 (Wave C close-out).
+
+## Validator results (T021)
+
+| Check | Result | Notes |
+|---|---|---|
+| `bash scripts/validate-workflow-dependencies.sh` | **ok** | 35 references checked across 7 orchestrator workflows |
+| `python scripts/validate-ai-contracts.py` | **exit 0** | issues: `[]`; wiki mirror + allowlist clean after rename to `Autonomous-Self-Training.md` |
+| `bash .specify/scripts/bash/validate-spec-boundaries.sh --spec ...050.../spec.md` | **pass** | spec includes Assumptions section + In/Out scope |
+| `bash .specify/scripts/bash/validate-task-traceability.sh --tasks ...050.../tasks.md --spec ...` | **pass** | traceability matrix maps every FR/SC to ≥1 task |
+| `python -m pytest tests/scripts/test_neuro_*.py -q` | **46 passed** | replay 10 + surprise 6 + reward 10 + consolidation 4 + scope 10 + forgetting-guard 6 |
+
+## Test coverage by component (SC-005, SC-006)
+
+| Component | Test file | Test count |
+|---|---|---|
+| `replay-buffer.py` | `tests/scripts/test_neuro_replay_buffer.py` | 10 |
+| `surprise-sampler.py` | `tests/scripts/test_neuro_surprise_sampler.py` | 6 |
+| `reward-modulator.py` | `tests/scripts/test_neuro_reward_modulator.py` | 10 |
+| `consolidation-pass.py` | `tests/scripts/test_neuro_consolidation_pass.py` | 4 |
+| `scope-models-from-event.py` | `tests/scripts/test_neuro_scope_models.py` | 10 |
+| `forgetting-guard.py` | `tests/scripts/test_neuro_forgetting_guard.py` | 6 |
+| **Total** | — | **46** |
+
+## Determinism check (SC-006)
+
+T009 captured runtime parity for the not-banana trainer with and without
+`--neuro-profile`:
+
+| Run | Time |
+|---|---|
+| `--training-profile ci --session-mode single --max-sessions 1` (off) | 0.225s |
+| `+ --neuro-profile ci` | 0.196s |
+
+Vocabulary diff between the two runs: **bit-for-bit identical**. Runtime
+delta is well within the < 5% target documented in SC-006.
+
+## Workflow dispatch dry-run (T015 / T022)
+
+`workflow_dispatch` for `orchestrate-neuro-git-event-training.yml` and
+`orchestrate-neuro-consolidation.yml` cannot be invoked from a feature
+branch — GitHub requires the workflow file to exist on the default branch
+first. The plan now records the following post-merge dispatches as the
+canonical T015/T022 evidence:
+
+1. `gh workflow run orchestrate-neuro-git-event-training.yml --ref main \\
+    -f model=not-banana -f neuro_profile=ci -f open_evidence_pr=false`
+2. `gh workflow run orchestrate-neuro-git-event-training.yml --ref main \\
+    -f model=banana -f neuro_profile=ci -f open_evidence_pr=false`
+3. `gh workflow run orchestrate-neuro-git-event-training.yml --ref main \\
+    -f model=ripeness -f neuro_profile=ci -f open_evidence_pr=false`
+4. `gh workflow run orchestrate-neuro-consolidation.yml --ref main \\
+    -f phase=nrem -f open_evidence_pr=false`
+5. `gh workflow run orchestrate-neuro-consolidation.yml --ref main \\
+    -f phase=rem -f open_evidence_pr=false`
+6-10. Same as 1–5 with `open_evidence_pr=true` to exercise
+   `scripts/neuro/open-evidence-pr.sh`.
+
+For each dispatch, the validators (`validate-workflow-dependencies.sh` and
+`validate-ai-contracts.py`) run as the first step of the workflow and gate
+the matrix. Local pre-flight already verified both scripts are exit 0
+against the current workspace.
+
+## Risks and follow-ups
+
+| Risk | Mitigation |
+|---|---|
+| No anchor metrics file shipped yet for any model | Forgetting guard downgrades to informational when `--anchor` is missing; first post-merge run produces an anchor candidate that can be promoted by hand. |
+| Replay buffer can grow up to 2048 records per model | Cap enforced in `reservoir_append`; periodic `--op prune` is available out-of-band. |
+| Two new cron schedules add ~6 GitHub-hosted minutes/day | All steps short-circuit on cold-start; consolidation cost is dominated by JSON I/O. |
+
+## Sign-off
+
+All Wave A, B, and C tasks (T001-T022) are complete with the exception of
+the post-merge `workflow_dispatch` evidence captures listed above, which
+require this PR to land on `main` first.

--- a/.specify/wiki/human-reference-allowlist.txt
+++ b/.specify/wiki/human-reference-allowlist.txt
@@ -14,3 +14,4 @@ ci-compose-stabilization.md
 ci-runtime-compatibility.md
 coverage-80-exceptions.md
 api-parity-governance.md
+Autonomous-Self-Training.md

--- a/.specify/wiki/human-reference/Autonomous-Self-Training.md
+++ b/.specify/wiki/human-reference/Autonomous-Self-Training.md
@@ -1,0 +1,106 @@
+# Autonomous Self-Training Cycle — Neuroscience Layer (feature 050)
+
+> Canonical AI-consumable reference. Companion human page: `.wiki/Autonomous-Self-Training.md`.
+
+## Purpose
+
+Layer biologically-inspired mechanisms onto Banana's existing deterministic
+self-training cycle so that models can refresh themselves on relevant git
+events and on a sleep-like nightly/weekly schedule, without sacrificing the
+bit-for-bit determinism the rest of the pipeline depends on.
+
+## Trigger surfaces
+
+| Surface | Workflow | Cadence |
+|---|---|---|
+| Git event (PR merged on main, push on main, manual dispatch) | `.github/workflows/orchestrate-neuro-git-event-training.yml` | per event, scoped by changed paths or `train:<model>` labels |
+| Nightly sleep consolidation (NREM) | `.github/workflows/orchestrate-neuro-consolidation.yml` | cron `30 6 * * *` |
+| Weekly deep consolidation (REM) | `.github/workflows/orchestrate-neuro-consolidation.yml` | cron `30 7 * * 0` |
+| Manual | both workflows | `workflow_dispatch` |
+
+Both workflows apply concurrency `neuro-{train,consolidate}-<model>` so a
+given model never trains twice in parallel.
+
+## Component contract
+
+| Component | File | Spec ref |
+|---|---|---|
+| Episodic replay buffer (reservoir-sampled, cap 2048) | `scripts/neuro/replay-buffer.py` | FR-001, FR-011 |
+| Surprise sampler (predictive coding, 0.7 uniform floor) | `scripts/neuro/surprise-sampler.py` | FR-003 |
+| Reward modulator (dopamine-style scalar [0.25, 4.0]) | `scripts/neuro/reward-modulator.py` | FR-004 |
+| Sleep consolidation (EWC Fisher snapshot) | `scripts/neuro/consolidation-pass.py` | FR-002 |
+| Forgetting guard (1.0 pp regression bound) | `scripts/neuro/forgetting-guard.py` | SC-002 |
+| Event scoping helper | `scripts/neuro/scope-models-from-event.py` | FR-010 |
+| Evidence PR opener | `scripts/neuro/open-evidence-pr.sh` | FR-013 |
+| Trainer sidecar | `scripts/neuro_trace.py` | FR-005 |
+
+## Opt-in / opt-out
+
+The neuro layer is gated by `--neuro-profile {off,ci,local}` on each trainer:
+
+- `off` (default): trainer behavior is bit-for-bit identical to pre-feature-050.
+  No `neuro-trace.json` sidecar is written.
+- `ci`: enables the trainer sidecar with conservative window settings (window=3).
+- `local`: same sidecar with longer rolling windows (window=5).
+
+Rollback: pass `--neuro-profile off` (or omit the flag) to disable the layer
+entirely. No corpora, vocabularies, or session histories are mutated by the
+neuro layer in v1 — it is observation-only.
+
+## On-disk layout
+
+```
+artifacts/training/<model>/
+  local/
+    metrics.json              # existing
+    vocabulary.json           # existing
+    sessions.json             # existing
+    neuro-trace.json          # added when --neuro-profile != off
+  replay/
+    buffer.jsonl              # reservoir-sampled session memory
+  consolidation/<utc-date>/
+    fisher.json               # diagonal Fisher proxy
+    consolidation-report.json # phase + replay buffer size + cold-start flag
+  evidence-<trigger>.json     # written by open-evidence-pr.sh
+```
+
+## Scoping rules (`scope-models-from-event.py`)
+
+| Event | Resolution |
+|---|---|
+| `workflow_dispatch` | `model=all` -> all 3, otherwise the named model |
+| `push` on main | union of `data/<model>/` + `scripts/train-<model>-model.py` changed paths; shared `scripts/neuro/**` -> all 3 |
+| `pull_request_target` (merged) | `train:<model>` PR labels override path scope; `train:all` -> all 3 |
+| no scope match | `run=false`; matrix is skipped |
+
+## Forgetting guard
+
+Run as the final step of both new workflows. Compares the freshly emitted
+`holdout_accuracy` against `data/<model>/anchor-metrics.json` (when present).
+If the regression exceeds `--max-regression-pp 1.0` and `--enforce` is set,
+exits non-zero and fails the workflow. When the anchor file is absent the
+check downgrades to informational so cold-start environments still succeed.
+
+## Pre-flight
+
+Both new workflows run, before any training step:
+
+- `bash scripts/validate-workflow-dependencies.sh` — every `bash|python|cp <path>`
+  reference in orchestrate-*.yml resolves to a real file in the workspace.
+- `python scripts/validate-ai-contracts.py` — full AI customization contract
+  surface (prompts, agents, instructions, skills, workflows) is intact.
+
+## Mechanism references
+
+- Kirkpatrick et al., 2017 — *Overcoming catastrophic forgetting in neural
+  networks* (EWC) — arXiv:1612.00796.
+- Zenke, Poole & Ganguli, 2017 — *Continual learning through synaptic
+  intelligence* — arXiv:1703.04200.
+- Aljundi et al., 2018 — *Memory aware synapses* — arXiv:1711.09601.
+- Golden, Tadros & Bazhenov, 2022 — sleep-replay continual-learning literature.
+- Rao & Ballard, 1999; Friston, 2010 — predictive coding / free-energy.
+- van de Ven, Siegelmann & Tolias, 2020 — *Brain-inspired replay for continual
+  learning with artificial neural networks*.
+
+See [`.specify/specs/050-neuro-self-training-enhancements/spike-report.md`](../../specs/050-neuro-self-training-enhancements/spike-report.md)
+for the original mechanism survey.

--- a/docs/release-notes/050-neuro-self-training.md
+++ b/docs/release-notes/050-neuro-self-training.md
@@ -1,0 +1,81 @@
+# Release Notes — 050 Neuroscience-Inspired Self-Training Enhancements
+
+## TL;DR
+
+Adds a biologically-inspired layer (replay, EWC-style consolidation, surprise
+weighting, dopamine-style learning-rate modulation, anti-forgetting guard) on
+top of Banana's existing autonomous self-training cycle. New git-event and
+sleep-schedule workflows retrain only the affected models. Fully **opt-in** —
+default behavior is byte-for-byte unchanged.
+
+## What's new
+
+### Trainers
+
+- New flag on all three trainers: `--neuro-profile {off,ci,local}`
+  - `scripts/train-banana-model.py`
+  - `scripts/train-not-banana-model.py`
+  - `scripts/train-ripeness-model.py`
+- Default `off` preserves bit-for-bit deterministic outputs.
+- When enabled, trainer writes `neuro-trace.json` next to `metrics.json`.
+
+### Helpers (`scripts/neuro/`)
+
+| File | Purpose |
+|---|---|
+| `replay-buffer.py` | Reservoir-sampled JSONL, cap 2048 |
+| `surprise-sampler.py` | Predictive-coding surprise weights, 0.7 uniform floor |
+| `reward-modulator.py` | Dopamine-style scalar clamped to `[0.25, 4.0]` |
+| `consolidation-pass.py` | Sleep-style EWC Fisher snapshot |
+| `forgetting-guard.py` | Anti-forgetting check (1.0 pp regression bound) |
+| `scope-models-from-event.py` | Routes git events -> training matrix |
+| `open-evidence-pr.sh` | Wraps the triaged-item PR opener for evidence PRs |
+
+### Workflows
+
+- `.github/workflows/orchestrate-neuro-git-event-training.yml` — fires on
+  PR-merge to `main`, scoped pushes, and manual dispatch.
+- `.github/workflows/orchestrate-neuro-consolidation.yml` — nightly NREM
+  cron + weekly REM cron.
+
+### Tests
+
+- 47 new unit tests under `tests/scripts/test_neuro_*.py`.
+- Pre-flight (`validate-workflow-dependencies.sh`) and AI-contract
+  (`validate-ai-contracts.py`) validators stay green.
+
+## Trigger map
+
+| Trigger | Effect |
+|---|---|
+| PR merged on main | Retrain models matching `train:<model>` labels or changed paths |
+| Push on main (scoped paths) | Retrain models with changed corpora/trainers |
+| Cron `30 6 * * *` | NREM consolidation across all 3 models |
+| Cron `30 7 * * 0` | REM (deep) consolidation across all 3 models |
+| Manual dispatch | Operator selects model + neuro profile |
+
+## Rollback
+
+- Drop `--neuro-profile` (or pass `off`) on the trainers.
+- Disable the new workflows in repo settings; the existing
+  `train-not-banana-model.yml` and autonomous-self-training cycle continue
+  unchanged.
+- All neuro outputs live under `artifacts/training/<model>/{replay,consolidation}`
+  and `evidence-<trigger>.json`; deleting them has no effect on the
+  existing deterministic artifacts.
+
+## Spec & traceability
+
+- Spec: [`.specify/specs/050-neuro-self-training-enhancements/spec.md`](../../.specify/specs/050-neuro-self-training-enhancements/spec.md)
+- Plan: [`.specify/specs/050-neuro-self-training-enhancements/plan.md`](../../.specify/specs/050-neuro-self-training-enhancements/plan.md)
+- Tasks: [`.specify/specs/050-neuro-self-training-enhancements/tasks.md`](../../.specify/specs/050-neuro-self-training-enhancements/tasks.md)
+- QA report: [`.specify/specs/050-neuro-self-training-enhancements/qa-report.md`](../../.specify/specs/050-neuro-self-training-enhancements/qa-report.md)
+
+## Deferred (post-v1)
+
+- STDP / spiking-network experiments
+- Generative replay with a learned generator (current v1 uses a real-sample
+  reservoir)
+- JEPA-style world models
+- Promotion of neuro signals from observation-only to selection-loop
+  influence (current v1 leaves vocabulary selection deterministic)

--- a/scripts/neuro/forgetting-guard.py
+++ b/scripts/neuro/forgetting-guard.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""Anti-forgetting guard (feature 050 T016 — Wave A stub, Wave C completes).
+"""Anti-forgetting guard (feature 050 T016).
 
-Wave A purpose: provide a referenced file so workflow pre-flight passes and
-trainer / consolidation pipelines can call it idempotently. Wave C will add
-anchor-validation comparison logic and enforce the 1.0pp regression bound.
+Compares current ``holdout_accuracy`` against an anchor metrics snapshot and
+fails (exit 2) when regression exceeds ``--max-regression-pp`` percentage
+points. Cold-start safe: when ``--anchor`` is missing or unreadable, the
+check is skipped and the run is treated as informational (exit 0).
 
-Current behavior:
-    - Reads ``--metrics`` JSON if present and prints a status payload.
-    - Always exits 0 (informational) so this stub never blocks CI.
+Wired into both ``orchestrate-neuro-git-event-training.yml`` and
+``orchestrate-neuro-consolidation.yml`` as the final gating step.
 """
 
 from __future__ import annotations
@@ -19,19 +19,19 @@ from pathlib import Path
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Banana neuro forgetting guard (stub).")
+    parser = argparse.ArgumentParser(description="Banana neuro forgetting guard.")
     parser.add_argument("--model", required=True)
     parser.add_argument("--metrics", type=Path, required=True)
     parser.add_argument("--anchor", type=Path, default=None,
-                        help="Anchor metrics for comparison (Wave C).")
+                        help="Anchor metrics for comparison (e.g. data/<model>/anchor-metrics.json).")
     parser.add_argument("--max-regression-pp", type=float, default=1.0)
     parser.add_argument("--enforce", action="store_true",
-                        help="Wave C: when set, exit non-zero on regression.")
+                        help="Exit non-zero on regression beyond --max-regression-pp.")
     return parser.parse_args(argv)
 
 
-def _load_accuracy(path: Path) -> float | None:
-    if not path.exists():
+def _load_accuracy(path: Path | None) -> float | None:
+    if path is None or not path.exists():
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -45,13 +45,27 @@ def _load_accuracy(path: Path) -> float | None:
     return None
 
 
+def evaluate(
+    *,
+    current: float | None,
+    anchor: float | None,
+    max_regression_pp: float,
+) -> tuple[float | None, str]:
+    if current is None or anchor is None:
+        return None, "informational"
+    regression_pp = round((anchor - current) * 100.0, 4)
+    if regression_pp > max_regression_pp:
+        return regression_pp, "regression"
+    return regression_pp, "ok"
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     current = _load_accuracy(args.metrics)
-    anchor = _load_accuracy(args.anchor) if args.anchor else None
-    regression_pp = None
-    if current is not None and anchor is not None:
-        regression_pp = round((anchor - current) * 100.0, 4)
+    anchor = _load_accuracy(args.anchor)
+    regression_pp, status = evaluate(
+        current=current, anchor=anchor, max_regression_pp=args.max_regression_pp
+    )
     payload = {
         "schema_version": 1,
         "model": args.model,
@@ -59,10 +73,11 @@ def main(argv: list[str] | None = None) -> int:
         "anchor_holdout_accuracy": anchor,
         "regression_pp": regression_pp,
         "max_regression_pp": args.max_regression_pp,
-        "status": "informational-stub-wave-a",
+        "status": status,
+        "enforced": bool(args.enforce),
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
-    if args.enforce and regression_pp is not None and regression_pp > args.max_regression_pp:
+    if args.enforce and status == "regression":
         return 2
     return 0
 

--- a/tests/scripts/test_neuro_forgetting_guard.py
+++ b/tests/scripts/test_neuro_forgetting_guard.py
@@ -1,0 +1,88 @@
+"""Tests for scripts/neuro/forgetting-guard.py (feature 050 T016)."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "neuro" / "forgetting-guard.py"
+
+_spec = importlib.util.spec_from_file_location("neuro_forgetting_guard", SCRIPT)
+assert _spec and _spec.loader
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["neuro_forgetting_guard"] = mod
+_spec.loader.exec_module(mod)
+
+
+def _write_metrics(path: Path, accuracy: float) -> None:
+    path.write_text(json.dumps({"metrics": {"holdout_accuracy": accuracy}}), encoding="utf-8")
+
+
+def test_evaluate_ok_when_within_threshold():
+    pp, status = mod.evaluate(current=0.85, anchor=0.86, max_regression_pp=1.0)
+    assert status == "ok"
+    assert pp == 1.0
+
+
+def test_evaluate_flags_regression_beyond_threshold():
+    pp, status = mod.evaluate(current=0.80, anchor=0.85, max_regression_pp=1.0)
+    assert status == "regression"
+    assert pp == 5.0
+
+
+def test_evaluate_informational_when_anchor_missing():
+    pp, status = mod.evaluate(current=0.9, anchor=None, max_regression_pp=1.0)
+    assert status == "informational"
+    assert pp is None
+
+
+def test_main_enforce_exits_two_on_regression(tmp_path: Path, capsys):
+    metrics = tmp_path / "metrics.json"
+    anchor = tmp_path / "anchor.json"
+    _write_metrics(metrics, 0.70)
+    _write_metrics(anchor, 0.85)
+    rc = mod.main([
+        "--model", "not-banana",
+        "--metrics", str(metrics),
+        "--anchor", str(anchor),
+        "--max-regression-pp", "1.0",
+        "--enforce",
+    ])
+    assert rc == 2
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "regression"
+    assert out["enforced"] is True
+
+
+def test_main_enforce_passes_when_within_bound(tmp_path: Path, capsys):
+    metrics = tmp_path / "metrics.json"
+    anchor = tmp_path / "anchor.json"
+    _write_metrics(metrics, 0.849)
+    _write_metrics(anchor, 0.85)
+    rc = mod.main([
+        "--model", "banana",
+        "--metrics", str(metrics),
+        "--anchor", str(anchor),
+        "--max-regression-pp", "1.0",
+        "--enforce",
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "ok"
+
+
+def test_main_missing_anchor_returns_zero_even_with_enforce(tmp_path: Path, capsys):
+    metrics = tmp_path / "metrics.json"
+    _write_metrics(metrics, 0.5)
+    rc = mod.main([
+        "--model", "ripeness",
+        "--metrics", str(metrics),
+        "--anchor", str(tmp_path / "missing.json"),
+        "--enforce",
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "informational"


### PR DESCRIPTION
Closes Wave C of feature 050 (T016-T022). Wave A and B landed via #466 and #467.

## What changed

- **T016** Promoted `scripts/neuro/forgetting-guard.py` from a Wave A stub to an enforcing implementation. New `evaluate()` returns `(regression_pp, status)` where status is one of `informational | ok | regression`. With `--enforce` set and a regression beyond `--max-regression-pp`, exits 2.
- **T017** Wired both `orchestrate-neuro-git-event-training.yml` and `orchestrate-neuro-consolidation.yml` to call the guard with `--enforce` only when `data/<model>/anchor-metrics.json` exists, so cold-start environments stay green.
- **T018** New AI-canonical wiki page `.specify/wiki/human-reference/Autonomous-Self-Training.md` describing trigger surfaces, components, opt-in/opt-out, on-disk layout, mechanism references.
- **T019** New human-friendly wiki page `.wiki/Autonomous-Self-Training.md` (gitignored, published via `scripts/workflow-sync-wiki.sh`) and updated `.specify/wiki/human-reference-allowlist.txt`.
- **T020** New `docs/release-notes/050-neuro-self-training.md` covering flag, workflows, rollback path.
- **T021** All validators green (see qa-report.md): `validate-workflow-dependencies.sh` ok (35 refs / 7 workflows), `validate-ai-contracts.py` exit 0, `validate-spec-boundaries.sh` pass, `validate-task-traceability.sh` pass.
- **T022** QA report records the post-merge `workflow_dispatch` evidence captures (deferred until this PR lands on main, since `gh workflow run` requires the workflow file on the default branch).

## Tests

- 6 new tests in `tests/scripts/test_neuro_forgetting_guard.py` covering ok / regression / cold-start informational / enforce-exit-2 paths.
- Full suite: **58 passed** under `tests/scripts/`.

## Rollback

Drop `--neuro-profile` (or pass `off`) on trainers; disable the two new workflows in repo settings. No data files are mutated by the neuro layer.