### PR TITLE
plan(103-107): restabilization follow-up specs after bulk execution

### DIFF
--- a/.specify/specs/103-aspnet-startup-pipeline-restabilization/spec.md
+++ b/.specify/specs/103-aspnet-startup-pipeline-restabilization/spec.md
@@ -1,0 +1,36 @@
+# Feature Specification: ASP.NET Startup and Pipeline Restabilization
+
+**Feature Branch**: `103-aspnet-startup-pipeline-restabilization`
+**Created**: 2026-05-01
+**Status**: Follow-up stabilization stub
+**Wave**: stabilization
+**Domain**: api / c-sharp
+**Depends on**: #054, #068, #069, #078, #080
+
+## Problem Statement
+
+Post-bulk merges introduced ASP.NET compile instability in startup wiring. The current build fails with `CS0128` due to duplicate `FrontendCorsPolicy` declaration in Program startup, which blocks CI confidence and delivery reliability.
+
+## In Scope *(mandatory)*
+
+- Remove duplicate startup declarations and normalize Program startup ordering.
+- Validate middleware registration order for auth, rate limiting, CORS, and pipeline steps.
+- Verify new pipeline steps added during bulk delivery (drift and A/B steps) resolve cleanly.
+- Add a compile-only guard lane that fails fast on startup wiring regressions.
+
+## Out of Scope *(mandatory)*
+
+- New endpoint features unrelated to startup reliability.
+- Auth policy redesign beyond compile and startup integrity fixes.
+
+## Success Criteria
+
+- `dotnet build src/c-sharp/asp.net/Banana.Api.csproj` succeeds in CI and local runs.
+- No duplicate constants or conflicting startup declarations remain in Program startup.
+- Pipeline step ordering is documented and validated by tests.
+
+## Notes for the planner
+
+- Prioritize minimal, low-risk changes in startup composition.
+- Add regression tests for startup invariants where practical.
+- Treat this as a stability blocker for all downstream API follow-ups.

--- a/.specify/specs/104-react-build-contract-reconciliation/spec.md
+++ b/.specify/specs/104-react-build-contract-reconciliation/spec.md
@@ -1,0 +1,36 @@
+# Feature Specification: React Build Contract Reconciliation
+
+**Feature Branch**: `104-react-build-contract-reconciliation`
+**Created**: 2026-05-01
+**Status**: Follow-up stabilization stub
+**Wave**: stabilization
+**Domain**: react / frontend
+**Depends on**: #075, #090, #091, #092
+
+## Problem Statement
+
+Post-bulk merges introduced React compile breakages in import contracts and dependencies. Current build errors include missing local module imports, missing `@sentry/react`, and API mismatch between exported and imported vitals symbols.
+
+## In Scope *(mandatory)*
+
+- Reconcile import paths and module boundaries for frontend hooks and API helpers.
+- Align vitals helper exports with consuming entrypoint usage.
+- Add required runtime and type dependencies for Sentry integration.
+- Enforce a deterministic frontend build gate that blocks unresolved symbol drift.
+
+## Out of Scope *(mandatory)*
+
+- UI redesign or major route restructuring.
+- New feature work not required to restore build stability.
+
+## Success Criteria
+
+- `bun run build` in React succeeds without TypeScript errors.
+- Sentry integration compiles when enabled and no-ops safely when disabled.
+- Contract tests or lint rules detect missing import/export symbols pre-merge.
+
+## Notes for the planner
+
+- Focus on preserving current behavior while fixing compile integrity.
+- Validate both local dev and CI build paths.
+- Keep changes bounded to stability and dependency correctness.

--- a/.specify/specs/105-wiki-contract-mirror-restabilization/spec.md
+++ b/.specify/specs/105-wiki-contract-mirror-restabilization/spec.md
@@ -1,0 +1,35 @@
+# Feature Specification: Wiki Contract and Mirror Restabilization
+
+**Feature Branch**: `105-wiki-contract-mirror-restabilization`
+**Created**: 2026-05-01
+**Status**: Follow-up stabilization stub
+**Wave**: stabilization
+**Domain**: docs / workflow
+**Depends on**: #102
+
+## Problem Statement
+
+The AI contract validator currently reports wiki allowlist and mirror drift. The section-based wiki structure and `.specify/wiki/human-reference` mirror are out of sync with the allowlist contract, causing deterministic validation failures.
+
+## In Scope *(mandatory)*
+
+- Reconcile `.wiki` markdown set with `.specify/wiki/human-reference-allowlist.txt`.
+- Ensure mirror parity by re-running and hardening consume/scaffold scripts.
+- Add explicit CI guardrails for section-based wiki path contracts.
+- Document recovery workflow for wiki drift remediation.
+
+## Out of Scope *(mandatory)*
+
+- New wiki information architecture changes beyond contract parity.
+- Rewriting content unrelated to validator compliance.
+
+## Success Criteria
+
+- `python scripts/validate-ai-contracts.py` returns zero issues.
+- Allowlist, source wiki set, and human-reference mirror remain parity aligned in CI.
+- Drift can be repaired by a single documented command path.
+
+## Notes for the planner
+
+- Treat section paths as canonical and avoid flattening mismatches.
+- Keep `_templates` and AI-only surfaces excluded per policy.

