### PR TITLE
feat(053): typed state baseline — TanStack Query + Zustand (first-wave frontend uplift)

### DIFF
--- a/.specify/specs/053-frontend-typed-state-baseline/spec.md
+++ b/.specify/specs/053-frontend-typed-state-baseline/spec.md
@@ -1,0 +1,52 @@
+# Feature Specification: Typed Client State Baseline (TanStack Query + Zustand)
+
+**Feature Branch**: `053-typed-state-baseline`
+**Created**: 2026-05-01
+**Status**: Implemented (v1 — provider + first hook + UI store)
+**Wave**: first
+**Domain**: react
+**Depends on**: none (pure-frontend; ships from current main)
+
+## Problem Statement
+
+All async state in `src/typescript/react` is local React + ad-hoc `fetch`. There is no cache, no background refresh, no optimistic UI, and no shared client store. Every new screen reinvents these patterns and the resilience-bootstrap queue has to be reasoned about by hand at every call site.
+
+## In Scope *(mandatory)*
+
+- Adopt **TanStack Query v5** as the server-state surface for the React app.
+- Adopt **Zustand** as the client UI-state surface (theme override, panel toggles, future settings).
+- Ship a single `QueryProvider` mounted in `main.tsx` that future hooks consume.
+- Ship one migration example (`useBananaSummary`) so subsequent slices have a pattern.
+- Tests cover the provider defaults and the store contract (initial state, setters, reset).
+
+## Out of Scope *(mandatory)*
+
+- Migrating the entire `App.tsx` fetch surface in one PR (subsequent slices migrate `predictRipeness`, `fetchEnsembleVerdictWithEmbedding`, `createChatSession`, `sendChatMessage`).
+- Replacing the existing `resilience-bootstrap` queue (it remains the durable submit layer).
+- Introducing Redux or RTK.
+- Persisting the Zustand store to localStorage (deferred to feature 059 theming + 063 auth).
+
+## Functional Requirements
+
+- **FR-001**: A `QueryProvider` MUST wrap `<App />` inside `<ErrorBoundary>` in `main.tsx`.
+- **FR-002**: `createBananaQueryClient()` MUST default to `staleTime=60_000`, `gcTime=300_000`, `retry=2`, `refetchOnWindowFocus=false`, `mutations.retry=0`.
+- **FR-003**: `useUiStore` MUST expose `themeOverride` (`system|light|dark`), `escalationPanelOpen`, their setters, and a `reset()`.
+- **FR-004**: `useBananaSummary(baseUrl, enabled?)` MUST wrap `fetchBananaSummary` and only enable the query when `baseUrl` is truthy.
+- **FR-005**: All existing React tests MUST continue to pass (`bun test` in `src/typescript/react`).
+
+## Success Criteria
+
+- **SC-001**: `bun test` exit 0 in `src/typescript/react` (55+ tests).
+- **SC-002**: New deps (`@tanstack/react-query`, `zustand`) install cleanly and the dedupe-react postinstall script keeps a single `react`/`react-dom` copy.
+- **SC-003**: The `useBananaSummary` hook is consumable from any descendant of `<App />` without additional setup.
+
+## Validation evidence
+
+- `bun test`: 55 pass, 0 fail (147 expect calls).
+- New tests:
+  - `src/lib/queryClient.test.ts` (1 test) — provider defaults.
+  - `src/lib/uiStore.test.ts` (4 tests) — store contract.
+
+## Follow-up handoff
+
+Subsequent migrations should land as their own PRs and add one test file per migrated endpoint. Feature 058 (i18n) will plug into `useUiStore` for locale persistence; feature 059 (theming) will read `themeOverride`; feature 063 (auth) will add a `useAuthStore` peer.

--- a/src/typescript/react/bun.lock
+++ b/src/typescript/react/bun.lock
@@ -8,12 +8,14 @@
         "@banana/resilience": "file:../shared/resilience",
         "@banana/ui": "file:../shared/ui",
         "@radix-ui/react-slot": "^1.1.0",
+        "@tanstack/react-query": "^5.59.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "lucide-react": "^0.439.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^2.5.0",
+        "zustand": "^4.5.5",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^15.0.0",
@@ -227,6 +229,10 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.7", "", {}, "sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.7", "", { "dependencies": { "@tanstack/query-core": "5.100.7" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-LoISYWz8dOOuQbeIctF8K6yi42TWtR1WPGpwGuRUpF3u79JVVIg/PVR0MQdIA0VSHqD/ydf/b7PhKTkg3I4fLQ=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
@@ -708,6 +714,8 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
@@ -739,6 +747,8 @@
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "@react-native/community-cli-plugin/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 

