### PR TITLE
plan: scaffold 20 cross-domain follow-up specs (#067-#086)

### DIFF
--- a/.specify/specs/067-api-openapi-and-typed-clients/spec.md
+++ b/.specify/specs/067-api-openapi-and-typed-clients/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: API OpenAPI Generation + Typed Clients
+
+**Feature Branch**: `067-api-openapi-and-typed-clients`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: first
+**Domain**: api / react / electron
+**Depends on**: none
+
+## Problem Statement
+
+Both API surfaces (Fastify+Prisma TS and ASP.NET) hand-roll request/response types, and clients duplicate them. There is no machine-checkable contract beyond the parity governance (feature 047) which compares semantics, not schemas.
+
+## In Scope *(mandatory)*
+
+- Emit OpenAPI 3.1 spec from both API surfaces during their build.
+- Generate typed TS clients for React, Electron, and React-Native consumers.
+- Add a CI lane that diffs the two emitted specs (parity check at the schema level).
+- Wire generated types into the TanStack Query hooks introduced by feature 053.
+
+## Out of Scope *(mandatory)*
+
+- Replacing the parity-governance lane (it stays, schema diff is additive).
+- GraphQL or gRPC migration.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/068-api-rate-limiting-and-abuse-protection/spec.md
+++ b/.specify/specs/068-api-rate-limiting-and-abuse-protection/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: API Rate Limiting & Abuse Protection
+
+**Feature Branch**: `068-api-rate-limiting-and-abuse-protection`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: second
+**Domain**: api
+**Depends on**: #063
+
+## Problem Statement
+
+Neither API surface has rate limiting. A noisy client or a runaway training-trigger can saturate the pipeline. Once auth ships (feature 063) per-principal limits become the natural primitive.
+
+## In Scope *(mandatory)*
+
+- Add token-bucket rate limiting to Fastify+Prisma TS API and ASP.NET pipeline.
+- Tier limits by route class (read / write / training-trigger / admin).
+- Surface 429 + Retry-After uniformly; consumers respect headers.
+- Mirror limits across both surfaces (parity governance).
+
+## Out of Scope *(mandatory)*
+
+- Bot-detection / fingerprinting heuristics.
+- DDoS protection at the edge (out of repo scope).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/069-api-audit-log-surface/spec.md
+++ b/.specify/specs/069-api-audit-log-surface/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: API Audit Log Surface
+
+**Feature Branch**: `069-api-audit-log-surface`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: third
+**Domain**: api
+**Depends on**: #063
+
+## Problem Statement
+
+Training triggers, model promotions, and operator actions are not auditable. Compliance and incident response need an immutable trail.
+
+## In Scope *(mandatory)*
+
+- Add an `audit_event` table + writer middleware to the TS API.
+- Mirror the writer in ASP.NET pipeline.
+- Expose a filtered read endpoint gated by the operator role.
+- Retention policy + deletion / export contract documented in the wiki.
+
+## Out of Scope *(mandatory)*
+
+- External SIEM integration (provide an export endpoint instead).
+- PII redaction tooling beyond field allowlists.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/070-api-background-jobs-runner/spec.md
+++ b/.specify/specs/070-api-background-jobs-runner/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Background Job Runner (Durable Queue)
+
+**Feature Branch**: `070-api-background-jobs-runner`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: second
+**Domain**: api
+**Depends on**: none
+
+## Problem Statement
+
+Long-running training triggers and PR-opener calls run inline on request handlers. Failures lose work, and operators cannot see what's pending.
+
+## In Scope *(mandatory)*
+
+- Adopt a durable job queue (BullMQ on Redis, or PostgreSQL-backed via pg-boss).
+- Move triggered-training, evidence-PR opener, and consolidation hand-off into jobs.
+- Add a small admin surface listing pending / failed / completed jobs.
+- Idempotency keys on all enqueue paths.
+
+## Out of Scope *(mandatory)*
+
+- Replacing the workflow orchestrator (feature 049) — the queue runs inside the API tier.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/071-api-webhook-delivery-system/spec.md
+++ b/.specify/specs/071-api-webhook-delivery-system/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Outbound Webhook Delivery System
+
+**Feature Branch**: `071-api-webhook-delivery-system`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: fourth
+**Domain**: api
+**Depends on**: #070
+
+## Problem Statement
+
+External systems cannot subscribe to Banana events (verdict produced, model promoted, training failed). Today every integration is a polling client.
+
+## In Scope *(mandatory)*
+
+- Add subscriber + delivery-attempt tables and an admin CRUD surface.
+- Sign payloads with HMAC-SHA256 + signing-secret rotation.
+- Use the durable job queue (feature 070) for retries with exponential backoff.
+- Document the contract (event types, payload schemas, replay endpoint) in the wiki.
+
+## Out of Scope *(mandatory)*
+
+- Inbound webhook receivers.
+- Multi-tenant per-subscriber filtering rules (basic event-type filter only in v1).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/072-native-abi-versioning-contract/spec.md
+++ b/.specify/specs/072-native-abi-versioning-contract/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Native ABI Versioning + Compatibility Contract
+
+**Feature Branch**: `072-native-abi-versioning-contract`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: first
+**Domain**: native / api-interop
+**Depends on**: none
+
+## Problem Statement
+
+The native wrapper exports symbols that the C# interop and downstream consumers depend on, but there is no semver discipline or compatibility CI. A silent ABI break would only surface at runtime.
+
+## In Scope *(mandatory)*
+
+- Stamp `libbanana_native` with a version + ABI hash exported via `banana_native_version()`.
+- Add a CI lane that diffs exported symbols + struct sizes against the prior tag.
+- Document the deprecation policy + grace period in `.specify/wiki/human-reference/`.
+- Update the C# interop to assert the expected ABI version at startup.
+
+## Out of Scope *(mandatory)*
+
+- Cross-platform shared libs beyond Linux x86_64 (handed to feature 074).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/073-native-sanitizer-ci-lane/spec.md
+++ b/.specify/specs/073-native-sanitizer-ci-lane/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Native Sanitizer CI Lane (ASAN / UBSAN / MSAN)
+
+**Feature Branch**: `073-native-sanitizer-ci-lane`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: second
+**Domain**: native
+**Depends on**: none
+
+## Problem Statement
+
+Native tests run with default flags. Memory leaks, undefined behavior, and use-after-free are not caught until production telemetry sees them (and there is no production telemetry yet either).
+
+## In Scope *(mandatory)*
+
+- Add a CMake preset that builds with `-fsanitize=address,undefined` (and a separate MSAN build).
+- Run the existing `tests/native` suite under each sanitizer in CI.
+- Triage failing cases as either fix-now or `LeakSanitizer.suppressions` entries with PR review.
+- Publish the suppression file as an artifact with each run.
+
+## Out of Scope *(mandatory)*
+
+- TSAN coverage in v1 (deferred — needs MT model audit first).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/074-native-cross-platform-build-matrix/spec.md
+++ b/.specify/specs/074-native-cross-platform-build-matrix/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Cross-Platform Native Build Matrix (linux/mac/win, x86_64/arm64)
+
+**Feature Branch**: `074-native-cross-platform-build-matrix`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: third
+**Domain**: native / infra
+**Depends on**: #072
+
+## Problem Statement
+
+Native binaries only ship for linux/x86_64. Apple Silicon developers and any future arm64 server target are blind.
+
+## In Scope *(mandatory)*
+
+- Extend CMake presets and CI matrix to cover linux/x86_64, linux/arm64, macos/arm64, windows/x86_64.
+- Cross-compile via clang or use github-hosted runners per arch as available.
+- Publish artifacts under `out/native/<triple>/` and update consumers (compose, dotnet) to pick the right triple.
+- Document download/install surface in the wiki.
+
+## Out of Scope *(mandatory)*
+
+- FreeBSD / illumos builds.
+- Static linking decisions (preserve current dynamic-link contract).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/075-native-pgo-and-perf-baseline/spec.md
+++ b/.specify/specs/075-native-pgo-and-perf-baseline/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Native PGO + Performance Baseline
+
+**Feature Branch**: `075-native-pgo-and-perf-baseline`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: fourth
+**Domain**: native
+**Depends on**: #073
+
+## Problem Statement
+
+There is no performance baseline on the native pipeline; classifier latency drifts can land unnoticed.
+
+## In Scope *(mandatory)*
+
+- Add a benchmark harness (Google Benchmark or hyperfine) covering the hot paths.
+- Land a PGO build pipeline (gcc/clang `-fprofile-generate` -> training corpus -> `-fprofile-use`).
+- Publish a baseline artifact (latency percentiles + instruction count) on each main commit.
+- CI lane fails if p95 regresses by >10% without an exception label.
+
+## Out of Scope *(mandatory)*
+
+- Hardware-specific tuning (-march=native is gated to local builds only).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/076-training-cross-model-joint-pipeline/spec.md
+++ b/.specify/specs/076-training-cross-model-joint-pipeline/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Cross-Model Joint Training Pipeline
+
+**Feature Branch**: `076-training-cross-model-joint-pipeline`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: fifth
+**Domain**: training
+**Depends on**: #050, #079
+
+## Problem Statement
+
+Banana, not-banana, and ripeness train independently. Shared signals (image features, surprise weights, replay items) are duplicated and inconsistent. The neuro layer (feature 050) explicitly deferred this.
+
+## In Scope *(mandatory)*
+
+- Introduce a shared feature-extraction stage that all three trainers can consume.
+- Add a joint-training profile that updates all three heads against a unified replay buffer.
+- Preserve the per-model deterministic outputs (single-model trainers stay bit-for-bit identical).
+- Document the conditions under which joint training is safe vs. risky.
+
+## Out of Scope *(mandatory)*
+
+- Replacing the existing per-model trainers (joint mode is additive).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/077-training-active-learning-loop/spec.md
+++ b/.specify/specs/077-training-active-learning-loop/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Active Learning Loop with Human-in-the-Loop
+
+**Feature Branch**: `077-training-active-learning-loop`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: fourth
+**Domain**: training / api / react
+**Depends on**: #050, #064
+
+## Problem Statement
+
+The neuro REM pass surfaces high-surprise items but there is no UI to label them. Operators must inspect JSON files.
+
+## In Scope *(mandatory)*
+
+- Add an API surface for queued label requests + label submission.
+- Add an `/operator/label-queue` UI route (depends on feature 064).
+- Feed accepted labels back into `data/<model>/corpus.json` via signed evidence PRs.
+- Track inter-rater agreement when more than one operator participates.
+
+## Out of Scope *(mandatory)*
+
+- Crowd-sourcing or external annotator integration.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/078-training-drift-detection-on-inference/spec.md
+++ b/.specify/specs/078-training-drift-detection-on-inference/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Drift Detection on Production Inference
+
+**Feature Branch**: `078-training-drift-detection-on-inference`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: fourth
+**Domain**: api / training
+**Depends on**: #061
+
+## Problem Statement
+
+There is no monitoring of input distribution or output entropy on production inference. A corpus / population shift would only surface as an accuracy regression in the next training cycle.
+
+## In Scope *(mandatory)*
+
+- Add a sampling middleware on both API surfaces that records input fingerprint + verdict distribution.
+- Compute population stability index (PSI) + KL divergence vs. the training reference set on a schedule.
+- Alert (via the audit log + observability surface) when drift exceeds a configurable threshold.
+- Document the operator runbook for drift triage.
+
+## Out of Scope *(mandatory)*
+
+- Automated retraining on drift (decision stays human-in-the-loop in v1).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/079-training-model-registry-signed-releases/spec.md
+++ b/.specify/specs/079-training-model-registry-signed-releases/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Model Registry + Signed Releases
+
+**Feature Branch**: `079-training-model-registry-signed-releases`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: third
+**Domain**: training / infra
+**Depends on**: none
+
+## Problem Statement
+
+Models are promoted by copying artifacts. There is no signed manifest, no rollback contract, and no audit of which model served which inference.
+
+## In Scope *(mandatory)*
+
+- Stand up a model registry (lightweight: PG table + content-addressed artifact store on S3 / MinIO).
+- Sign release manifests with cosign or minisign; verify on load.
+- API records the active model id + manifest hash in every verdict response.
+- Operator action 'rollback' surfaces a prior signed manifest atomically.
+
+## Out of Scope *(mandatory)*
+
+- External MLflow / Weights & Biases integration.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/080-training-ab-harness-live-comparison/spec.md
+++ b/.specify/specs/080-training-ab-harness-live-comparison/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: A/B Harness for Live Model Comparison
+
+**Feature Branch**: `080-training-ab-harness-live-comparison`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: fifth
+**Domain**: api / training
+**Depends on**: #079, #061
+
+## Problem Statement
+
+There is no way to ship two trained variants and compare them on real traffic. Promotion decisions are made on holdout accuracy alone.
+
+## In Scope *(mandatory)*
+
+- Add a traffic-splitting layer in both API surfaces (sticky on session id).
+- Record per-variant verdicts + outcomes in the audit log.
+- Operator dashboard surfaces variant comparison (depends on feature 064).
+- Tear-down contract: variants automatically retire after a configurable window unless promoted.
+
+## Out of Scope *(mandatory)*
+
+- Bandit / contextual-bandit allocation in v1 (fixed splits only).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/081-infra-helm-and-k8s-manifests/spec.md
+++ b/.specify/specs/081-infra-helm-and-k8s-manifests/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: Helm Chart + Kubernetes Manifests
+
+**Feature Branch**: `081-infra-helm-and-k8s-manifests`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: fourth
+**Domain**: infra
+**Depends on**: none
+
+## Problem Statement
+
+Banana ships compose-only. Production-grade deployment requires k8s manifests with proper liveness/readiness, autoscaling, and resource limits.
+
+## In Scope *(mandatory)*
+
+- Author Helm chart covering API (TS + ASP.NET), Postgres operator dep, native job runner, observability sidecars.
+- Define liveness/readiness probes + HPA policies aligned with current compose health checks.
+- Document the compose-vs-k8s contract; compose stays canonical for local + CI.
+- Add a smoke deploy lane against kind / k3d in CI.
+
+## Out of Scope *(mandatory)*
+
+- Service mesh (Istio/Linkerd) selection.
+- Multi-cluster topology.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/082-infra-secrets-management-vault/spec.md
+++ b/.specify/specs/082-infra-secrets-management-vault/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Secrets Management (Vault Integration)
+
+**Feature Branch**: `082-infra-secrets-management-vault`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: fourth
+**Domain**: infra / api
+**Depends on**: none
+
+## Problem Statement
+
+Secrets live in env files and per-developer machines. There is no rotation, no audit, no centralized policy.
+
+## In Scope *(mandatory)*
+
+- Adopt HashiCorp Vault (or equivalent) for runtime secret distribution.
+- Replace `BANANA_PG_CONNECTION` and similar env-var contracts with Vault-issued credentials.
+- Rotation policy + audit pulled into the operator dashboard (feature 064).
+- Local dev keeps `.env` workflow with explicit guard rails.
+
+## Out of Scope *(mandatory)*
+
+- Replacing GitHub Actions secrets surface for CI.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/083-infra-disaster-recovery-and-backups/spec.md
+++ b/.specify/specs/083-infra-disaster-recovery-and-backups/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Disaster Recovery + Automated Backups
+
+**Feature Branch**: `083-infra-disaster-recovery-and-backups`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: fifth
+**Domain**: infra
+**Depends on**: #079
+
+## Problem Statement
+
+Postgres backups + model artifact archives are manual. There is no documented RPO/RTO and no restore drill.
+
+## In Scope *(mandatory)*
+
+- Automate Postgres `pg_basebackup` + WAL archive to object storage.
+- Snapshot model registry (feature 079) and replay buffers on a schedule.
+- Document RPO=15min / RTO=1h targets; quarterly restore drill workflow.
+- Restore-test job runs in CI nightly against a small-data fixture.
+
+## Out of Scope *(mandatory)*
+
+- Multi-region active-active topology.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/084-infra-multi-arch-container-images/spec.md
+++ b/.specify/specs/084-infra-multi-arch-container-images/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Multi-Architecture Container Images
+
+**Feature Branch**: `084-infra-multi-arch-container-images`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: third
+**Domain**: infra
+**Depends on**: #074
+
+## Problem Statement
+
+Container images are amd64 only. Apple Silicon developers compile inside Rosetta and arm64 servers are unsupported.
+
+## In Scope *(mandatory)*
+
+- Convert each Dockerfile to multi-arch via `docker buildx`.
+- Publish manifests covering linux/amd64 + linux/arm64.
+- Update compose health checks + smoke flows to verify both arches.
+- Pin base-image digests + record per-arch SBOM (handed to feature 086).
+
+## Out of Scope *(mandatory)*
+
+- windows/amd64 container variants.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/085-quality-mutation-testing-baseline/spec.md
+++ b/.specify/specs/085-quality-mutation-testing-baseline/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Mutation Testing Baseline (PIT / Stryker)
+
+**Feature Branch**: `085-quality-mutation-testing-baseline`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: fourth
+**Domain**: tests
+**Depends on**: none
+
+## Problem Statement
+
+Coverage is high (feature 003 rehydration) but coverage doesn't measure assertion strength. A test can execute a line and assert nothing meaningful.
+
+## In Scope *(mandatory)*
+
+- Adopt Stryker for the TS surface and PIT for the .NET surface.
+- Run on a path-scoped CI lane (touching `Banana.Api`, `src/typescript/api`, or `tests/`).
+- Establish a baseline mutation score per project; fail PRs that regress by >5%.
+- Allowlist for known-low-value mutants.
+
+## Out of Scope *(mandatory)*
+
+- Native mutation testing (no good tooling for our C surface).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).

