### PR TITLE
feat(103): autonomous spec-drain loop with auto-merge and CI follow-up scaffolding

### DIFF
--- a/.github/workflows/orchestrate-autonomous-self-training-cycle.yml
+++ b/.github/workflows/orchestrate-autonomous-self-training-cycle.yml
@@ -39,6 +39,55 @@ on:
         options:
           - "true"
           - "false"
+      sdlc_mode:
+        description: SDLC run mode (`incremental` default or `spec-drain`)
+        required: false
+        default: "incremental"
+        type: choice
+        options:
+          - "incremental"
+          - "spec-drain"
+      autonomy_stop:
+        description: Emergency stop flag for autonomous spec-drain mode
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      spec_drain_state_path:
+        description: Optional explicit path for spec-drain checkpoint state JSON
+        required: false
+        default: ""
+      auto_debug_ci:
+        description: In spec-drain mode, inspect failed CI runs and scaffold follow-up specs
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      ci_idea_budget:
+        description: Maximum number of autonomous CI follow-up specs to scaffold per run
+        required: false
+        default: "3"
+      enable_auto_merge:
+        description: Enable auto-merge for generated PRs
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      auto_merge_method:
+        description: Auto-merge method (squash, merge, rebase)
+        required: false
+        default: "squash"
+        type: choice
+        options:
+          - "squash"
+          - "merge"
+          - "rebase"
   schedule:
     - cron: "30 5,11,17 * * 1-5"
   pull_request_target:
@@ -62,6 +111,14 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BANANA_REQUIRED_HUMAN_REVIEWER: LahkLeKey
       BANANA_SDLC_ID: autonomous-self-train
+      BANANA_SDLC_MODE: ${{ github.event.inputs.sdlc_mode || 'incremental' }}
+      BANANA_AUTONOMY_STOP: ${{ github.event.inputs.autonomy_stop || 'false' }}
+      BANANA_SDLC_DRAIN_STATE_PATH: ${{ github.event.inputs.spec_drain_state_path || '' }}
+      BANANA_SDLC_AUTO_DEBUG_CI: ${{ github.event.inputs.auto_debug_ci || 'true' }}
+      BANANA_SDLC_AUTO_SCAFFOLD_SPECS: ${{ github.event.inputs.auto_debug_ci || 'true' }}
+      BANANA_SDLC_CI_IDEA_BUDGET: ${{ github.event.inputs.ci_idea_budget || '3' }}
+      BANANA_ENABLE_AUTO_MERGE: ${{ github.event.inputs.enable_auto_merge || 'true' }}
+      BANANA_AUTO_MERGE_METHOD: ${{ github.event.inputs.auto_merge_method || 'squash' }}
       BANANA_SDLC_INCREMENT_PLAN_MODEL: native-deterministic-agent-pulse
       BANANA_SDLC_INCREMENT_PLAN_JSON: ${{ github.event.inputs.incremental_plan_json || '' }}
       BANANA_SDLC_INCREMENT_CATALOG_PATH: docs/automation/agent-pulse/autonomous-self-training-default-increments.json

