### PR TITLE
spike(051): frontend robustness uplift + scaffold 15 follow-up specs (#052-#066)

### DIFF
--- a/.specify/specs/051-frontend-robustness-spike/spec.md
+++ b/.specify/specs/051-frontend-robustness-spike/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: Frontend Robustness Uplift Spike
+
+**Feature Branch**: `051-frontend-robustness-spike`
+**Created**: 2026-05-01
+**Status**: Spike — research only
+**Input**: User description: "do a spike on how we could deliver a more robust frontend experience, our frontend is pretty limited given the infrastructure of the project. then scaffold follow up specs for implementation and QA. Plan at least 15 specs that we could follow up on."
+
+## In Scope *(mandatory)*
+
+- A research spike (no code shipped) that surveys how Banana's React, Electron, React-Native, and shared-UI surfaces can be uplifted to match the depth of the API/native/training infrastructure.
+- An honest inventory of the current frontend surface (one-page App.tsx, 5 shared components, no router, no state-machine, minimal a11y/i18n/observability).
+- A prioritized list of **15 follow-up Spec Kit features** (#052–#066) covering routing, state management, streaming, PWA/offline, storybook, accessibility, i18n, theming, e2e, observability, performance budgets, auth/roles, operator dashboard, neuro-trace viewer, and mobile parity.
+- Scaffold a `spec.md` stub for each follow-up feature so the planner agent can `speckit.specify` / `speckit.plan` them in dependency order.
+
+## Out of Scope *(mandatory)*
+
+- Implementing any of the 15 follow-up features in this PR (they each get their own branch + PR).
+- Changing the API contract, native pipeline, or training cycle (the spike is frontend-only).
+- Replacing React, Electron, or React-Native runtimes — uplift is additive.
+- Adopting any framework that conflicts with the Bun + Vite + Tailwind + shadcn baseline already shipped in feature 048.
+
+## Background
+
+The Banana frontend currently consists of:
+
+- One React app (`src/typescript/react`) with a single `App.tsx` page rendering ensemble verdict + chat + ripeness in a long form-style layout. shadcn primitives (Alert, Button, Card, Input, Textarea) are wired in.
+- A shared `@banana/ui` package with 5 components (BananaBadge, ChatMessageBubble, ErrorText, EscalationPanel, RetryButton, RipenessLabel) plus tokens.
+- An Electron shell (`src/typescript/electron`) with main/preload/ipc/notifications/storage/tray and a smoke harness — no rendered desktop polish.
+- A React-Native app (`src/typescript/react-native`) with three screens (Capture, History, Verdict) and a thin api/copy/resilience-bootstrap lib.
+- Resilience primitives (retry policy, queue) used only in App.tsx.
+
+The backend infrastructure is dramatically deeper than the UX surface: ASP.NET pipeline + native interop, Fastify+Prisma TS API, three trainers with neuro-self-training cycle, validation governance, parity gates, compose-orchestrated runtimes, AI-contract guards. The frontend is where the gap is most visible.
+
+## Spike findings — 9 uplift themes
+
+See [`spike-report.md`](./spike-report.md) for the full survey. The spike identifies nine themes that map cleanly to the 15 follow-up features:
+
+| Theme | Follow-up features |
+|---|---|
+| Application architecture | 052 routing, 053 state |
+| Real-time UX | 054 streaming, 065 neuro-trace viewer |
+| Resilience & offline | 055 PWA, 060 e2e |
+| Design system depth | 056 storybook, 059 theming |
+| Quality gates | 057 a11y, 061 observability, 062 perf budget |
+| Internationalization | 058 i18n |
+| Authn/Authz UX | 063 auth, 064 operator dashboard |
+| Mobile parity | 066 mobile parity |
+
+## Follow-up spec inventory (15 features)
+
+| # | Feature | Domain | Sequence |
+|---|---|---|---|
+| 052 | Frontend routing + multi-page architecture | react / electron | first wave |
+| 053 | Typed state baseline (TanStack Query + Zustand) | react | first wave |
+| 054 | Streaming verdict + chat (SSE/WebSocket) | react / api | second wave |
+| 055 | PWA + offline service worker shell | react | second wave |
+| 056 | Storybook + component documentation | shared/ui | second wave |
+| 057 | Accessibility WCAG 2.2 AA audit + CI gate | shared/ui / react | third wave |
+| 058 | i18n + localization scaffold | shared/ui / react | third wave |
+| 059 | Dark mode + theming via design tokens | shared/ui | third wave |
+| 060 | E2E test harness (Playwright across react/electron) | react / electron / qa | third wave |
+| 061 | Frontend observability (telemetry, web vitals, error reporting) | react / electron / api | fourth wave |
+| 062 | Performance budget + bundle analysis CI gate | workflow | fourth wave |
+| 063 | Auth + session/role-aware UI | react / api | fourth wave |
+| 064 | Operator dashboard (metrics + training runs) | react / api | fifth wave |
+| 065 | Real-time training-run visualization (neuro-trace viewer) | react / api | fifth wave |
+| 066 | Mobile parity sprint (RN screen depth + share/upload) | react-native | fifth wave |
+
+## Functional Requirements *(mandatory)*
+
+- **FR-001**: Spike report MUST document the current frontend surface inventory with file references.
+- **FR-002**: Spike report MUST cite at least one external authoritative source per uplift theme.
+- **FR-003**: Spike report MUST identify which themes have hard prerequisites on the API/native layers and which can ship purely from the frontend domain.
+- **FR-004**: Each of the 15 follow-up features MUST have a stub `spec.md` under `.specify/specs/<NNN>-<name>/spec.md` containing at minimum a title, branch name, In Scope, Out of Scope, and a one-paragraph problem statement.
+- **FR-005**: Follow-up stubs MUST declare the dependency wave they belong to (first/second/third/fourth/fifth) so they can be sequenced.
+- **FR-006**: This feature MUST NOT mutate any runtime code, workflows, or trainer outputs (spike-only contract).
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: PR containing this spike + 15 stubs lands on `main` without modifying any file outside `.specify/specs/051-066-*` or `docs/release-notes/051-frontend-robustness.md`.
+- **SC-002**: `validate-ai-contracts.py` exit 0 after the new files land.
+- **SC-003**: Each follow-up stub is discoverable by `speckit.specify --feature <NNN>` (i.e., directory + spec.md exists, branch slug is consistent).
+- **SC-004**: At least 5 of the 15 follow-ups are tagged "first/second wave" so a sprint can start immediately without additional sequencing work.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Stubs become abandoned shelfware | Dependency-wave tagging + explicit ownership in plan artifact when each is picked up |
+| Frontend uplift drifts from API contract | Each feature that changes the API surface (054, 061, 063, 064, 065) declares it in the stub's "depends on" line |
+| shadcn baseline regressions during expansion | All UI work continues to build on feature 048 baseline; component additions go through 056 storybook gate once shipped |

--- a/.specify/specs/051-frontend-robustness-spike/spike-report.md
+++ b/.specify/specs/051-frontend-robustness-spike/spike-report.md
@@ -1,0 +1,148 @@
+# Spike Report — Frontend Robustness Uplift
+
+**Feature**: 051-frontend-robustness-spike
+**Generated**: 2026-05-01
+**Author**: spike (no code shipped)
+
+## 1. Current frontend surface (inventory)
+
+### React (`src/typescript/react`)
+- Single page: [`src/typescript/react/src/App.tsx`](../../../src/typescript/react/src/App.tsx) (~600+ LOC, all UX in one component tree).
+- shadcn primitives wired (feature 048): Alert, Button, Card, Input, Textarea under `components/ui/`.
+- Bespoke `ErrorBoundary` only.
+- No client routing; the React app is effectively one screen with conditional regions for chat, ripeness, ensemble verdict, escalation.
+- No state library — local React state + bespoke `lib/resilience-bootstrap.ts` queue.
+- API client: handwritten `fetch` wrappers in `src/lib/api.ts`. No request cache, no streaming.
+- Tests: Bun + happy-dom + Testing Library. ~10 component tests; no e2e.
+
+### Shared UI (`src/typescript/shared/ui`)
+- 5 components: BananaBadge, ChatMessageBubble, ErrorText, EscalationPanel, RetryButton, RipenessLabel.
+- `tokens/` directory with JSON tokens + a generator script that emits Tailwind tokens.
+- No Storybook, no visual regression harness, no public component API doc.
+
+### Electron (`src/typescript/electron`)
+- Main/preload/ipc/notifications/storage/tray + `smoke.js` harness.
+- Renders the same React build inside a BrowserWindow; no desktop-specific UX (no command palette, no menubar polish, no native notifications surface).
+
+### React-Native (`src/typescript/react-native`)
+- 3 screens: Capture, History, Verdict.
+- Thin `lib/` (api.ts, copy.ts, resilience-bootstrap.ts).
+- No share-extension wiring beyond `share-handler.ts`; no offline cache, no push notifications, no biometric auth.
+
+### Resilience layer
+- Retry policy + offline queue (resilience-bootstrap) is solid but only wired to the ensemble submit path. Not used for chat, ripeness, or any future streaming endpoint.
+
+## 2. Gap analysis vs. backend depth
+
+The backend surface in this repo is large: ASP.NET pipeline + native interop, Fastify+Prisma TS API, three trainers with the new neuroscience-inspired self-training cycle (feature 050), validation governance (feature 047 parity gates), AI contract guards, compose-orchestrated runtimes, workflow recovery (feature 049). Customer-visible value is gated by a single React page — the depth gap is severe.
+
+## 3. Nine uplift themes (ranked by leverage)
+
+### 3.1 Application architecture
+**Problem**: Single-page App.tsx mixes 5 concerns (chat, ensemble, ripeness, escalation, history). Adding any new feature increases coupling.
+**Direction**: File-based routing (TanStack Router or React Router 7), code-splitting per route, layout primitives in shared/ui.
+**Sources**: TanStack Router docs (https://tanstack.com/router); React Router v7 framework mode; Vercel "Why split routes" guide.
+**Maps to**: 052 routing.
+
+### 3.2 Typed client state
+**Problem**: All async state is local React + ad-hoc fetch. No cache, no background refresh, no optimistic updates.
+**Direction**: TanStack Query for server state + Zustand (or Jotai) for client state. Strict TS types from API openapi.
+**Sources**: TanStack Query v5 docs; Zustand patterns; "Server state vs client state" (Tanner Linsley).
+**Maps to**: 053 state baseline.
+
+### 3.3 Real-time UX
+**Problem**: Verdict + chat both block on a full HTTP roundtrip. The neuro layer (feature 050) emits trace events that have nowhere to surface in the UI.
+**Direction**: Server-Sent Events for verdict streaming + chat tokens. WebSocket (or SSE multiplex) for training-run progress.
+**Sources**: WHATWG EventSource spec; HTMX SSE swap patterns; OpenAI streaming chat patterns.
+**Maps to**: 054 streaming, 065 neuro-trace viewer.
+
+### 3.4 Offline & resilience
+**Problem**: Resilience queue exists but the app shell itself is non-functional offline. Mobile users on flaky networks get blank pages.
+**Direction**: PWA install + service worker app shell (Workbox); use existing resilience queue as the durable submit layer.
+**Sources**: web.dev PWA series; Workbox v7; Apple "Designing Web Apps for the Home Screen" notes.
+**Maps to**: 055 PWA.
+
+### 3.5 Design system depth
+**Problem**: 5 shared components, no docs, no visual regression. Theming = "default Tailwind".
+**Direction**: Storybook 8 + Chromatic-style snapshot testing in CI; CSS variables for theming.
+**Sources**: Storybook 8 release notes; shadcn theming guide; Radix Themes color system.
+**Maps to**: 056 storybook, 059 theming.
+
+### 3.6 Quality gates (a11y / perf / observability)
+**Problem**: No a11y CI, no performance budget, no production telemetry. We ship blind.
+**Direction**: axe-core + @testing-library/jest-dom in unit; Playwright + axe in e2e; Lighthouse CI for perf budget; Web Vitals + OpenTelemetry browser SDK for production telemetry.
+**Sources**: WCAG 2.2 AA reference; web.dev Core Web Vitals; OpenTelemetry JS SDK browser autoinstrumentation.
+**Maps to**: 057 a11y, 061 observability, 062 perf budget, 060 e2e.
+
+### 3.7 Internationalization
+**Problem**: All copy is hardcoded English in `lib/copy.ts`. No locale negotiation.
+**Direction**: i18next or FormatJS; integrate with shared/ui token pipeline so locale-aware components are first-class.
+**Sources**: ICU MessageFormat; FormatJS docs; i18next React adapter.
+**Maps to**: 058 i18n.
+
+### 3.8 Auth & roles
+**Problem**: There is no client authentication surface. Operator-only views (training metrics, neuro-trace, audit) are blocked from existing because there's nothing to gate them on.
+**Direction**: OIDC PKCE flow against an external IdP (or device-bound local accounts for the desktop channel); role-aware route guards.
+**Sources**: OAuth 2.1 BCP, IETF OAuth 2.0 for Browser-Based Apps draft; Auth.js v5 patterns.
+**Maps to**: 063 auth, 064 operator dashboard.
+
+### 3.9 Mobile parity
+**Problem**: 3 RN screens vs the API's full surface. No share-target, no offline cache, no push notifications.
+**Direction**: Share-extension polish, expo-secure-store for credentials, FlashList for history, push via Expo Notifications.
+**Sources**: Expo SDK 51 docs; Apple Share Extension HIG; Android intent filter docs.
+**Maps to**: 066 mobile parity.
+
+## 4. Dependency map
+
+```
+052 routing  ┐
+053 state     ├─► 054 streaming ─► 065 neuro-trace viewer
+055 PWA       │                  ╲
+056 storybook ┤                   └─► 064 operator dashboard
+057 a11y      │       ╱─ 063 auth ─┘
+058 i18n      │      ╱
+059 theming   │     ╱
+060 e2e       ┴─► 061 observability ─► 062 perf budget
+066 mobile parity (parallel, depends on 053 + 057)
+```
+
+First wave (no prerequisites beyond current main): 052, 053, 056.
+Second wave (depends on first): 054, 055.
+Third wave (cross-cutting): 057, 058, 059, 060.
+Fourth wave (depends on observability + auth): 061, 062, 063.
+Fifth wave (depends on auth/observability): 064, 065, 066.
+
+## 5. Pure-frontend vs cross-layer features
+
+**Pure frontend (no API/native changes required)**: 052, 053, 055, 056, 057, 058, 059, 060, 062, 066.
+
+**Cross-layer (requires API or native coordination)**:
+- 054 streaming — needs SSE or WebSocket endpoints in Fastify + ASP.NET.
+- 061 observability — needs trace ingestion endpoint or OTLP collector.
+- 063 auth — needs IdP integration on API.
+- 064 operator dashboard — needs metrics-read API endpoints.
+- 065 neuro-trace viewer — needs read-only `artifacts/training/*/local/neuro-trace.json` exposure.
+
+## 6. Non-goals for this spike
+
+- No code edits to React/Electron/RN/shared in this PR.
+- No new API endpoints in this PR (they are scoped into 054/061/063/064/065 specs).
+- No commitment to a specific routing/state library — each follow-up spec will run its own ADR.
+
+## 7. References
+
+1. WCAG 2.2 — https://www.w3.org/TR/WCAG22/
+2. TanStack Router — https://tanstack.com/router
+3. TanStack Query v5 — https://tanstack.com/query/latest
+4. WHATWG EventSource — https://html.spec.whatwg.org/multipage/server-sent-events.html
+5. Workbox v7 — https://developer.chrome.com/docs/workbox
+6. Storybook 8 — https://storybook.js.org/blog/storybook-8/
+7. axe-core — https://github.com/dequelabs/axe-core
+8. Lighthouse CI — https://github.com/GoogleChrome/lighthouse-ci
+9. Web Vitals — https://web.dev/vitals/
+10. OpenTelemetry JS Browser SDK — https://opentelemetry.io/docs/instrumentation/js/getting-started/browser/
+11. FormatJS — https://formatjs.io/
+12. OAuth 2.0 for Browser-Based Apps — https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps
+13. Expo SDK 51 — https://docs.expo.dev/
+14. shadcn/ui theming — https://ui.shadcn.com/docs/theming
+15. Radix Themes color system — https://www.radix-ui.com/themes/docs/theme/color

--- a/.specify/specs/052-frontend-routing-architecture/spec.md
+++ b/.specify/specs/052-frontend-routing-architecture/spec.md
@@ -1,0 +1,31 @@
+# Feature Specification: Frontend Routing & Multi-Page Architecture
+
+**Feature Branch**: `052-frontend-routing-architecture`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: first
+**Domain**: react / electron
+**Depends on**: none (pure-frontend; can ship from current main)
+
+## Problem Statement
+
+Single-page App.tsx couples chat, ensemble verdict, ripeness, escalation, and history into one component tree. Adding any new screen requires editing the same file, and route-level code-splitting is impossible.
+
+## In Scope *(mandatory)*
+
+- Adopt a typed file-based router (TanStack Router or React Router 7 framework mode) for the React app.
+- Split the existing App.tsx surface into 4-5 routes (verdict, chat, history, escalation, settings).
+- Code-split each route via Vite dynamic import; preserve current shadcn baseline and resilience wiring.
+- Wire Electron BrowserWindow navigation to the new router (history mode + deep-link).
+
+## Out of Scope *(mandatory)*
+
+- Replacing Vite or migrating to Next.js / Remix.
+- Server-side rendering.
+- Adding new business features beyond surfacing the existing ones.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/053-frontend-typed-state-baseline/spec.md
+++ b/.specify/specs/053-frontend-typed-state-baseline/spec.md
@@ -1,0 +1,31 @@
+# Feature Specification: Typed Client State Baseline (TanStack Query + Zustand)
+
+**Feature Branch**: `053-frontend-typed-state-baseline`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: first
+**Domain**: react
+**Depends on**: none (pure-frontend; can ship from current main)
+
+## Problem Statement
+
+All async state is local React + ad-hoc fetch. There is no cache, no background refresh, no optimistic UI, and no shared client store. Every new feature reinvents these patterns.
+
+## In Scope *(mandatory)*
+
+- Adopt TanStack Query v5 for all server state (verdict, chat, ripeness, history, future operator endpoints).
+- Adopt Zustand for client UI state (panels open, selected history entry, theme override).
+- Generate strict TS types from the Fastify+Prisma OpenAPI surface and feed them into the query hooks.
+- Migrate App.tsx fetch calls to query hooks while preserving resilience-bootstrap retry semantics.
+
+## Out of Scope *(mandatory)*
+
+- Replacing the existing resilience-bootstrap queue.
+- Introducing Redux or RTK.
+- Server-state for non-Banana endpoints.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/054-frontend-streaming-verdict-and-chat/spec.md
+++ b/.specify/specs/054-frontend-streaming-verdict-and-chat/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Streaming Verdict & Chat (SSE/WebSocket)
+
+**Feature Branch**: `054-frontend-streaming-verdict-and-chat`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: second
+**Domain**: react / api
+**Depends on**: #053
+
+## Problem Statement
+
+Verdict and chat both block on a full HTTP roundtrip; users see a long spinner. The neuro layer (feature 050) emits trace events that have nowhere to surface.
+
+## In Scope *(mandatory)*
+
+- Add SSE endpoints in Fastify+Prisma TS API for chat tokens and ensemble verdict progress.
+- Mirror the streaming contract in the ASP.NET pipeline so both API surfaces stay parity-aligned (feature 047 governance).
+- Consume streams in React via TanStack Query streamed-query pattern.
+- Define backpressure + reconnect policy using existing resilience primitives.
+
+## Out of Scope *(mandatory)*
+
+- Bidirectional WebSocket for chat (SSE one-way is sufficient for v1).
+- Streaming for non-customer endpoints (admin/operator).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/055-frontend-pwa-offline-shell/spec.md
+++ b/.specify/specs/055-frontend-pwa-offline-shell/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: PWA & Offline Service Worker Shell
+
+**Feature Branch**: `055-frontend-pwa-offline-shell`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: second
+**Domain**: react
+**Depends on**: #052
+
+## Problem Statement
+
+App shell is non-functional offline; mobile users on flaky networks see blank pages. The resilience queue exists but the chrome that hosts it does not survive an offline reload.
+
+## In Scope *(mandatory)*
+
+- Generate a PWA manifest + Workbox-managed service worker that caches the app shell.
+- Wire the existing resilience-bootstrap submit queue to flush on `online` events.
+- Add install prompt UX with copy reviewed by the human-reference doc lane.
+- Ship offline fallback page mounted by the router (depends on 052).
+
+## Out of Scope *(mandatory)*
+
+- Background sync for non-submit endpoints.
+- Push notifications (covered by 066 mobile parity).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/056-shared-ui-storybook-and-docs/spec.md
+++ b/.specify/specs/056-shared-ui-storybook-and-docs/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Shared UI Storybook & Component Docs
+
+**Feature Branch**: `056-shared-ui-storybook-and-docs`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: second
+**Domain**: shared/ui
+**Depends on**: none (pure-frontend; can ship from current main)
+
+## Problem Statement
+
+Five shared components have no docs and no visual regression harness; the design token pipeline has no consuming surface to validate against.
+
+## In Scope *(mandatory)*
+
+- Stand up Storybook 8 inside `src/typescript/shared/ui/`.
+- Author stories for all existing components plus the shadcn primitives wired in feature 048.
+- Add a CI lane that builds Storybook and uploads it as a PR artifact.
+- Document the token pipeline (`tokens/` -> Tailwind generator) as a Storybook page.
+
+## Out of Scope *(mandatory)*
+
+- Visual regression diffing in v1 (deferred).
+- Replacing the existing Bun + happy-dom unit lane.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/057-frontend-accessibility-wcag22-gate/spec.md
+++ b/.specify/specs/057-frontend-accessibility-wcag22-gate/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Accessibility (WCAG 2.2 AA) Audit & CI Gate
+
+**Feature Branch**: `057-frontend-accessibility-wcag22-gate`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: third
+**Domain**: shared/ui / react
+**Depends on**: #056
+
+## Problem Statement
+
+There is no a11y CI lane. Shipping an operator dashboard or any expanded surface without an enforceable contract guarantees regressions.
+
+## In Scope *(mandatory)*
+
+- Add axe-core to the React + shared-ui Bun test lane (jest-dom matcher).
+- Add Playwright + @axe-core/playwright to the future e2e lane (handed to 060).
+- Author a baseline a11y allowlist with explicit, time-boxed exceptions and reviewer sign-off.
+- Codify a checklist in `.specify/wiki/human-reference/` for new component PRs.
+
+## Out of Scope *(mandatory)*
+
+- Manual screen-reader QA contracts (deferred to next iteration).
+- Audio captions / video transcript work (no video surface yet).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/058-frontend-i18n-localization-scaffold/spec.md
+++ b/.specify/specs/058-frontend-i18n-localization-scaffold/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: i18n & Localization Scaffold
+
+**Feature Branch**: `058-frontend-i18n-localization-scaffold`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: third
+**Domain**: shared/ui / react
+**Depends on**: #053
+
+## Problem Statement
+
+All copy is hardcoded English in `src/typescript/react/src/lib/copy.ts`. No locale negotiation, no message-format support, no RTL.
+
+## In Scope *(mandatory)*
+
+- Adopt FormatJS (ICU MessageFormat) for the React app and shared/ui copy.
+- Refactor `lib/copy.ts` to a message catalog seeded with `en-US`.
+- Add a stub `es-MX` catalog as a smoke test of the pipeline.
+- Wire locale negotiation via Accept-Language with a user override stored in Zustand (depends on 053).
+
+## Out of Scope *(mandatory)*
+
+- Translating all copy in v1 (only `en-US` ships fully populated).
+- RTL audit (deferred).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/059-frontend-theming-and-dark-mode/spec.md
+++ b/.specify/specs/059-frontend-theming-and-dark-mode/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Theming & Dark Mode via Design Tokens
+
+**Feature Branch**: `059-frontend-theming-and-dark-mode`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: third
+**Domain**: shared/ui
+**Depends on**: #056
+
+## Problem Statement
+
+Theming is 'default Tailwind'. The token pipeline emits values but the UI never consumes a non-default theme; dark mode does not exist.
+
+## In Scope *(mandatory)*
+
+- Extend the `tokens/` pipeline to emit CSS-variable themes (light + dark + a high-contrast preset).
+- Adopt the shadcn theming convention so existing primitives respect `data-theme`.
+- Add a theme toggle component in shared/ui with persistence via Zustand.
+- Document the contract in Storybook (depends on 056).
+
+## Out of Scope *(mandatory)*
+
+- Per-tenant or per-customer theme branding.
+- Animated theme transitions.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/060-frontend-e2e-playwright-harness/spec.md
+++ b/.specify/specs/060-frontend-e2e-playwright-harness/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: End-to-End Test Harness (Playwright across React/Electron)
+
+**Feature Branch**: `060-frontend-e2e-playwright-harness`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: third
+**Domain**: react / electron / qa
+**Depends on**: #052
+
+## Problem Statement
+
+There is no e2e lane today; regressions in the routing, streaming, or auth flows would only be caught in production.
+
+## In Scope *(mandatory)*
+
+- Stand up Playwright with web + Electron driver.
+- Author smoke flows: open verdict route, submit ensemble, observe streamed chat, escalate, drain offline queue.
+- Wire @axe-core/playwright into the same lane (handoff with 057).
+- Run e2e on PRs that touch React, Electron, or shared/ui paths via path-scoped GitHub Actions trigger.
+
+## Out of Scope *(mandatory)*
+
+- Mobile e2e (covered by 066).
+- Visual regression diffing (handled by 056 follow-on).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/061-frontend-observability-and-vitals/spec.md
+++ b/.specify/specs/061-frontend-observability-and-vitals/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Frontend Observability (Telemetry, Web Vitals, Error Reporting)
+
+**Feature Branch**: `061-frontend-observability-and-vitals`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: fourth
+**Domain**: react / electron / api
+**Depends on**: #054
+
+## Problem Statement
+
+No production telemetry; every regression is reported by humans. Web Vitals are unmeasured.
+
+## In Scope *(mandatory)*
+
+- Adopt OpenTelemetry JS browser SDK for traces and metrics.
+- Add a thin OTLP collector endpoint on the Fastify+Prisma TS API (or proxy to an external collector).
+- Capture Core Web Vitals (LCP, INP, CLS) and ship them to the same collector.
+- Wire client-side error reporting (window.onerror + React error boundary) into the trace surface.
+
+## Out of Scope *(mandatory)*
+
+- Server-side tracing changes (already covered by API observability work).
+- PII collection.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/062-frontend-performance-budget-gate/spec.md
+++ b/.specify/specs/062-frontend-performance-budget-gate/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Performance Budget & Bundle Analysis CI Gate
+
+**Feature Branch**: `062-frontend-performance-budget-gate`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: fourth
+**Domain**: workflow
+**Depends on**: #052, #061
+
+## Problem Statement
+
+There is no enforced bundle size or Lighthouse budget; routing + streaming additions could regress LCP without anyone noticing.
+
+## In Scope *(mandatory)*
+
+- Add a Lighthouse CI lane against a preview build of the React app.
+- Set explicit budgets: JS < 250KB gz per route, LCP < 2.5s, INP < 200ms, CLS < 0.1.
+- Add `vite-bundle-visualizer` artifact upload on PRs touching React.
+- Surface deltas in a comment on the PR; block on >10% regressions unless an exception label is present.
+
+## Out of Scope *(mandatory)*
+
+- Real-user-monitoring budgets (covered by 061).
+- Native binary size budgets (out of frontend scope).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/063-frontend-auth-and-roles/spec.md
+++ b/.specify/specs/063-frontend-auth-and-roles/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Auth & Session/Role-Aware UI
+
+**Feature Branch**: `063-frontend-auth-and-roles`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: fourth
+**Domain**: react / api
+**Depends on**: #053
+
+## Problem Statement
+
+There is no client authentication surface. Operator-only views (training metrics, neuro-trace, audit) cannot exist because there is nothing to gate them on.
+
+## In Scope *(mandatory)*
+
+- Adopt OIDC PKCE flow against an external IdP (or device-bound local accounts for the Electron channel).
+- Add session + role storage in Zustand with secure persistence (httpOnly cookie for web, expo-secure-store for RN).
+- Add route guards in the new router (depends on 052) keyed off role claims.
+- Mirror the auth contract in the ASP.NET pipeline + Fastify+Prisma TS API (parity governance).
+
+## Out of Scope *(mandatory)*
+
+- Multi-tenant org switcher.
+- SAML / SCIM provisioning.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/064-frontend-operator-dashboard/spec.md
+++ b/.specify/specs/064-frontend-operator-dashboard/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Operator Dashboard (Metrics + Training Runs)
+
+**Feature Branch**: `064-frontend-operator-dashboard`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: fifth
+**Domain**: react / api
+**Depends on**: #063, #061
+
+## Problem Statement
+
+Backend ships a deep training + governance surface (features 047, 049, 050) that has no human window. Operators read JSON in artifact directories.
+
+## In Scope *(mandatory)*
+
+- Add an `/operator` route group gated by the `operator` role (depends on 063).
+- Surface training-run history, neuro-cycle status, parity-gate results, workflow-recovery counters.
+- Use TanStack Query against new read-only endpoints in the Fastify+Prisma TS API.
+- Stream live run progress when feature 054 is available (deferred enhancement).
+
+## Out of Scope *(mandatory)*
+
+- Mutating training configuration from the UI (read-only in v1).
+- Per-customer dashboards.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/065-frontend-neuro-trace-viewer/spec.md
+++ b/.specify/specs/065-frontend-neuro-trace-viewer/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Real-Time Neuro-Trace Viewer
+
+**Feature Branch**: `065-frontend-neuro-trace-viewer`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: fifth
+**Domain**: react / api
+**Depends on**: #054, #063
+
+## Problem Statement
+
+Feature 050 emits `neuro-trace.json` per training run with reward / surprise / replay metadata that today is only readable by AI agents inspecting the artifact directory.
+
+## In Scope *(mandatory)*
+
+- Expose `artifacts/training/<model>/local/neuro-trace.json` via a read-only API endpoint.
+- Add a viewer route under `/operator/neuro` (depends on 063 + 064).
+- Render the reward window, surprise distribution, replay-buffer size, and forgetting-guard status with sparkline charts.
+- When a training run is live, stream incremental trace updates over SSE (depends on 054).
+
+## Out of Scope *(mandatory)*
+
+- Mutating neuro profile from the UI.
+- Cross-model comparison (single-model view in v1).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).

--- a/.specify/specs/066-mobile-parity-sprint/spec.md
+++ b/.specify/specs/066-mobile-parity-sprint/spec.md
@@ -1,0 +1,31 @@
+# Feature Specification: Mobile Parity Sprint (RN screen depth + share/upload)
+
+**Feature Branch**: `066-mobile-parity-sprint`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by feature 051 frontend-robustness spike)
+**Wave**: fifth
+**Domain**: react-native
+**Depends on**: #053, #057
+
+## Problem Statement
+
+React-Native ships only Capture/History/Verdict screens with no offline cache, no share-target polish, no biometric auth, and no push notifications.
+
+## In Scope *(mandatory)*
+
+- Polish the iOS + Android share extension; route shared images through `share-handler.ts` with retry + queue.
+- Add an offline cache for history using Expo SQLite (or MMKV).
+- Adopt expo-secure-store for credential persistence (depends on 063 once shipped).
+- Add Expo Notifications hooks for verdict-ready and operator-alert events.
+- Match the React app's a11y baseline (depends on 057).
+
+## Out of Scope *(mandatory)*
+
+- Native module rewrites.
+- Replacing Expo with bare React Native.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the 15-feature follow-up inventory in [`.specify/specs/051-frontend-robustness-spike/spec.md`](../051-frontend-robustness-spike/spec.md).


### PR DESCRIPTION
## What this PR does

Spike-only PR. No runtime code, workflows, or trainer outputs are touched.

- **Spike**: `.specify/specs/051-frontend-robustness-spike/spec.md` + `spike-report.md` survey the current React/Electron/RN/shared-UI surface against the depth of the API + native + training infrastructure and identify 9 uplift themes.
- **Scaffold**: 15 follow-up Spec Kit feature stubs (#052-#066), each with title, branch slug, problem statement, in-scope/out-of-scope, dependency wave, and dependency map. Ready for `speckit.specify` expansion.

## The 15 follow-ups

| # | Feature | Wave |
|---|---|---|
| 052 | Frontend routing + multi-page architecture | first |
| 053 | Typed client state baseline (TanStack Query + Zustand) | first |
| 054 | Streaming verdict + chat (SSE) | second |
| 055 | PWA + offline service worker shell | second |
| 056 | Shared UI Storybook + component docs | second |
| 057 | Accessibility WCAG 2.2 AA audit + CI gate | third |
| 058 | i18n + localization scaffold | third |
| 059 | Theming + dark mode via design tokens | third |
| 060 | E2E test harness (Playwright across React/Electron) | third |
| 061 | Frontend observability + Web Vitals | fourth |
| 062 | Performance budget + bundle analysis CI gate | fourth |
| 063 | Auth + session/role-aware UI | fourth |
| 064 | Operator dashboard (metrics + training runs) | fifth |
| 065 | Real-time neuro-trace viewer | fifth |
| 066 | Mobile parity sprint (RN screen depth + share/upload) | fifth |

## Validators

- `validate-ai-contracts.py`: exit 0
- No code edits outside `.specify/specs/051..066`

## Next steps

Pick a first-wave feature (052, 053, or 056), run `speckit.specify` to expand the stub, then `speckit.plan` and `speckit.tasks`.