### PR TITLE
plan: scaffold 15 additional follow-up specs (#087-#101)

### DIFF
--- a/.specify/specs/087-devex-monorepo-task-graph/spec.md
+++ b/.specify/specs/087-devex-monorepo-task-graph/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Monorepo Task Graph (Nx / Turbo / Bun workspaces)
+
+**Feature Branch**: `087-devex-monorepo-task-graph`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: third
+**Domain**: devex / infra
+**Depends on**: none
+
+## Problem Statement
+
+Cross-workspace builds re-run unchanged work. There is no incremental task graph spanning Bun workspaces, dotnet projects, and CMake targets.
+
+## In Scope *(mandatory)*
+
+- Adopt a task-graph runner (Turborepo for TS, integrated with dotnet+CMake via wrapper scripts).
+- Cache build + test outputs keyed on input hashes; share cache in CI via remote cache backend.
+- Document the canonical command surface (`bun run check`, `bun run test`, etc.) in the wiki.
+- Measure CI wall-clock improvement; target -40% on no-op PRs.
+
+## Out of Scope *(mandatory)*
+
+- Replacing existing `scripts/*.sh` entry points (the runner wraps them).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/088-devex-devcontainer-and-codespaces/spec.md
+++ b/.specify/specs/088-devex-devcontainer-and-codespaces/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Dev Container + GitHub Codespaces Onboarding
+
+**Feature Branch**: `088-devex-devcontainer-and-codespaces`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: second
+**Domain**: devex / infra
+**Depends on**: none
+
+## Problem Statement
+
+New contributors must follow a long onboarding doc to get the toolchain working (Bun, .NET 9, CMake, native libs, Postgres). A devcontainer collapses this to one click.
+
+## In Scope *(mandatory)*
+
+- Author `.devcontainer/devcontainer.json` covering Bun + .NET + CMake + Postgres + native deps.
+- Validate it in GitHub Codespaces and locally in VS Code Dev Containers.
+- Smoke a sample feature loop (`bun run check` + `dotnet test`) on first attach.
+- Document the choice between devcontainer and the native Ubuntu WSL2 contract.
+
+## Out of Scope *(mandatory)*
+
+- Replacing the Ubuntu WSL2 runtime contract — devcontainer is additive.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/089-devex-pre-commit-hooks-baseline/spec.md
+++ b/.specify/specs/089-devex-pre-commit-hooks-baseline/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Pre-commit Hook Baseline (lint + format + secret scan)
+
+**Feature Branch**: `089-devex-pre-commit-hooks-baseline`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: first
+**Domain**: devex
+**Depends on**: none
+
+## Problem Statement
+
+Lint + format + secret-detection only run in CI; broken commits land on feature branches and waste review time.
+
+## In Scope *(mandatory)*
+
+- Adopt `pre-commit` framework with hooks for prettier, biome, dotnet format, clang-format, ruff, and gitleaks.
+- Hooks use the same configs as the CI lanes (single source of truth).
+- Document opt-in install (`pre-commit install`) and the bypass policy.
+- CI lane verifies the hook config still matches the CI checks (no drift).
+
+## Out of Scope *(mandatory)*
+
+- Forcing hooks for all contributors (opt-in only).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/090-devex-feature-flag-platform/spec.md
+++ b/.specify/specs/090-devex-feature-flag-platform/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Feature Flag Platform (OpenFeature)
+
+**Feature Branch**: `090-devex-feature-flag-platform`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: third
+**Domain**: devex / api / react
+**Depends on**: none
+
+## Problem Statement
+
+There is no feature-flag primitive. Risky changes either gate behind env vars or merge as big-bang releases.
+
+## In Scope *(mandatory)*
+
+- Adopt OpenFeature SDK across React, Electron, TS API, and ASP.NET API.
+- Provider: start with a Postgres-backed flag store; allow swap to LaunchDarkly / Flagsmith later.
+- Operator dashboard (feature 064) surfaces flag state + per-flag rollout %.
+- Document evaluation contract: server-side decisions only for security-sensitive flags.
+
+## Out of Scope *(mandatory)*
+
+- A/B experimentation (handed to feature 080).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/091-devex-error-tracking-sentry/spec.md
+++ b/.specify/specs/091-devex-error-tracking-sentry/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Error Tracking (Sentry / OpenTelemetry Errors)
+
+**Feature Branch**: `091-devex-error-tracking-sentry`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: third
+**Domain**: devex / observability
+**Depends on**: #061
+
+## Problem Statement
+
+Runtime errors in React, Electron, both APIs, and the React-Native client surface only as logs. There is no aggregated, deduplicated error inbox.
+
+## In Scope *(mandatory)*
+
+- Wire Sentry SDK (or OTel logs + Grafana errors) into all five runtimes.
+- Source-map upload from React + Electron CI builds.
+- Release tagging tied to git SHA + model registry id (feature 079).
+- Operator dashboard (064) links to error inbox; alerts wired to PagerDuty/Slack.
+
+## Out of Scope *(mandatory)*
+
+- Performance monitoring (handed to feature 092).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/092-perf-rum-and-core-web-vitals/spec.md
+++ b/.specify/specs/092-perf-rum-and-core-web-vitals/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Real-User Monitoring + Core Web Vitals Budget
+
+**Feature Branch**: `092-perf-rum-and-core-web-vitals`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: third
+**Domain**: frontend / observability
+**Depends on**: #061
+
+## Problem Statement
+
+Frontend perf is measured ad-hoc on developer machines. There is no production CWV budget or RUM data feeding back to the team.
+
+## In Scope *(mandatory)*
+
+- Add web-vitals + RUM beacon (Sentry RUM or self-hosted).
+- Per-route LCP/INP/CLS budgets; CI lane fails on >10% lab regression.
+- Operator dashboard (064) surfaces p75 vitals over time.
+- Document the perf-budget contract for new routes.
+
+## Out of Scope *(mandatory)*
+
+- Synthetic monitoring (handed to feature 093).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/093-perf-synthetic-monitoring-blackbox/spec.md
+++ b/.specify/specs/093-perf-synthetic-monitoring-blackbox/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Synthetic / Black-Box Monitoring
+
+**Feature Branch**: `093-perf-synthetic-monitoring-blackbox`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: fourth
+**Domain**: infra / observability
+**Depends on**: #063
+
+## Problem Statement
+
+Production health is judged by absence of error reports. A canary that exercises the verdict pipeline end-to-end every minute would catch regressions earlier.
+
+## In Scope *(mandatory)*
+
+- Stand up a synthetic-runner (k6 cloud or self-hosted Playwright cron).
+- Cover: anonymous read endpoints, authenticated verdict round-trip, training-trigger smoke.
+- Alert on missed-checkin or SLO-burn (latency / error rate).
+- Publish public status page driven by synthetic results.
+
+## Out of Scope *(mandatory)*
+
+- Multi-region synthetics in v1.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/094-perf-load-testing-baseline/spec.md
+++ b/.specify/specs/094-perf-load-testing-baseline/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Load Testing Baseline (k6 / Locust)
+
+**Feature Branch**: `094-perf-load-testing-baseline`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: fourth
+**Domain**: tests / infra
+**Depends on**: none
+
+## Problem Statement
+
+There is no documented capacity baseline. We do not know at what RPS the verdict pipeline degrades, nor when the native pipeline becomes the bottleneck.
+
+## In Scope *(mandatory)*
+
+- Author k6 scripts covering the four canonical user journeys.
+- Run nightly against an ephemeral compose stack; publish RPS-vs-latency curves.
+- Capacity-planning doc updated each release with the latest curves.
+- PR lane optionally runs a small load-smoke (1k requests) on perf-sensitive changes.
+
+## Out of Scope *(mandatory)*
+
+- Continuous load against production.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/095-data-postgres-migration-discipline/spec.md
+++ b/.specify/specs/095-data-postgres-migration-discipline/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Postgres Migration Discipline (Prisma + EF Parity)
+
+**Feature Branch**: `095-data-postgres-migration-discipline`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: second
+**Domain**: api / data
+**Depends on**: none
+
+## Problem Statement
+
+Prisma migrations and EF Core migrations evolve independently against the same database. There is no canonical schema source and no backward-compat policy.
+
+## In Scope *(mandatory)*
+
+- Pick Prisma as the canonical schema authority; EF generates code-first models from the same DB.
+- Add a CI lane that diffs the live schema against both ORMs after migration.
+- Backward-compatibility policy: every migration must be reversible or paired with a code-only follow-up.
+- Document the migration-review checklist in the wiki.
+
+## Out of Scope *(mandatory)*
+
+- Replacing EF Core (the parity continues; only schema authority is unified).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/096-data-pii-classification-and-redaction/spec.md
+++ b/.specify/specs/096-data-pii-classification-and-redaction/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: PII Classification + Field-Level Redaction
+
+**Feature Branch**: `096-data-pii-classification-and-redaction`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: fourth
+**Domain**: api / data
+**Depends on**: #069
+
+## Problem Statement
+
+There is no inventory of which columns hold PII, no field-level encryption, and the audit log (069) cannot redact safely without one.
+
+## In Scope *(mandatory)*
+
+- Annotate Prisma + EF schemas with PII classification (`@pii(level=...)`).
+- Generate redaction middleware from the annotations; applied to logs + audit + export.
+- Field-level encryption for high-sensitivity columns (KMS key from feature 082).
+- GDPR right-to-erasure endpoint backed by the inventory.
+
+## Out of Scope *(mandatory)*
+
+- Cross-system PII discovery (only repo-defined schemas in v1).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/097-data-event-sourcing-for-training/spec.md
+++ b/.specify/specs/097-data-event-sourcing-for-training/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Event Sourcing for Training Lifecycle
+
+**Feature Branch**: `097-data-event-sourcing-for-training`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: fifth
+**Domain**: data / training
+**Depends on**: #070, #079
+
+## Problem Statement
+
+The training lifecycle (corpus add -> trigger -> evidence PR -> promotion) is reconstructable only by reading scattered logs. An event-sourced view enables replay + debugging + compliance.
+
+## In Scope *(mandatory)*
+
+- Define the canonical event schema covering corpus, training, evidence, and promotion.
+- Persist events in an append-only Postgres table (Outbox pattern).
+- Project read models for the operator dashboard + audit log.
+- Replay tooling: rebuild any model release from the event log alone.
+
+## Out of Scope *(mandatory)*
+
+- Event-sourcing the verdict pipeline itself.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/098-security-threat-model-and-stride/spec.md
+++ b/.specify/specs/098-security-threat-model-and-stride/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Threat Model + STRIDE Review
+
+**Feature Branch**: `098-security-threat-model-and-stride`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: second
+**Domain**: security
+**Depends on**: none
+
+## Problem Statement
+
+There is no documented threat model. New features ship without a structured security review against STRIDE categories.
+
+## In Scope *(mandatory)*
+
+- Author the canonical threat model in `.specify/wiki/human-reference/security/threat-model.md`.
+- Cover trust boundaries between React/Electron/Mobile, both APIs, native pipeline, and Postgres.
+- STRIDE checklist added to the PR template for security-sensitive changes.
+- Quarterly review: the model is re-evaluated against shipped changes.
+
+## Out of Scope *(mandatory)*
+
+- Pen-testing engagement (handed to feature 099).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/099-security-third-party-pentest-readiness/spec.md
+++ b/.specify/specs/099-security-third-party-pentest-readiness/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Third-Party Pen-Test Readiness Pack
+
+**Feature Branch**: `099-security-third-party-pentest-readiness`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: fifth
+**Domain**: security
+**Depends on**: #098, #086
+
+## Problem Statement
+
+Before a paid pen-test engagement, we need scoping doc, account provisioning, attestations, and a fix-and-retest workflow.
+
+## In Scope *(mandatory)*
+
+- Author scoping doc + RoE template in the wiki.
+- Stand up a long-lived staging environment matching production topology.
+- Test-account provisioning flow + mass-revoke escape hatch.
+- Findings tracker tied to GH issues with severity SLA.
+
+## Out of Scope *(mandatory)*
+
+- The actual engagement (this is the readiness pack).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/100-security-csp-and-headers-hardening/spec.md
+++ b/.specify/specs/100-security-csp-and-headers-hardening/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: CSP + HTTP Security Headers Hardening
+
+**Feature Branch**: `100-security-csp-and-headers-hardening`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: second
+**Domain**: frontend / api
+**Depends on**: none
+
+## Problem Statement
+
+Frontend currently ships without strict Content-Security-Policy. APIs do not set HSTS / X-Frame-Options / Referrer-Policy uniformly.
+
+## In Scope *(mandatory)*
+
+- Author a strict CSP for React + Electron renderer (nonce-based).
+- Add helmet/SecurityHeaders middleware to both APIs with identical policy.
+- CI lane scans built HTML + API responses with `securityheaders.com`-equivalent assertions.
+- Document the per-runtime exemption list.
+
+## Out of Scope *(mandatory)*
+
+- WAF rules at the edge.
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).