--- a/.specify/specs/086-supply-chain-sbom-and-signing/spec.md
+++ b/.specify/specs/086-supply-chain-sbom-and-signing/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Supply-Chain Hardening (SBOM + Signed Releases)
+
+**Feature Branch**: `086-supply-chain-sbom-and-signing`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 067 cross-domain follow-up planning)
+**Wave**: third
+**Domain**: infra / workflow
+**Depends on**: #084
+
+## Problem Statement
+
+Container images and shipped binaries have no SBOM, no provenance attestation, and no signature. Downstream consumers cannot verify what they ran.
+
+## In Scope *(mandatory)*
+
+- Generate CycloneDX SBOMs for every shipped image and binary.
+- Sign images with cosign keyless OIDC (GitHub Actions OIDC token).
+- Publish SLSA Level 3 provenance attestations.
+- Document the verification contract for downstream consumers.
+
+## Out of Scope *(mandatory)*
+
+- Custom CA / private signing infra in v1 (keyless OIDC is sufficient).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the cross-domain planning batch documented in [`.specify/specs/067-cross-domain-followup-planning/spec.md`](../067-cross-domain-followup-planning/spec.md).


### PR DESCRIPTION
Continues the planning work started by feature 051 (frontend) — extends the backlog into API depth, native quality, training/ML maturity, infrastructure/SRE, and supply-chain.