--- a/src/typescript/react/package.json
+++ b/src/typescript/react/package.json
@@ -14,12 +14,14 @@
         "@banana/resilience": "file:../shared/resilience",
         "@banana/ui": "file:../shared/ui",
         "@radix-ui/react-slot": "^1.1.0",
+        "@tanstack/react-query": "^5.59.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "lucide-react": "^0.439.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^2.5.0"
+        "tailwind-merge": "^2.5.0",
+        "zustand": "^4.5.5"
     },
     "devDependencies": {
         "@happy-dom/global-registrator": "^15.0.0",

--- a/src/typescript/react/src/lib/api.ts
+++ b/src/typescript/react/src/lib/api.ts
@@ -40,6 +40,8 @@ type BananaSummaryResponse = {
   banana: number;
 };
 
+export type { BananaSummaryResponse };
+
 type ElectronBridge = {
   apiBaseUrl: string; platform: string;
   chatApiBaseUrl?: string;

--- a/src/typescript/react/src/lib/hooks/useBananaSummary.ts
+++ b/src/typescript/react/src/lib/hooks/useBananaSummary.ts
@@ -1,0 +1,27 @@
+/**
+ * Feature 053 — typed state baseline.
+ *
+ * First TanStack Query hook in the migration. Wraps `fetchBananaSummary`
+ * so callers can drop the local `useState` + `useEffect` + `try/catch`
+ * pattern and get cache + retry + background refresh for free.
+ *
+ * Subsequent slices migrate `predictRipeness`, `fetchEnsembleVerdictWith
+ * Embedding`, `createChatSession`, and `sendChatMessage` using the same
+ * pattern.
+ */
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { fetchBananaSummary, type BananaSummaryResponse } from "./api";
+
+export const bananaSummaryKey = (baseUrl: string) =>
+    ["banana", "summary", baseUrl] as const;
+
+export function useBananaSummary(
+    baseUrl: string,
+    enabled = true,
+): UseQueryResult<BananaSummaryResponse, Error> {
+    return useQuery({
+        queryKey: bananaSummaryKey(baseUrl),
+        queryFn: () => fetchBananaSummary(baseUrl),
+        enabled: enabled && Boolean(baseUrl),
+    });
+}

--- a/src/typescript/react/src/lib/queryClient.test.ts
+++ b/src/typescript/react/src/lib/queryClient.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Feature 053 — typed state baseline tests.
+ *
+ * Verifies the QueryClient defaults so future migrations cannot silently
+ * regress retry / staleTime behavior the resilience layer relies on.
+ */
+import { describe, expect, it } from "bun:test";
+import { createBananaQueryClient } from "./queryClient";
+
+describe("createBananaQueryClient (feature 053)", () => {
+    it("applies the documented defaults", () => {
+        const client = createBananaQueryClient();
+        const defaults = client.getDefaultOptions();
+        expect(defaults.queries?.staleTime).toBe(60_000);
+        expect(defaults.queries?.gcTime).toBe(5 * 60_000);
+        expect(defaults.queries?.retry).toBe(2);
+        expect(defaults.queries?.refetchOnWindowFocus).toBe(false);
+        expect(defaults.mutations?.retry).toBe(0);
+    });
+});

--- a/src/typescript/react/src/lib/queryClient.tsx
+++ b/src/typescript/react/src/lib/queryClient.tsx
@@ -1,0 +1,34 @@
+/**
+ * Feature 053 — typed state baseline.
+ *
+ * Centralized TanStack Query client + provider. Subsequent slices (054
+ * streaming, 064 operator dashboard, 065 neuro-trace viewer) consume this
+ * provider; v1 ships the provider plus a single `useBananaSummary` hook so
+ * the migration pattern is established without rewriting App.tsx in one go.
+ */
+import { ReactNode, useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export function createBananaQueryClient(): QueryClient {
+    return new QueryClient({
+        defaultOptions: {
+            queries: {
+                // Server state stays fresh for one minute by default; matches
+                // the cadence the resilience-bootstrap queue uses for retry
+                // bookkeeping. Individual hooks can override.
+                staleTime: 60_000,
+                gcTime: 5 * 60_000,
+                retry: 2,
+                refetchOnWindowFocus: false,
+            },
+            mutations: {
+                retry: 0,
+            },
+        },
+    });
+}
+
+export function QueryProvider({ children }: { children: ReactNode }): JSX.Element {
+    const [client] = useState(() => createBananaQueryClient());
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/src/typescript/react/src/lib/uiStore.test.ts
+++ b/src/typescript/react/src/lib/uiStore.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Feature 053 — typed state baseline tests.
+ *
+ * Verifies the Zustand UI store contract (initial values, setters, reset).
+ * Server-state hook tests live with their owning hook file.
+ */
+import { describe, expect, it, beforeEach } from "bun:test";
+import { useUiStore } from "./uiStore";
+
+describe("uiStore (feature 053)", () => {
+    beforeEach(() => {
+        useUiStore.getState().reset();
+    });
+
+    it("seeds with system theme and closed escalation panel", () => {
+        const state = useUiStore.getState();
+        expect(state.themeOverride).toBe("system");
+        expect(state.escalationPanelOpen).toBe(false);
+    });
+
+    it("setThemeOverride mutates only the theme slice", () => {
+        useUiStore.getState().setThemeOverride("dark");
+        expect(useUiStore.getState().themeOverride).toBe("dark");
+        expect(useUiStore.getState().escalationPanelOpen).toBe(false);
+    });
+
+    it("setEscalationPanelOpen toggles independently", () => {
+        useUiStore.getState().setEscalationPanelOpen(true);
+        expect(useUiStore.getState().escalationPanelOpen).toBe(true);
+        expect(useUiStore.getState().themeOverride).toBe("system");
+    });
+
+    it("reset returns the store to its seed values", () => {
+        const s = useUiStore.getState();
+        s.setThemeOverride("light");
+        s.setEscalationPanelOpen(true);
+        s.reset();
+        const after = useUiStore.getState();
+        expect(after.themeOverride).toBe("system");
+        expect(after.escalationPanelOpen).toBe(false);
+    });
+});

--- a/src/typescript/react/src/lib/uiStore.ts
+++ b/src/typescript/react/src/lib/uiStore.ts
@@ -1,0 +1,34 @@
+/**
+ * Feature 053 — typed state baseline.
+ *
+ * Zustand store for client-only UI state. Server state lives in TanStack
+ * Query; this store is for local preferences (theme override, last-opened
+ * panel, etc.) that need to survive route changes once feature 052 lands.
+ *
+ * Persistence is intentionally minimal in v1: state lives in memory only.
+ * Feature 059 (theming) and 063 (auth) will add localStorage persistence
+ * once the contract for what is safe to persist is decided.
+ */
+import { create } from "zustand";
+
+export type ThemeOverride = "system" | "light" | "dark";
+
+export type UiState = {
+    themeOverride: ThemeOverride;
+    setThemeOverride: (override: ThemeOverride) => void;
+    escalationPanelOpen: boolean;
+    setEscalationPanelOpen: (open: boolean) => void;
+    reset: () => void;
+};
+
+const INITIAL = {
+    themeOverride: "system" as ThemeOverride,
+    escalationPanelOpen: false,
+};
+
+export const useUiStore = create<UiState>((set) => ({
+    ...INITIAL,
+    setThemeOverride: (override) => set({ themeOverride: override }),
+    setEscalationPanelOpen: (open) => set({ escalationPanelOpen: open }),
+    reset: () => set({ ...INITIAL }),
+}));

--- a/src/typescript/react/src/main.tsx
+++ b/src/typescript/react/src/main.tsx
@@ -2,12 +2,15 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { QueryProvider } from "./lib/queryClient";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
     <StrictMode>
         <ErrorBoundary>
-            <App />
+            <QueryProvider>
+                <App />
+            </QueryProvider>
         </ErrorBoundary>
     </StrictMode>,
 );


### PR DESCRIPTION
First-wave delivery from the feature 051 frontend-robustness spike.

## What ships

- **Provider**: `src/typescript/react/src/lib/queryClient.tsx` — `QueryProvider` mounted in `main.tsx` between `ErrorBoundary` and `App`. Defaults: staleTime 60s, gcTime 5m, retry 2, refetchOnWindowFocus false, mutations.retry 0.
- **Client store**: `src/typescript/react/src/lib/uiStore.ts` — Zustand store for theme override + escalation panel, with `reset()`.
- **First hook**: `src/typescript/react/src/lib/hooks/useBananaSummary.ts` — migration pattern for subsequent slices.
- **Deps**: `@tanstack/react-query@^5.59.0`, `zustand@^4.5.5`. Dedupe-react postinstall keeps a single React copy.
- **Tests**: 5 new tests; 55/55 react suite green.

## What does NOT change

- `App.tsx` is untouched — incremental migration ships in subsequent slices.
- `resilience-bootstrap` queue is unchanged.
- No API or native changes.

## Validators

- `bun test` (react): 55 pass / 0 fail
- `validate-ai-contracts.py`: exit 0
- `validate-workflow-dependencies.sh`: ok

## Next slice

Migrate `predictRipeness` -> `useRipenessPrediction` and `fetchEnsembleVerdictWithEmbedding` -> `useEnsembleVerdict` in follow-up PRs against this same baseline.