### PR TITLE
feat(101,089): Renovate dependency-update bot + pre-commit hook baseline

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+BreakBeforeBraces: Allman
+SpaceAfterCStyleCast: false
+SortIncludes: CaseSensitive

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "timezone": "America/Chicago",
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
+  "prCreation": "immediate",
+  "rebaseWhen": "behind-base-branch",
+  "packageRules": [
+    {
+      "description": "Group all patch + minor bumps; auto-merge on green CI",
+      "matchUpdateTypes": ["patch", "minor"],
+      "matchCurrentVersion": "!/^0/",
+      "groupName": "non-major dependencies",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Major bumps get a draft PR with release-notes summary",
+      "matchUpdateTypes": ["major"],
+      "draftPR": true,
+      "groupName": "major dependency updates",
+      "automerge": false
+    },
+    {
+      "description": "Group GitHub Actions bumps together",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true
+    },
+    {
+      "description": "Group Docker base image bumps",
+      "matchManagers": ["dockerfile"],
+      "groupName": "Docker base images",
+      "automerge": false
+    },
+    {
+      "description": "Group Bun workspace TS packages",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["src/typescript/**/package.json"],
+      "groupName": "TypeScript workspace dependencies"
+    },
+    {
+      "description": "Group NuGet packages",
+      "matchManagers": ["nuget"],
+      "groupName": "NuGet dependencies"
+    },
+    {
+      "description": "Never auto-merge security-sensitive packages",
+      "matchPackageNames": ["jsonwebtoken", "bcrypt", "bcryptjs", "passport"],
+      "automerge": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "automerge": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on the first day of the month"]
+  },
+  "ignorePaths": [
+    "**/.venv/**",
+    "**/node_modules/**",
+    "artifacts/**",
+    "build/**",
+    "out/**"
+  ],
+  "enabledManagers": [
+    "npm",
+    "nuget",
+    "github-actions",
+    "dockerfile",
+    "docker-compose"
+  ]
+}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,39 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    name: pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.x"
+
+      - name: Install clang-format
+        run: sudo apt-get install -y clang-format-19
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: dotnet-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,79 @@
+repos:
+  # ── Whitespace / end-of-file hygiene ──────────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '^(artifacts|build|out|\.venv)/'
+      - id: end-of-file-fixer
+        exclude: '^(artifacts|build|out|\.venv)/'
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+        exclude: '^(artifacts|build|out|\.venv)/'
+      - id: check-merge-conflict
+      - id: check-yaml
+        args: ['--allow-multiple-documents']
+        exclude: '^(artifacts|build|out|\.venv)/'
+      - id: check-json
+        exclude: '^(artifacts|build|out|\.venv)/'
+
+  # ── Secret scanning ────────────────────────────────────────────────────────
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+        name: "gitleaks: scan for secrets"
+        exclude: '^(artifacts|build|out|\.venv|\.git)/'
+
+  # ── Shell scripts ──────────────────────────────────────────────────────────
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ['--severity=warning', '--external-sources']
+        files: '\.sh$'
+        exclude: '^(artifacts|build|out|\.venv)/'
+
+  # ── Python (training scripts, validators) ─────────────────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.9
+    hooks:
+      - id: ruff
+        args: ['--fix']
+        files: '\.py$'
+        exclude: '^(artifacts|build|out|\.venv)/'
+      - id: ruff-format
+        files: '\.py$'
+        exclude: '^(artifacts|build|out|\.venv)/'
+
+  # ── C / native source ──────────────────────────────────────────────────────
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.7
+    hooks:
+      - id: clang-format
+        args: ['--style=file', '-i']
+        types: [c]
+        files: '^src/native/.*\.(c|h)$'
+
+  # ── TypeScript / JavaScript (Biome) ───────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: biome-check
+        name: "biome: lint + format TypeScript"
+        language: node
+        entry: bunx @biomejs/biome check --write
+        types_or: [ts, tsx, javascript, jsx, json]
+        files: '^src/typescript/'
+        pass_filenames: true
+        additional_dependencies: ['@biomejs/biome@^2.0.0']
+
+  # ── .NET format ────────────────────────────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: dotnet-format
+        name: "dotnet format: C# style check"
+        language: system
+        entry: dotnet
+        args: ['format', 'src/c-sharp/asp.net/asp.net.sln', '--verify-no-changes', '--severity', 'warn']
+        pass_filenames: false
+        files: '^src/c-sharp/.*\.cs$'

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["src/typescript/**"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "warn"
+      },
+      "style": {
+        "noNonNullAssertion": "warn"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "es5",
+      "semicolons": "always"
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Sprint 1 quick wins from the 3-month priority plan (#102). Two score-14/12 items with zero prerequisites — ships in one PR.

## Changes

### #101 — Renovate Dependency-Update Bot
**`.github/renovate.json`**
- Covers: npm (Bun workspaces), NuGet, GitHub Actions, Dockerfile, Docker Compose
- Patch + minor bumps: grouped, auto-merge on green CI
- Major bumps: draft PR with release-notes summary
- Vulnerability alerts: auto-merge enabled
- Lock-file maintenance: monthly
- Never auto-merges `jsonwebtoken`, `bcrypt`, `passport`

### #089 — Pre-commit Hook Baseline
**`.pre-commit-config.yaml`**
| Hook | Tool | Scope |
|------|------|-------|
| Whitespace / EOF | pre-commit-hooks | All files |
| Secret scanning | gitleaks v8 | All files |
| Shell lint | shellcheck | `*.sh` |
| Python lint + format | ruff | `*.py` |
| C formatter | clang-format v19 | `src/native/**.(c,h)` |
| TS/JS lint + format | Biome | `src/typescript/**` |
| .NET format check | dotnet format | `src/c-sharp/**/*.cs` |

**`biome.json`** — root Biome config (formatter + recommended lint rules for all TS workspaces)

**`.clang-format`** — LLVM-based style for native C source

**`.github/workflows/pre-commit.yml`** — CI lane runs all hooks on every PR + main push (dotnet-format skipped in CI; runs locally only)

## Validators
- `validate-ai-contracts.py`: exit 0
- `validate-workflow-dependencies.sh`: ok (35 refs / 7 workflows)