--- a/.specify/specs/101-security-dependency-update-bot/spec.md
+++ b/.specify/specs/101-security-dependency-update-bot/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Dependency Update Bot (Renovate)
+
+**Feature Branch**: `101-security-dependency-update-bot`
+**Created**: 2026-05-01
+**Status**: Stub (scaffolded by 087 additional planning batch)
+**Wave**: first
+**Domain**: security / devex
+**Depends on**: none
+
+## Problem Statement
+
+Dependabot covers npm but not Bun lockfiles, NuGet metadata, or CMake `FetchContent`. Patch-level CVEs sit until someone notices.
+
+## In Scope *(mandatory)*
+
+- Adopt Renovate with a config covering Bun, npm, NuGet, CMake, GitHub Actions, and Dockerfile bases.
+- Group patch updates; auto-merge on green CI for non-major bumps.
+- Major bumps create a draft PR with release-notes preview.
+- Document the security-disclosure-window policy.
+
+## Out of Scope *(mandatory)*
+
+- Replacing Dependabot for surfaces it already covers (Renovate is canonical going forward).
+
+## Notes for the planner
+
+- Run `speckit.specify` against this stub to expand User Scenarios, Functional Requirements, and Success Criteria before `speckit.plan`.
+- Cross-layer dependencies (API or native changes) MUST be enumerated in the plan artifact and parity-governed (feature 047) when applicable.
+- This stub was generated as part of the additional cross-domain planning batch documented in [`.specify/specs/087-additional-followup-planning/spec.md`](../087-additional-followup-planning/spec.md).