--- a/.specify/specs/106-post-merge-quality-gate-hardening/spec.md
+++ b/.specify/specs/106-post-merge-quality-gate-hardening/spec.md
@@ -1,0 +1,38 @@
+# Feature Specification: Post-Merge Quality Gate Hardening
+
+**Feature Branch**: `106-post-merge-quality-gate-hardening`
+**Created**: 2026-05-01
+**Status**: Follow-up stabilization stub
+**Wave**: stabilization
+**Domain**: testing / workflow / infra
+**Depends on**: #103, #104, #105
+
+## Problem Statement
+
+Recent bulk deliveries merged successfully but left cross-surface compile and contract drift undetected until manual checks. Existing CI gates are fragmented and do not enforce a minimum stability baseline across ASP.NET, React, TS API, and wiki contracts.
+
+## In Scope *(mandatory)*
+
+- Create a consolidated stabilization workflow with mandatory gates:
+  - ASP.NET build
+  - TS API tests
+  - React build
+  - AI contract validator
+- Add path filters and ownership mapping so changed surfaces trigger the right gates.
+- Standardize failure output and remediation hints for fast triage.
+
+## Out of Scope *(mandatory)*
+
+- Full E2E expansion beyond a stabilization baseline.
+- Non-blocking observability improvements that do not affect merge safety.
+
+## Success Criteria
+
+- Any regression in compile, test, or wiki contract fails the same PR before merge.
+- Gate execution time remains practical for routine PR use.
+- Contributors receive actionable failure context without manual forensics.
+
+## Notes for the planner
+
+- Reuse existing scripts where possible.
+- Prefer incremental adoption to avoid workflow churn.

--- a/.specify/specs/107-bulk-delivery-regression-burn-down/spec.md
+++ b/.specify/specs/107-bulk-delivery-regression-burn-down/spec.md
@@ -1,0 +1,35 @@
+# Feature Specification: Bulk Delivery Regression Burn-Down
+
+**Feature Branch**: `107-bulk-delivery-regression-burn-down`
+**Created**: 2026-05-01
+**Status**: Follow-up stabilization stub
+**Wave**: stabilization
+**Domain**: cross-domain
+**Depends on**: #103, #104, #105, #106
+
+## Problem Statement
+
+Bulk spec execution accelerated feature throughput but introduced multi-domain instability that now requires structured burn-down. Without an explicit burn-down spec, regressions are fixed ad hoc and quality debt persists.
+
+## In Scope *(mandatory)*
+
+- Establish a prioritized regression queue grouped by compile, runtime, test, and contract failures.
+- Define exit criteria for declaring the repository stabilized after bulk delivery.
+- Add traceable closure evidence per regression item (command output, test lane, or artifact).
+- Publish a stabilization checklist for future bulk waves.
+
+## Out of Scope *(mandatory)*
+
+- New product features unrelated to repository stabilization.
+- Long-term platform migrations not required for immediate quality recovery.
+
+## Success Criteria
+
+- All blocker regressions from the latest bulk wave are closed with evidence.
+- Stabilization checklist is reusable for the next bulk execution cycle.
+- Repository returns to green baseline for primary build and contract lanes.
+
+## Notes for the planner
+
+- Start with blocker-first sequencing.
+- Pair each closure item with automated validation where available.


### PR DESCRIPTION
## Why
Repository-level stabilization is needed after bulk spec execution. Current checks show compile/build and contract drift risks that require explicit follow-up planning.

## Evidence snapshot
- ASP.NET build failure: duplicate FrontendCorsPolicy declaration (CS0128)
- React build failures: unresolved import contract, missing @sentry/react dependency, vitals export mismatch
- AI contract validator: wiki allowlist and mirror drift

## Added follow-up specs
- #103 ASP.NET startup/pipeline restabilization
- #104 React build contract reconciliation
- #105 Wiki contract/mirror restabilization
- #106 Post-merge quality gate hardening
- #107 Bulk delivery regression burn-down

## Outcome
Creates a quality-focused stabilization backlog with clear boundaries and acceptance criteria before further feature expansion.