--- a/.github/workflows/orchestrate-autonomous-spec-drain.yml
+++ b/.github/workflows/orchestrate-autonomous-spec-drain.yml
@@ -1,0 +1,97 @@
+name: Orchestrate Autonomous Spec Drain
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      sdlc_id:
+        description: SDLC orchestration identifier for this drain run
+        required: false
+        default: "autonomous-spec-drain"
+      autonomy_stop:
+        description: Emergency stop flag (set true to stop immediately)
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      spec_drain_state_path:
+        description: Optional explicit path for checkpoint state JSON
+        required: false
+        default: ""
+      auto_debug_ci:
+        description: Inspect failed CI runs and scaffold follow-up specs
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      ci_idea_budget:
+        description: Maximum number of CI follow-up specs to scaffold per run
+        required: false
+        default: "3"
+      enable_auto_merge:
+        description: Enable auto-merge for generated PRs
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      auto_merge_method:
+        description: Auto-merge method (squash, merge, rebase)
+        required: false
+        default: "squash"
+        type: choice
+        options:
+          - "squash"
+          - "merge"
+          - "rebase"
+      validate_ai_contracts:
+        description: Validate AI customization and wiki contracts before run
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+jobs:
+  spec-drain:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BANANA_REQUIRED_HUMAN_REVIEWER: LahkLeKey
+      BANANA_SDLC_ID: ${{ github.event.inputs.sdlc_id || 'autonomous-spec-drain' }}
+      BANANA_SDLC_MODE: spec-drain
+      BANANA_AUTONOMY_STOP: ${{ github.event.inputs.autonomy_stop || 'false' }}
+      BANANA_SDLC_DRAIN_STATE_PATH: ${{ github.event.inputs.spec_drain_state_path || '' }}
+      BANANA_SDLC_AUTO_DEBUG_CI: ${{ github.event.inputs.auto_debug_ci || 'true' }}
+      BANANA_SDLC_AUTO_SCAFFOLD_SPECS: ${{ github.event.inputs.auto_debug_ci || 'true' }}
+      BANANA_SDLC_CI_IDEA_BUDGET: ${{ github.event.inputs.ci_idea_budget || '3' }}
+      BANANA_ENABLE_AUTO_MERGE: ${{ github.event.inputs.enable_auto_merge || 'true' }}
+      BANANA_AUTO_MERGE_METHOD: ${{ github.event.inputs.auto_merge_method || 'squash' }}
+      BANANA_SDLC_VALIDATE_AI_CONTRACTS: ${{ github.event.inputs.validate_ai_contracts || 'true' }}
+      BANANA_SDLC_ENABLE_WIKI_SYNC: 'false'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run autonomous spec-drain mode
+        run: |
+          bash scripts/workflow-orchestrate-sdlc.sh
+
+      - name: Upload orchestration artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spec-drain-summary-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/sdlc-orchestration/
+          if-no-files-found: warn

--- a/.github/workflows/orchestrate-banana-sdlc.yml
+++ b/.github/workflows/orchestrate-banana-sdlc.yml
@@ -63,6 +63,55 @@ on:
         options:
           - "true"
           - "false"
+      sdlc_mode:
+        description: SDLC run mode (`incremental` default or `spec-drain`)
+        required: false
+        default: "incremental"
+        type: choice
+        options:
+          - "incremental"
+          - "spec-drain"
+      autonomy_stop:
+        description: Emergency stop flag for autonomous spec-drain mode
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      spec_drain_state_path:
+        description: Optional explicit path for spec-drain checkpoint state JSON
+        required: false
+        default: ""
+      enable_auto_merge:
+        description: Enable auto-merge for generated PRs
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      auto_merge_method:
+        description: Auto-merge method (squash, merge, rebase)
+        required: false
+        default: "squash"
+        type: choice
+        options:
+          - "squash"
+          - "merge"
+          - "rebase"
+      auto_debug_ci:
+        description: In spec-drain mode, inspect failed CI runs and scaffold follow-up specs
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      ci_idea_budget:
+        description: Maximum number of autonomous CI follow-up specs to scaffold per run
+        required: false
+        default: "3"
       require_real_updates:
         description: Require each increment to touch source/workflow impact paths before PR creation
         required: false
@@ -146,6 +195,14 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BANANA_REQUIRED_HUMAN_REVIEWER: LahkLeKey
       BANANA_SDLC_ID: ${{ github.event.inputs.sdlc_id || 'banana-sdlc' }}