### PR DESCRIPTION
Continues planning batches #051 (frontend, 15 stubs) and #067 (cross-domain, 20 stubs). Adds developer-experience, performance, data layer, and security depth.

## The 15 follow-ups

### Developer experience (5)
- 087 Monorepo task graph (Turbo/Nx) — third
- 088 Dev container + Codespaces onboarding — second
- 089 Pre-commit hook baseline (lint/format/secrets) — first
- 090 Feature-flag platform (OpenFeature) — third
- 091 Error tracking (Sentry) — third

### Performance & scale (3)
- 092 RUM + Core Web Vitals budget — third
- 093 Synthetic / black-box monitoring — fourth
- 094 Load testing baseline (k6) — fourth

### Data layer (3)
- 095 Postgres migration discipline (Prisma+EF parity) — second
- 096 PII classification + redaction — fourth
- 097 Event sourcing for training lifecycle — fifth

### Security depth (4)
- 098 Threat model + STRIDE review — second
- 099 Third-party pen-test readiness pack — fifth
- 100 CSP + HTTP security headers hardening — second
- 101 Dependency update bot (Renovate) — first

## Wave summary

| Wave | Specs |
|---|---|
| First | 089, 101 |
| Second | 088, 095, 098, 100 |
| Third | 087, 090, 091, 092 |
| Fourth | 093, 094, 096 |
| Fifth | 097, 099 |

## Validators

- `validate-ai-contracts.py`: exit 0
- No code edits outside `.specify/specs/087..101`

## Backlog state after this PR

| Range | Theme | Count |
|---|---|---|
| #052-#066 | Frontend uplift | 15 |
| #067-#086 | Cross-domain depth | 20 |
| #087-#101 | DX / perf / data / security | 15 |
| **Total stubs** | | **50** |