## The 20 follow-ups

### API depth (5)
- 067 OpenAPI generation + typed clients (first wave)
- 068 Rate limiting & abuse protection (second)
- 069 Audit log surface (third)
- 070 Background job runner (durable queue) (second)
- 071 Outbound webhook delivery system (fourth)

### Native quality (4)
- 072 ABI versioning + compatibility contract (first)
- 073 Sanitizer CI lane (ASAN / UBSAN / MSAN) (second)
- 074 Cross-platform native build matrix (third)
- 075 PGO + performance baseline (fourth)

### Training / ML maturity (5)
- 076 Cross-model joint training pipeline (fifth)
- 077 Active learning loop with human-in-the-loop (fourth)
- 078 Drift detection on production inference (fourth)
- 079 Model registry + signed releases (third)
- 080 A/B harness for live model comparison (fifth)

### Infrastructure / SRE (4)
- 081 Helm chart + k8s manifests (fourth)
- 082 Secrets management (Vault) (fourth)
- 083 Disaster recovery + automated backups (fifth)
- 084 Multi-architecture container images (third)

### Quality + supply chain (2)
- 085 Mutation testing baseline (PIT / Stryker) (fourth)
- 086 Supply-chain hardening (SBOM + cosign + SLSA) (third)

## Wave summary

| Wave | Specs |
|---|---|
| First | 067, 072 |
| Second | 068, 070, 073 |
| Third | 069, 074, 079, 084, 086 |
| Fourth | 071, 075, 077, 078, 081, 082, 085 |
| Fifth | 076, 080, 083 |

## Validators

- `validate-ai-contracts.py`: exit 0
- No code edits outside `.specify/specs/067..086`

## Total backlog after this PR

51 stub features in flight (#052-#066 frontend uplift + #067-#086 cross-domain). The Banana planner agent can now sequence work for many sprints without additional ideation overhead.