+      BANANA_SDLC_MODE: ${{ github.event.inputs.sdlc_mode || 'incremental' }}
+      BANANA_AUTONOMY_STOP: ${{ github.event.inputs.autonomy_stop || 'false' }}
+      BANANA_SDLC_DRAIN_STATE_PATH: ${{ github.event.inputs.spec_drain_state_path || '' }}
+      BANANA_ENABLE_AUTO_MERGE: ${{ github.event.inputs.enable_auto_merge || 'true' }}
+      BANANA_AUTO_MERGE_METHOD: ${{ github.event.inputs.auto_merge_method || 'squash' }}
+      BANANA_SDLC_AUTO_DEBUG_CI: ${{ github.event.inputs.auto_debug_ci || 'true' }}
+      BANANA_SDLC_AUTO_SCAFFOLD_SPECS: ${{ github.event.inputs.auto_debug_ci || 'true' }}
+      BANANA_SDLC_CI_IDEA_BUDGET: ${{ github.event.inputs.ci_idea_budget || '3' }}
       BANANA_SDLC_INCREMENT_PLAN_JSON: ${{ github.event.inputs.incremental_plan_json || '' }}
       BANANA_BASE_BRANCH: ${{ github.event.inputs.base_branch || 'main' }}
       BANANA_BRANCH_PREFIX: ${{ github.event.inputs.branch_prefix || 'sdlc' }}

--- a/scripts/workflow-autonomous-ci-followup.sh
+++ b/scripts/workflow-autonomous-ci-followup.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+MAX_SPECS="${BANANA_SDLC_CI_IDEA_BUDGET:-3}"
+REPO="${BANANA_GITHUB_REPO:-LahkLeKey/Banana}"
+OUTPUT_PATH="${BANANA_SDLC_CI_FOLLOWUP_OUTPUT_PATH:-artifacts/sdlc-orchestration/ci-followup-summary.json}"
+PREFIX="${BANANA_SDLC_CI_FOLLOWUP_PREFIX:-ci-auto-debug}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+TMP_RUNS_JSON="${BANANA_SDLC_CI_TMP_RUNS_JSON:-$(dirname "$OUTPUT_PATH")/ci-runs-${RANDOM}-${RANDOM}.json}"
+
+BANANA_CI_REPO="$REPO" python - <<'PY' > "$TMP_RUNS_JSON"
+import json
+import os
+import subprocess
+import sys
+
+repo = os.environ.get("BANANA_CI_REPO", "LahkLeKey/Banana")
+
+cmd = [
+    "gh", "run", "list",
+    "--limit", "50",
+  "--repo", repo,
+    "--json", "databaseId,name,conclusion,displayTitle,headBranch,url"
+]
+try:
+    raw = subprocess.check_output(cmd, text=True)
+except subprocess.CalledProcessError:
+    print("[]")
+    sys.exit(0)
+print(raw)
+PY
+
+created_specs=()
+created_count=0
+
+while IFS=$'\t' read -r run_id run_name run_title run_url; do
+  [[ -z "$run_id" ]] && continue
+  if [[ "$created_count" -ge "$MAX_SPECS" ]]; then
+    break
+  fi
+
+  next_number="$(python - <<'PY'
+import pathlib
+import re
+
+spec_dir = pathlib.Path('.specify/specs')
+max_n = 0
+for p in spec_dir.iterdir():
+    if not p.is_dir():
+        continue
+    m = re.match(r'^(\d+)-', p.name)
+    if m:
+        max_n = max(max_n, int(m.group(1)))
+print(max_n + 1)
+PY
+)"
+
+  slug_title="$(printf '%s' "$run_name" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')"
+  [[ -z "$slug_title" ]] && slug_title="workflow-failure"
+  spec_slug="$(printf '%03d-%s-%s' "$next_number" "$PREFIX" "$slug_title")"
+  spec_dir=".specify/specs/${spec_slug}"
+
+  mkdir -p "$spec_dir"
+  cat > "$spec_dir/spec.md" <<EOF
+# Feature Specification: CI Auto-Debug Follow-up for ${run_name}
+
+**Feature Branch**: `${spec_slug}`
+**Created**: $(date +%Y-%m-%d)
+**Status**: Stub (autonomous CI follow-up)
+**Wave**: stabilization
+**Domain**: workflow / quality
+**Depends on**: none
+
+## Problem Statement
+
+Autonomous orchestrator detected a failed CI run requiring follow-up stabilization work.
+
+- Run id: ${run_id}
+- Workflow: ${run_name}
+- Title: ${run_title}
+- URL: ${run_url}
+
+## In Scope *(mandatory)*
+
+- Reproduce the failure locally or in a scoped CI rerun.
+- Identify root cause and implement smallest safe fix.
+- Add or update guardrails/tests to prevent recurrence.
+- Capture evidence paths and closure status in PR description.
+
+## Out of Scope *(mandatory)*
+
+- Unrelated refactors outside failure remediation.
+- Broad platform changes without a direct link to this failure.
+
+## Notes for the planner
+
+- Start with failure logs and changed files in the triggering run.
+- Prioritize deterministic fixes and explicit regression coverage.
+EOF
+
+  created_specs+=("$spec_slug")
+  created_count=$((created_count + 1))
+done < <(python - "$TMP_RUNS_JSON" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+runs = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+for run in runs:
+    if str(run.get('conclusion')) != 'failure':
+        continue
+    print(f"{run.get('databaseId','')}\t{run.get('name','')}\t{run.get('displayTitle','')}\t{run.get('url','')}")
+PY
+)
+
+python - "$OUTPUT_PATH" "$created_count" "${created_specs[*]:-}" <<'PY'
+import json
+import pathlib
+import sys
+
+out = pathlib.Path(sys.argv[1])
+count = int(sys.argv[2])
+specs = [s for s in sys.argv[3].split() if s]
+payload = {
+    "status": "ok",
+    "created_spec_count": count,
+    "created_specs": specs,
+}
+out.parent.mkdir(parents=True, exist_ok=True)
+out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+print(json.dumps(payload, indent=2))
+PY
+
+rm -f "$TMP_RUNS_JSON"

--- a/scripts/workflow-orchestrate-sdlc.sh
+++ b/scripts/workflow-orchestrate-sdlc.sh
@@ -9,6 +9,11 @@ bash scripts/workflow-ensure-speckit.sh
 RUN_ID="${GITHUB_RUN_ID:-local-run}"
 RUN_ATTEMPT="${GITHUB_RUN_ATTEMPT:-1}"
 SDLC_ID="${BANANA_SDLC_ID:-banana-sdlc}"
+SDLC_MODE="${BANANA_SDLC_MODE:-incremental}"
+AUTONOMY_STOP="${BANANA_AUTONOMY_STOP:-false}"
+AUTO_DEBUG_CI="${BANANA_SDLC_AUTO_DEBUG_CI:-true}"
+AUTO_SCAFFOLD_SPECS="${BANANA_SDLC_AUTO_SCAFFOLD_SPECS:-true}"
+CI_IDEA_BUDGET="${BANANA_SDLC_CI_IDEA_BUDGET:-3}"
 PLAN_JSON="${BANANA_SDLC_INCREMENT_PLAN_JSON:-}"
 PLAN_PATH="${BANANA_SDLC_INCREMENT_PLAN_PATH:-}"
 PLAN_MODEL="${BANANA_SDLC_INCREMENT_PLAN_MODEL:-}"
@@ -33,10 +38,97 @@ WIKI_REMOTE_URL="${BANANA_WIKI_REMOTE_URL:-https://github.com/LahkLeKey/Banana.w
 WIKI_ENFORCE_CANONICAL_REMOTE="${BANANA_ENFORCE_CANONICAL_WIKI_REMOTE:-true}"
 OUTPUT_DIR="${BANANA_SDLC_OUTPUT_DIR:-artifacts/sdlc-orchestration}"
 SUMMARY_PATH="${BANANA_SDLC_SUMMARY_PATH:-${OUTPUT_DIR}/summary-${RUN_ID}-attempt-${RUN_ATTEMPT}.json}"
+SPEC_DRAIN_STATE_PATH="${BANANA_SDLC_DRAIN_STATE_PATH:-${OUTPUT_DIR}/spec-drain-state-${RUN_ID}-attempt-${RUN_ATTEMPT}.json}"
+CI_FOLLOWUP_OUTPUT_PATH="${BANANA_SDLC_CI_FOLLOWUP_OUTPUT_PATH:-${OUTPUT_DIR}/ci-followup-${RUN_ID}-attempt-${RUN_ATTEMPT}.json}"
 RUN_API_PARITY_CHECK="${BANANA_SDLC_RUN_API_PARITY_CHECK:-false}"
 API_PARITY_STRICT="${BANANA_SDLC_API_PARITY_STRICT:-false}"
+ENABLE_AUTO_MERGE="${BANANA_ENABLE_AUTO_MERGE:-true}"
+AUTO_MERGE_METHOD="${BANANA_AUTO_MERGE_METHOD:-squash}"
 
 mkdir -p "$OUTPUT_DIR"
+
+if [[ "$SDLC_MODE" == "spec-drain" ]]; then
+  echo "Running SDLC in spec-drain mode..."
+
+  bash scripts/workflow-spec-drain-state.sh init "$SPEC_DRAIN_STATE_PATH" "$RUN_ID" "$RUN_ATTEMPT"
+
+  if [[ "$AUTONOMY_STOP" == "true" ]]; then
+    bash scripts/workflow-spec-drain-state.sh set-stop "$SPEC_DRAIN_STATE_PATH" "kill_switch"
+  fi
+
+  if [[ "$AUTO_DEBUG_CI" == "true" && "$AUTO_SCAFFOLD_SPECS" == "true" && "$AUTONOMY_STOP" != "true" ]]; then
+    export BANANA_SDLC_CI_IDEA_BUDGET="$CI_IDEA_BUDGET"
+    export BANANA_SDLC_CI_FOLLOWUP_OUTPUT_PATH="$CI_FOLLOWUP_OUTPUT_PATH"
+    bash scripts/workflow-autonomous-ci-followup.sh
+  fi
+
+  python - "$SUMMARY_PATH" "$SPEC_DRAIN_STATE_PATH" "$AUTONOMY_STOP" "$CI_FOLLOWUP_OUTPUT_PATH" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+summary_path = pathlib.Path(sys.argv[1])
+state_path = pathlib.Path(sys.argv[2])
+autonomy_stop = sys.argv[3].lower() == "true"
+ci_followup_path = pathlib.Path(sys.argv[4])
+
+state = json.loads(state_path.read_text(encoding="utf-8"))
+
+spec_dirs = []
+for path in sorted(pathlib.Path(".specify/specs").glob("*")):
+    if not path.is_dir():
+        continue
+    name = path.name
+    if not re.match(r"^[0-9]{3,}-", name):
+        continue
+    if (path / "spec.md").exists():
+        spec_dirs.append(name)
+
+completed = set(state.get("completed_specs", []))
+failed = {str(item.get("spec_id")) for item in state.get("failed_specs", [])}
+runnable = [spec for spec in spec_dirs if spec not in completed and spec not in failed]
+
+stop_reason = state.get("stop_reason")
+ci_followup = None
+if ci_followup_path.exists():
+    try:
+        ci_followup = json.loads(ci_followup_path.read_text(encoding="utf-8"))
+    except Exception:
+        ci_followup = {"status": "failed", "reason": f"unable to parse {ci_followup_path.name}"}
+
+if stop_reason is None:
+    if autonomy_stop:
+      stop_reason = "kill_switch"
+    elif ci_followup is not None and int(ci_followup.get("created_spec_count", 0)) == 0:
+      stop_reason = "ci_runs_out_of_ideas"
+    elif not runnable:
+      stop_reason = "exhausted"
+    else:
+      stop_reason = "runnable_specs_available"
+
+summary = {
+    "mode": "spec-drain",
+    "status": "stopped" if autonomy_stop or stop_reason == "exhausted" else "running",
+    "stop_reason": stop_reason,
+    "spec_discovery": {
+        "total_specs": len(spec_dirs),
+        "runnable_specs": runnable,
+        "completed_specs": sorted(completed),
+        "failed_specs": sorted(failed),
+    },
+    "ci_followup": ci_followup,
+    "state_path": str(state_path),
+}
+
+summary_path.parent.mkdir(parents=True, exist_ok=True)
+summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+print(json.dumps(summary, indent=2))
+PY
+
+  echo "Spec-drain summary written to: ${SUMMARY_PATH}"
+  exit 0
+fi
 
 if [[ "${BANANA_SDLC_VALIDATE_AI_CONTRACTS:-true}" == "true" ]]; then
   echo "Validating AI customization and wiki-sync contracts..."
@@ -237,6 +329,8 @@ while IFS=$'\t' read -r increment_id change_b64 commit_b64 title_b64 body_b64 la
   export BANANA_DRAFT_PR="$draft_pr"
   export BANANA_PR_LABELS="$labels"
   export BANANA_PR_REVIEWERS="$reviewers"
+  export BANANA_ENABLE_AUTO_MERGE="$ENABLE_AUTO_MERGE"
+  export BANANA_AUTO_MERGE_METHOD="$AUTO_MERGE_METHOD"
   export BANANA_SKIP_IF_NO_CHANGES="$SKIP_NO_CHANGES"
   export BANANA_REQUIRE_REAL_UPDATES="$SDLC_REQUIRE_REAL_UPDATES"
   export BANANA_SKIP_DOCS_ONLY_CHANGES="$SDLC_SKIP_NON_REAL_UPDATES"

--- a/scripts/workflow-orchestrate-triaged-item-pr.sh
+++ b/scripts/workflow-orchestrate-triaged-item-pr.sh
@@ -16,6 +16,8 @@ COMMIT_MESSAGE="${BANANA_COMMIT_MESSAGE:-chore(triage): automated triaged change
 PR_TITLE_OVERRIDE="${BANANA_PR_TITLE:-}"
 PR_BODY_OVERRIDE="${BANANA_PR_BODY:-}"
 DRAFT_PR="${BANANA_DRAFT_PR:-true}"
+ENABLE_AUTO_MERGE="${BANANA_ENABLE_AUTO_MERGE:-false}"
+AUTO_MERGE_METHOD="${BANANA_AUTO_MERGE_METHOD:-squash}"
 PR_LABELS="${BANANA_PR_LABELS:-automation,triaged-item,requires-human-approval,copilot-auto-approve,speckit-driven}"
 PR_REVIEWERS="${BANANA_PR_REVIEWERS:-}"
 LOCAL_DRY_RUN="${BANANA_LOCAL_DRY_RUN:-false}"
@@ -602,6 +604,19 @@ if [[ ${#parsed_reviewers[@]} -gt 0 ]]; then
       echo "::warning::Failed to request reviewer '$reviewer' for PR #$pr_number."
     fi
   done
+fi
+
+if [[ "$ENABLE_AUTO_MERGE" == "true" ]]; then
+  merge_method_flag="--squash"
+  case "$AUTO_MERGE_METHOD" in
+    merge) merge_method_flag="--merge" ;;
+    rebase) merge_method_flag="--rebase" ;;
+    squash|*) merge_method_flag="--squash" ;;
+  esac
+
+  if ! gh pr merge "$pr_number" --auto "$merge_method_flag" >/dev/null 2>&1; then
+    echo "::warning::Failed to enable auto-merge for PR #$pr_number."
+  fi
 fi
 
 echo "Triaged PR ready for review: $pr_url"

--- a/scripts/workflow-spec-drain-state.sh
+++ b/scripts/workflow-spec-drain-state.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lightweight JSON state helper for spec-drain mode.
+# Usage:
+#   bash scripts/workflow-spec-drain-state.sh init <state-path> <run-id> <run-attempt>
+#   bash scripts/workflow-spec-drain-state.sh mark-completed <state-path> <spec-id>
+#   bash scripts/workflow-spec-drain-state.sh mark-failed <state-path> <spec-id> <reason>
+#   bash scripts/workflow-spec-drain-state.sh set-stop <state-path> <reason>
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+command_name="${1:-}"
+state_path="${2:-}"
+
+if [[ -z "$command_name" || -z "$state_path" ]]; then
+  echo "Usage: $0 <init|mark-completed|mark-failed|set-stop> <state-path> [args...]" >&2
+  exit 1
+fi
+
+case "$command_name" in
+  init)
+    run_id="${3:-local-run}"
+    run_attempt="${4:-1}"
+    python - "$state_path" "$run_id" "$run_attempt" <<'PY'
+import json
+import pathlib
+import sys
+
+state_path = pathlib.Path(sys.argv[1])
+run_id = sys.argv[2]
+run_attempt = sys.argv[3]
+
+if state_path.exists():
+    # Preserve existing checkpoint for resumability.
+    sys.exit(0)
+
+payload = {
+    "schema_version": 1,
+    "mode": "spec-drain",
+    "run_id": run_id,
+    "run_attempt": run_attempt,
+    "status": "running",
+    "stop_reason": None,
+    "completed_specs": [],
+    "failed_specs": [],
+}
+
+state_path.parent.mkdir(parents=True, exist_ok=True)
+state_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+    ;;
+  mark-completed)
+    spec_id="${3:-}"
+    if [[ -z "$spec_id" ]]; then
+      echo "mark-completed requires <spec-id>" >&2
+      exit 1
+    fi
+    python - "$state_path" "$spec_id" <<'PY'
+import json
+import pathlib
+import sys
+
+state_path = pathlib.Path(sys.argv[1])
+spec_id = sys.argv[2]
+payload = json.loads(state_path.read_text(encoding="utf-8"))
+
+completed = set(payload.get("completed_specs", []))
+if spec_id not in completed:
+    payload.setdefault("completed_specs", []).append(spec_id)
+
+failed = []
+for entry in payload.get("failed_specs", []):
+    if str(entry.get("spec_id")) != spec_id:
+        failed.append(entry)
+payload["failed_specs"] = failed
+
+state_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+    ;;
+  mark-failed)
+    spec_id="${3:-}"
+    reason="${4:-failed}"
+    if [[ -z "$spec_id" ]]; then
+      echo "mark-failed requires <spec-id> <reason>" >&2
+      exit 1
+    fi
+    python - "$state_path" "$spec_id" "$reason" <<'PY'
+import json
+import pathlib
+import sys
+
+state_path = pathlib.Path(sys.argv[1])
+spec_id = sys.argv[2]
+reason = sys.argv[3]
+payload = json.loads(state_path.read_text(encoding="utf-8"))
+
+failed_specs = payload.setdefault("failed_specs", [])
+failed_specs.append({"spec_id": spec_id, "reason": reason})
+
+state_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+    ;;
+  set-stop)
+    reason="${3:-unknown}"
+    python - "$state_path" "$reason" <<'PY'
+import json
+import pathlib
+import sys
+
+state_path = pathlib.Path(sys.argv[1])
+reason = sys.argv[2]
+payload = json.loads(state_path.read_text(encoding="utf-8"))
+payload["status"] = "stopped"
+payload["stop_reason"] = reason
+state_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+    ;;
+  *)
+    echo "Unsupported command: $command_name" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
Implements autonomy expectations for spec-drain orchestration.

### Included
- Auto-merge support for generated PRs in triage orchestration.
- New spec-drain state helper for checkpoint and stop metadata.
- New autonomous CI follow-up helper that inspects failed runs and scaffolds new follow-up specs up to a configurable budget.
- New dedicated workflow: orchestrate-autonomous-spec-drain.
- Extended existing SDLC workflows with inputs/env for:
  - spec-drain mode
  - emergency kill switch
  - auto-merge enable/method
  - CI auto-debug follow-up and idea budget
- Spec-drain summary now records ci_followup details and supports stop reason ci_runs_out_of_ideas.

## Validation
- Shell syntax checks for modified scripts passed.
- Spec-drain dry run (kill switch) passed and wrote summary/state artifacts.
- CI follow-up helper validated with zero-budget dry run.
- Workflow YAML diagnostics show no errors.
