### PR TITLE
feat(grade-school): add quiz QA surface and benchmark trend release gates

### DIFF
--- a/.github/workflows/grade-school-uat.yml
+++ b/.github/workflows/grade-school-uat.yml
@@ -1,0 +1,410 @@
+name: Grade School UAT
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/typescript/react/src/pages/BananaAIPage.tsx"
+      - "src/typescript/react/src/pages/QuizQaPage.tsx"
+      - "src/typescript/react/grade-school-uat.config.ts"
+      - "tests/e2e/playwright/specs/grade-school-quiz-qa.spec.ts"
+      - "scripts/quiz-model-benchmark-gate.ts"
+      - "scripts/quiz-benchmark-trend-gate.ts"
+      - "src/typescript/react/package.json"
+      - ".github/workflows/grade-school-uat.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/typescript/react/src/pages/BananaAIPage.tsx"
+      - "src/typescript/react/src/pages/QuizQaPage.tsx"
+      - "src/typescript/react/grade-school-uat.config.ts"
+      - "tests/e2e/playwright/specs/grade-school-quiz-qa.spec.ts"
+      - "scripts/quiz-model-benchmark-gate.ts"
+      - "scripts/quiz-benchmark-trend-gate.ts"
+      - "src/typescript/react/package.json"
+      - ".github/workflows/grade-school-uat.yml"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Override target URL (default: https://banana.engineer)"
+        required: false
+        default: "https://banana.engineer"
+      gate_mode:
+        description: "Gate behavior: enforce fails the job, observe records warnings only"
+        required: false
+        default: "enforce"
+        type: choice
+        options:
+          - enforce
+          - observe
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  grade-school-uat:
+    name: Grade School UAT + Gate Evaluator
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    env:
+      GRADE_SCHOOL_GATE_MODE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_mode || 'enforce' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Node.js (Playwright dependency)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install shared UI dependencies
+        run: bun install --cwd src/typescript/shared/ui
+
+      - name: Install React app dependencies
+        run: bun install --cwd src/typescript/react
+
+      - name: Install Playwright Chromium browser + system deps
+        working-directory: src/typescript/react
+        run: bunx playwright install chromium --with-deps
+
+      - name: Run grade-school UAT suites against production URL (readonly)
+        id: run_grade_school_uat
+        continue-on-error: true
+        working-directory: src/typescript/react
+        run: bun run test:grade-school-uat
+        env:
+          CI: "true"
+          PLAYWRIGHT_BASE_URL: ${{ github.event.inputs.base_url || 'https://banana.engineer' }}
+
+      - name: Run quiz model benchmark gate (readonly production API)
+        id: run_quiz_benchmark_gate
+        continue-on-error: true
+        shell: bash
+        run: |
+          target_url="${{ github.event.inputs.base_url || 'https://banana.engineer' }}"
+          api_base="${target_url/https:\/\/banana.engineer/https:\/\/api.banana.engineer}"
+          bun scripts/quiz-model-benchmark-gate.ts \
+            --base-url "${api_base}" \
+            --out-dir ".artifacts/grade-school-gate" \
+            --benchmark-target "0.80" \
+            --regression-floor "0.65"
+
+      - name: Resolve latest main quiz benchmark artifact URL
+        id: resolve_previous_quiz_artifact
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const currentRunId = Number(process.env.GITHUB_RUN_ID || "0");
+
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: "grade-school-uat.yml",
+              branch: "main",
+              status: "success",
+              per_page: 30,
+            });
+
+            let artifactUrl = "";
+            let sourceRunId = "";
+
+            for (const run of runs.data.workflow_runs) {
+              if (run.id === currentRunId) {
+                continue;
+              }
+
+              const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner,
+                repo,
+                run_id: run.id,
+                per_page: 100,
+              });
+
+              const match = artifacts.data.artifacts.find((artifact) =>
+                artifact.name === "quiz-benchmark-gate-report" && !artifact.expired
+              );
+
+              if (match) {
+                artifactUrl = match.archive_download_url;
+                sourceRunId = String(run.id);
+                break;
+              }
+            }
+
+            core.setOutput("artifact_url", artifactUrl);
+            core.setOutput("source_run_id", sourceRunId);
+
+      - name: Download previous main quiz benchmark artifact
+        if: always() && steps.resolve_previous_quiz_artifact.outputs.artifact_url != ''
+        shell: bash
+        run: |
+          mkdir -p .artifacts/previous-quiz-benchmark
+          curl -sSL \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            "${{ steps.resolve_previous_quiz_artifact.outputs.artifact_url }}" \
+            -o .artifacts/previous-quiz-benchmark/artifact.zip
+          unzip -o .artifacts/previous-quiz-benchmark/artifact.zip -d .artifacts/previous-quiz-benchmark
+
+      - name: Run quiz benchmark trend gate
+        id: run_quiz_trend_gate
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          previous_report=".artifacts/previous-quiz-benchmark/quiz-benchmark-gate-report.json"
+          args=(
+            "--current-report" ".artifacts/grade-school-gate/quiz-benchmark-gate-report.json"
+            "--out-dir" ".artifacts/grade-school-gate"
+            "--benchmark-target" "0.80"
+            "--regression-floor" "0.65"
+          )
+
+          if [[ -f "$previous_report" ]]; then
+            args+=("--previous-report" "$previous_report")
+          fi
+
+          bun scripts/quiz-benchmark-trend-gate.ts "${args[@]}"
+
+      - name: Build grade-school gate report artifact
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p .artifacts/grade-school-gate
+          outcome="${{ steps.run_grade_school_uat.outcome }}"
+          quiz_outcome="${{ steps.run_quiz_benchmark_gate.outcome }}"
+          trend_outcome="${{ steps.run_quiz_trend_gate.outcome }}"
+          target_url="${{ github.event.inputs.base_url || 'https://banana.engineer' }}"
+          gate_mode="${GRADE_SCHOOL_GATE_MODE}"
+          timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          if [[ "$outcome" == "success" && "$quiz_outcome" == "success" && "$trend_outcome" == "success" ]]; then
+            gate_status="pass"
+            gate_decision="allow"
+          elif [[ "$gate_mode" == "observe" ]]; then
+            gate_status="warn"
+            gate_decision="allow-with-warning"
+          else
+            gate_status="fail"
+            gate_decision="block"
+          fi
+
+          cat > .artifacts/grade-school-gate/grade-school-gate-report.md <<EOF
+          # Grade-School Release Gate Report
+
+          - generated_at_utc: ${timestamp}
+          - target_url: ${target_url}
+          - gate_mode: ${gate_mode}
+          - suites:
+            - grade-school-quiz-qa.spec.ts
+          - gate_status: ${gate_status}
+          - gate_decision: ${gate_decision}
+          - uat_step_outcome: ${outcome}
+          - quiz_benchmark_step_outcome: ${quiz_outcome}
+          - quiz_trend_step_outcome: ${trend_outcome}
+          - previous_main_artifact_run_id: ${{ steps.resolve_previous_quiz_artifact.outputs.source_run_id || 'n/a' }}
+
+          ## Threshold Inputs
+
+          - Quiz QA UI suite must pass.
+          - Quiz benchmark suite must pass and remain above the non-regression floor.
+          - Quiz trend gate must not regress versus previous successful main benchmark while below target.
+          - Enforce mode: failures block the gate.
+          - Observe mode: failures warn but do not block.
+          EOF
+
+          printf '{"generated_at_utc":"%s","target_url":"%s","gate_mode":"%s","gate_status":"%s","gate_decision":"%s","uat_step_outcome":"%s","quiz_benchmark_step_outcome":"%s","quiz_trend_step_outcome":"%s","previous_main_artifact_run_id":"%s"}\n' "$timestamp" "$target_url" "$gate_mode" "$gate_status" "$gate_decision" "$outcome" "$quiz_outcome" "$trend_outcome" "${{ steps.resolve_previous_quiz_artifact.outputs.source_run_id || 'n/a' }}" > .artifacts/grade-school-gate/grade-school-gate-report.json
+
+      - name: Publish gate summary
+        if: always()
+        shell: bash
+        run: |
+          outcome="${{ steps.run_grade_school_uat.outcome }}"
+          quiz_outcome="${{ steps.run_quiz_benchmark_gate.outcome }}"
+          trend_outcome="${{ steps.run_quiz_trend_gate.outcome }}"
+          if [[ "$outcome" == "success" && "$quiz_outcome" == "success" && "$trend_outcome" == "success" ]]; then
+            gate_status="pass"
+          elif [[ "${GRADE_SCHOOL_GATE_MODE}" == "observe" ]]; then
+            gate_status="warn"
+          else
+            gate_status="fail"
+          fi
+
+          {
+            echo "## Grade-School Gate Summary"
+            echo ""
+            echo "- target_url: ${{ github.event.inputs.base_url || 'https://banana.engineer' }}"
+            echo "- gate_mode: ${GRADE_SCHOOL_GATE_MODE}"
+            echo "- uat_outcome: ${outcome}"
+            echo "- quiz_benchmark_outcome: ${quiz_outcome}"
+            echo "- quiz_trend_outcome: ${trend_outcome}"
+            echo "- previous_main_artifact_run_id: ${{ steps.resolve_previous_quiz_artifact.outputs.source_run_id || 'n/a' }}"
+            echo "- gate_status: ${gate_status}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upsert PR gate summary comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          UAT_OUTCOME: ${{ steps.run_grade_school_uat.outcome }}
+          QUIZ_BENCHMARK_OUTCOME: ${{ steps.run_quiz_benchmark_gate.outcome }}
+          QUIZ_TREND_OUTCOME: ${{ steps.run_quiz_trend_gate.outcome }}
+          PREVIOUS_MAIN_ARTIFACT_RUN_ID: ${{ steps.resolve_previous_quiz_artifact.outputs.source_run_id || 'n/a' }}
+          TARGET_URL: ${{ github.event.inputs.base_url || 'https://banana.engineer' }}
+          GATE_MODE: ${{ env.GRADE_SCHOOL_GATE_MODE }}
+        with:
+          script: |
+            const marker = "<!-- grade-school-gate-comment -->";
+            const uatOutcome = process.env.UAT_OUTCOME ?? "unknown";
+            const quizBenchmarkOutcome = process.env.QUIZ_BENCHMARK_OUTCOME ?? "unknown";
+            const quizTrendOutcome = process.env.QUIZ_TREND_OUTCOME ?? "unknown";
+            const previousMainArtifactRunId = process.env.PREVIOUS_MAIN_ARTIFACT_RUN_ID ?? "n/a";
+            const gateMode = process.env.GATE_MODE ?? "enforce";
+            const targetUrl = process.env.TARGET_URL ?? "https://banana.engineer";
+
+            let gateStatus = "fail";
+            if (
+              uatOutcome === "success" &&
+              quizBenchmarkOutcome === "success" &&
+              quizTrendOutcome === "success"
+            ) {
+              gateStatus = "pass";
+            } else if (gateMode === "observe") {
+              gateStatus = "warn";
+            }
+
+            const icon = gateStatus === "pass" ? "✅" : gateStatus === "warn" ? "⚠️" : "❌";
+            const body = `${marker}
+            ## Grade-School Gate Summary
+
+            ${icon} status: **${gateStatus}**
+
+            - target_url: ${targetUrl}
+            - gate_mode: ${gateMode}
+            - uat_outcome: ${uatOutcome}
+            - quiz_benchmark_outcome: ${quizBenchmarkOutcome}
+            - quiz_trend_outcome: ${quizTrendOutcome}
+            - previous_main_artifact_run_id: ${previousMainArtifactRunId}
+            - suites: grade-school-quiz-qa.spec.ts
+            - artifact: \`grade-school-gate-report\` (workflow artifacts)
+            - artifact: \`quiz-benchmark-gate-report\` (workflow artifacts)
+            - artifact: \`quiz-benchmark-trend-gate-report\` (workflow artifacts)
+            `;
+
+            const issue_number = context.payload.pull_request.number;
+            const {owner, repo} = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              typeof comment.body === "string" && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Upload grade-school gate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: grade-school-gate-report
+          path: .artifacts/grade-school-gate/
+          retention-days: 14
+
+      - name: Upload quiz benchmark gate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quiz-benchmark-gate-report
+          path: |
+            .artifacts/grade-school-gate/quiz-benchmark-gate-report.json
+            .artifacts/grade-school-gate/quiz-benchmark-gate-report.md
+          retention-days: 14
+
+      - name: Upload quiz benchmark trend gate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quiz-benchmark-trend-gate-report
+          path: |
+            .artifacts/grade-school-gate/quiz-benchmark-trend-gate-report.json
+            .artifacts/grade-school-gate/quiz-benchmark-trend-gate-report.md
+          retention-days: 14
+
+      - name: Upload Playwright report on failure
+        if: steps.run_grade_school_uat.outcome != 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: grade-school-uat-playwright-report
+          path: src/typescript/react/playwright-report/grade-school-uat/
+          retention-days: 7
+
+      - name: Upload Playwright traces on failure
+        if: steps.run_grade_school_uat.outcome != 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: grade-school-uat-test-results
+          path: src/typescript/react/test-results/grade-school-uat/
+          retention-days: 7
+
+      - name: Enforce grade-school release gate
+        if: always()
+        shell: bash
+        run: |
+          if [[ "${GRADE_SCHOOL_GATE_MODE}" == "observe" ]]; then
+            if [[ "${{ steps.run_grade_school_uat.outcome }}" != "success" ]]; then
+              echo "Grade-school release gate observe mode: UAT suites failed but gate is non-blocking."
+            fi
+            if [[ "${{ steps.run_quiz_benchmark_gate.outcome }}" != "success" ]]; then
+              echo "Grade-school release gate observe mode: quiz benchmark gate failed but remains non-blocking."
+            fi
+            if [[ "${{ steps.run_quiz_trend_gate.outcome }}" != "success" ]]; then
+              echo "Grade-school release gate observe mode: quiz trend gate failed but remains non-blocking."
+            fi
+            exit 0
+          fi
+
+          if [[ "${{ steps.run_grade_school_uat.outcome }}" != "success" ]]; then
+            echo "Grade-school release gate failed: one or more readonly production UAT suites failed."
+            exit 1
+          fi
+
+          if [[ "${{ steps.run_quiz_benchmark_gate.outcome }}" != "success" ]]; then
+            echo "Grade-school release gate failed: quiz benchmark is below regression floor."
+            exit 1
+          fi
+
+          if [[ "${{ steps.run_quiz_trend_gate.outcome }}" != "success" ]]; then
+            echo "Grade-school release gate failed: quiz benchmark regressed versus previous main run while below target."
+            exit 1
+          fi

--- a/scripts/analytics-surface-manifest.json
+++ b/scripts/analytics-surface-manifest.json
@@ -1,0 +1,23 @@
+{
+    "criticalWorkflows": [
+        {
+            "name": "workspace-navigation",
+            "requiredRoutes": [
+                "/workspace",
+                "/knowledge",
+                "/functions",
+                "/api-docs",
+                "/data-science",
+                "/banana-ai",
+                "/quiz-qa",
+                "/review-spikes",
+                "/classify",
+                "/operator"
+            ],
+            "requiredEvents": [
+                "banana_page_view",
+                "banana_nav_click"
+            ]
+        }
+    ]
+}

--- a/scripts/quiz-benchmark-trend-gate.ts
+++ b/scripts/quiz-benchmark-trend-gate.ts
@@ -1,0 +1,264 @@
+#!/usr/bin/env bun
+
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from "node:fs";
+import {join, resolve} from "node:path";
+
+type Args = {
+    currentReportPath: string;
+    previousReportPath?: string; outDir : string; benchmarkTarget : number;
+    regressionFloor : number;
+};
+
+type BenchmarkReport = {
+    generated_at_utc?: string;
+    score?: number;
+    benchmark_target?: number;
+    regression_floor?: number;
+};
+
+function parseArgs(argv: string[]): Args
+{
+    const cwd = process.cwd();
+    const args: Args = {
+        currentReportPath :
+            resolve(cwd, ".artifacts/grade-school-gate/quiz-benchmark-gate-report.json"),
+        outDir : resolve(cwd, ".artifacts/grade-school-gate"),
+        benchmarkTarget : 0.8,
+        regressionFloor : 0.65,
+    };
+
+    for (let i = 0; i < argv.length; i += 1)
+    {
+        const token = argv[i];
+        switch (token)
+        {
+        case "--current-report":
+            args.currentReportPath = resolve(cwd, argv[++i]);
+            break;
+        case "--previous-report":
+            args.previousReportPath = resolve(cwd, argv[++i]);
+            break;
+        case "--out-dir":
+            args.outDir = resolve(cwd, argv[++i]);
+            break;
+        case "--benchmark-target":
+            args.benchmarkTarget = Number(argv[++i]);
+            break;
+        case "--regression-floor":
+            args.regressionFloor = Number(argv[++i]);
+            break;
+        default:
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    if (!Number.isFinite(args.benchmarkTarget) || args.benchmarkTarget < 0 ||
+        args.benchmarkTarget > 1)
+    {
+        throw new Error("--benchmark-target must be between 0 and 1");
+    }
+
+    if (!Number.isFinite(args.regressionFloor) || args.regressionFloor < 0 ||
+        args.regressionFloor > 1)
+    {
+        throw new Error("--regression-floor must be between 0 and 1");
+    }
+
+    return args;
+}
+
+function readReport(path: string): BenchmarkReport
+{
+    const raw = readFileSync(path, "utf-8");
+    return JSON.parse(raw) as BenchmarkReport;
+}
+
+function toMarkdown(report: {
+    generatedAtUtc: string; currentScore : number; previousScore : number | null;
+    benchmarkTarget : number;
+    regressionFloor : number;
+    trendStatus : string;
+    gatePass : boolean;
+    reason : string;
+}): string
+{
+    const lines: string[] = [];
+    lines.push("# Quiz Benchmark Trend Gate Report");
+    lines.push("");
+    lines.push(`- generated_at_utc: ${report.generatedAtUtc}`);
+    lines.push(`- current_score: ${report.currentScore.toFixed(4)}`);
+    lines.push(`- previous_score: ${
+        report.previousScore == null ? "n/a" : report.previousScore.toFixed(4)}`);
+    lines.push(`- benchmark_target: ${report.benchmarkTarget.toFixed(4)}`);
+    lines.push(`- regression_floor: ${report.regressionFloor.toFixed(4)}`);
+    lines.push(`- trend_status: ${report.trendStatus}`);
+    lines.push(`- gate_pass: ${report.gatePass}`);
+    lines.push(`- reason: ${report.reason}`);
+    lines.push("");
+    return `${lines.join("\n")}\n`;
+}
+
+function resolveTrend(currentScore: number, previousScore: number|null, benchmarkTarget: number,
+                      regressionFloor: number):
+    {trendStatus: string; gatePass : boolean; reason : string}
+{
+    const tolerance = 0.0001;
+
+    if (currentScore < regressionFloor)
+    {
+        return {
+            trendStatus : "regressed-below-floor",
+            gatePass : false,
+            reason : `Current score ${currentScore.toFixed(4)} is below floor ${
+                regressionFloor.toFixed(4)}.`,
+        };
+    }
+
+    if (previousScore == null)
+    {
+        if (currentScore >= benchmarkTarget)
+        {
+            return {
+                trendStatus : "meets-benchmark-no-baseline",
+                gatePass : true,
+                reason :
+                    "No previous baseline artifact found; current score meets benchmark target.",
+            };
+        }
+
+        return {
+            trendStatus : "no-baseline",
+            gatePass : true,
+            reason :
+                "No previous baseline artifact found; floor is satisfied and trend comparison skipped.",
+        };
+    }
+
+    if (currentScore >= benchmarkTarget)
+    {
+        if (currentScore + tolerance < previousScore)
+        {
+            return {
+                trendStatus : "meets-benchmark-soft-regression",
+                gatePass : true,
+                reason :
+                    "Current score remains above benchmark target despite a small drop from previous run.",
+            };
+        }
+
+        return {
+            trendStatus : "meets-benchmark",
+            gatePass : true,
+            reason : "Current score meets benchmark target and floor.",
+        };
+    }
+
+    if (currentScore + tolerance < previousScore)
+    {
+        return {
+            trendStatus : "regressed-vs-previous",
+            gatePass : false,
+            reason : `Current score ${currentScore.toFixed(4)} regressed below previous ${
+                previousScore.toFixed(
+                    4)} while still below benchmark target ${benchmarkTarget.toFixed(4)}.`,
+        };
+    }
+
+    if (currentScore > previousScore + tolerance)
+    {
+        return {
+            trendStatus : "growing",
+            gatePass : true,
+            reason : "Current score improved relative to previous run.",
+        };
+    }
+
+    return {
+        trendStatus : "stable",
+        gatePass : true,
+        reason : "Current score is stable versus previous run and above floor.",
+    };
+}
+
+function main(): number
+{
+    const args = parseArgs(process.argv.slice(2));
+
+    if (!existsSync(args.currentReportPath))
+    {
+        throw new Error(`Current report not found: ${args.currentReportPath}`);
+    }
+
+    const current = readReport(args.currentReportPath);
+    const currentScore = Number(current.score ?? Number.NaN);
+    if (!Number.isFinite(currentScore))
+    {
+        throw new Error(`Current report has invalid score: ${args.currentReportPath}`);
+    }
+
+    let previousScore: number|null = null;
+    if (args.previousReportPath && existsSync(args.previousReportPath))
+    {
+        const previous = readReport(args.previousReportPath);
+        const parsedPrevious = Number(previous.score ?? Number.NaN);
+        if (Number.isFinite(parsedPrevious))
+        {
+            previousScore = parsedPrevious;
+        }
+    }
+
+    const benchmarkTarget = args.benchmarkTarget;
+    const regressionFloor = args.regressionFloor;
+
+    const resolution = resolveTrend(currentScore, previousScore, benchmarkTarget, regressionFloor);
+    const generatedAtUtc = new Date().toISOString();
+
+    const report = {
+        generated_at_utc : generatedAtUtc,
+        current_score : Number(currentScore.toFixed(4)),
+        previous_score : previousScore == null ? null : Number(previousScore.toFixed(4)),
+        benchmark_target : benchmarkTarget,
+        regression_floor : regressionFloor,
+        trend_status : resolution.trendStatus,
+        gate_pass : resolution.gatePass,
+        reason : resolution.reason,
+        current_report_path : args.currentReportPath,
+        previous_report_path : args.previousReportPath ?? null,
+    };
+
+    mkdirSync(args.outDir, {recursive : true});
+    writeFileSync(join(args.outDir, "quiz-benchmark-trend-gate-report.json"),
+                  `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+    writeFileSync(join(args.outDir, "quiz-benchmark-trend-gate-report.md"), toMarkdown({
+                      generatedAtUtc,
+                      currentScore,
+                      previousScore,
+                      benchmarkTarget,
+                      regressionFloor,
+                      trendStatus : resolution.trendStatus,
+                      gatePass : resolution.gatePass,
+                      reason : resolution.reason,
+                  }),
+                  "utf-8");
+
+    if (!resolution.gatePass)
+    {
+        console.error("[quiz-benchmark-trend-gate] trend policy failure");
+        console.error(`- trend_status=${resolution.trendStatus}`);
+        console.error(`- reason=${resolution.reason}`);
+        return 1;
+    }
+
+    return 0;
+}
+
+try
+{
+    process.exit(main());
+}
+catch (error)
+{
+    console.error(`[quiz-benchmark-trend-gate] fatal: ${
+        error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+}

--- a/scripts/quiz-model-benchmark-gate.ts
+++ b/scripts/quiz-model-benchmark-gate.ts
@@ -1,0 +1,251 @@
+#!/usr/bin/env bun
+
+import {mkdirSync, writeFileSync} from "node:fs";
+import {join, resolve} from "node:path";
+
+type QuizPrompt = {
+    id: string; prompt : string; expectedLabel : "banana" | "not-banana";
+};
+
+type GateArgs = {
+    baseUrl: string; outDir : string; benchmarkTarget : number; regressionFloor : number;
+};
+
+const DETERMINISTIC_SCANNER_VERSION = 1;
+
+const prompts: QuizPrompt[] = [
+    {
+        id : "q-001",
+        prompt : "A ripe yellow banana with a few brown spots.",
+        expectedLabel : "banana",
+    },
+    {
+        id : "q-002",
+        prompt : "A steel keyboard with RGB lights.",
+        expectedLabel : "not-banana",
+    },
+    {
+        id : "q-003",
+        prompt : "A banana smoothie in a clear cup.",
+        expectedLabel : "banana",
+    },
+    {
+        id : "q-004",
+        prompt : "A ceramic coffee mug on a desk.",
+        expectedLabel : "not-banana",
+    },
+    {
+        id : "q-005",
+        prompt : "A peeled banana cut into slices.",
+        expectedLabel : "banana",
+    },
+    {
+        id : "q-006",
+        prompt : "A laptop charging cable with a USB-C connector.",
+        expectedLabel : "not-banana",
+    },
+];
+
+function parseArgs(argv: string[]): GateArgs
+{
+    const cwd = process.cwd();
+    const args: GateArgs = {
+        baseUrl : "https://api.banana.engineer",
+        outDir : resolve(cwd, ".artifacts/grade-school-gate"),
+        benchmarkTarget : 0.8,
+        regressionFloor : 0.65,
+    };
+
+    for (let i = 0; i < argv.length; i += 1)
+    {
+        const token = argv[i];
+        switch (token)
+        {
+        case "--base-url":
+            args.baseUrl = argv[++i];
+            break;
+        case "--out-dir":
+            args.outDir = resolve(cwd, argv[++i]);
+            break;
+        case "--benchmark-target":
+            args.benchmarkTarget = Number(argv[++i]);
+            break;
+        case "--regression-floor":
+            args.regressionFloor = Number(argv[++i]);
+            break;
+        default:
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    if (!Number.isFinite(args.benchmarkTarget) || args.benchmarkTarget < 0 ||
+        args.benchmarkTarget > 1)
+    {
+        throw new Error("--benchmark-target must be between 0 and 1");
+    }
+
+    if (!Number.isFinite(args.regressionFloor) || args.regressionFloor < 0 ||
+        args.regressionFloor > 1)
+    {
+        throw new Error("--regression-floor must be between 0 and 1");
+    }
+
+    return args;
+}
+
+type EnsembleResponse = {
+    label?: string;
+};
+
+function normalizeLabel(rawLabel: string): "banana"|"not-banana"|"unknown"
+{
+    const normalized = rawLabel.trim().toLowerCase().replace(/[_\s]+/g, "-");
+    if (normalized === "banana")
+    {
+        return "banana";
+    }
+    if (normalized === "not-banana")
+    {
+        return "not-banana";
+    }
+    return "unknown";
+}
+
+async function requestVerdict(baseUrl: string, prompt: string): Promise<string>
+{
+    const response = await fetch(`${baseUrl}/ml/ensemble`, {
+        method : "POST",
+        headers : {"content-type" : "application/json"},
+        body : JSON.stringify({inputJson : JSON.stringify({text : prompt})}),
+    });
+
+    if (!response.ok)
+    {
+        const message = await response.text();
+        throw new Error(`request failed (${response.status}): ${message}`);
+    }
+
+    const payload = (await response.json()) as EnsembleResponse;
+    return normalizeLabel(String(payload.label ?? ""));
+}
+
+function scoreToPercent(score: number): string
+{
+    return `${(score * 100).toFixed(2)}%`;
+}
+
+function trendLabel(score: number, benchmarkTarget: number, regressionFloor: number): string
+{
+    if (score < regressionFloor)
+    {
+        return "regressed-below-floor";
+    }
+    if (score >= benchmarkTarget)
+    {
+        return "meets-benchmark";
+    }
+    return "growing";
+}
+
+function toMarkdown(report: {
+    generatedAtUtc: string; targetUrl : string; benchmarkTarget : number; regressionFloor : number;
+    score : number;
+    trend : string;
+    gatePass : boolean;
+    rows : Array<{id : string; expectedLabel : string; predictedLabel : string; pass : boolean;}>;
+}): string
+{
+    const lines: string[] = [];
+    lines.push("# Quiz Model Benchmark Gate Report");
+    lines.push("");
+    lines.push(`- generated_at_utc: ${report.generatedAtUtc}`);
+    lines.push(`- target_url: ${report.targetUrl}`);
+    lines.push(`- benchmark_target: ${report.benchmarkTarget}`);
+    lines.push(`- regression_floor: ${report.regressionFloor}`);
+    lines.push(`- score: ${scoreToPercent(report.score)}`);
+    lines.push(`- trend: ${report.trend}`);
+    lines.push(`- gate_pass: ${report.gatePass}`);
+    lines.push("");
+    lines.push("## Prompt Results");
+    lines.push("");
+    lines.push("| Prompt | Expected | Predicted | Pass |");
+    lines.push("| --- | --- | --- | --- |");
+    for (const row of report.rows)
+    {
+        lines.push(`| ${row.id} | ${row.expectedLabel} | ${row.predictedLabel} | ${row.pass} |`);
+    }
+    lines.push("");
+    return `${lines.join("\n")}\n`;
+}
+
+async function main(): Promise<number>
+{
+    const args = parseArgs(process.argv.slice(2));
+    const timestamp = new Date().toISOString();
+
+    const rows: Array<{
+        id : string; prompt : string; expectedLabel : string; predictedLabel : string;
+        pass : boolean;
+    }> = [];
+
+    for (const entry of prompts)
+    {
+        const predictedLabel = await requestVerdict(args.baseUrl, entry.prompt);
+        const pass = predictedLabel === entry.expectedLabel;
+        rows.push({
+            id : entry.id,
+            prompt : entry.prompt,
+            expectedLabel : entry.expectedLabel,
+            predictedLabel,
+            pass,
+        });
+    }
+
+    const passed = rows.filter((row) => row.pass).length;
+    const score = rows.length > 0 ? Number((passed / rows.length).toFixed(4)) : 0;
+    const trend = trendLabel(score, args.benchmarkTarget, args.regressionFloor);
+    const gatePass = score >= args.regressionFloor;
+
+    const report = {
+        generated_at_utc : timestamp,
+        scanner_version : DETERMINISTIC_SCANNER_VERSION,
+        target_url : args.baseUrl,
+        benchmark_target : args.benchmarkTarget,
+        regression_floor : args.regressionFloor,
+        score,
+        trend,
+        gate_pass : gatePass,
+        prompt_results : rows,
+    };
+
+    mkdirSync(args.outDir, {recursive : true});
+    writeFileSync(join(args.outDir, "quiz-benchmark-gate-report.json"),
+                  `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+    writeFileSync(join(args.outDir, "quiz-benchmark-gate-report.md"), toMarkdown({
+                      generatedAtUtc : timestamp,
+                      targetUrl : args.baseUrl,
+                      benchmarkTarget : args.benchmarkTarget,
+                      regressionFloor : args.regressionFloor,
+                      score,
+                      trend,
+                      gatePass,
+                      rows,
+                  }),
+                  "utf-8");
+
+    if (!gatePass)
+    {
+        console.error("[quiz-model-benchmark-gate] regression floor check failed");
+        console.error(`- score=${score.toFixed(4)}`);
+        console.error(`- regression_floor=${args.regressionFloor.toFixed(4)}`);
+        return 1;
+    }
+
+    return 0;
+}
+
+main().then((code) => process.exit(code)).catch((error) => {
+    console.error(`[quiz-model-benchmark-gate] fatal: ${
+        error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+});

--- a/scripts/scan-web-analytics-surfaces.ts
+++ b/scripts/scan-web-analytics-surfaces.ts
@@ -1,0 +1,378 @@
+#!/usr/bin/env bun
+
+import {mkdirSync, readFileSync, writeFileSync} from "node:fs";
+import {join, resolve} from "node:path";
+
+type Args = {
+    manifestPath: string; outDir : string; routerPath : string; analyticsPath : string;
+    workspaceShellPath : string;
+    strict : boolean;
+    minRouteCoverage : number;
+    minEventCoverage : number;
+};
+
+type CriticalWorkflow = {
+    name: string; requiredRoutes : string[]; requiredEvents : string[];
+};
+
+type Manifest = {
+    criticalWorkflows: CriticalWorkflow[];
+};
+
+type RouteCoverage = {
+    route: string; instrumented : boolean; required : boolean;
+};
+
+type EventCoverage = {
+    event: string; present : boolean; required : boolean;
+};
+
+const DETERMINISTIC_GENERATED_AT = "1970-01-01T00:00:00Z";
+
+function parseArgs(argv: string[]): Args
+{
+    const cwd = process.cwd();
+    const args: Args = {
+        manifestPath : resolve(cwd, "scripts/analytics-surface-manifest.json"),
+        outDir : resolve(cwd, "artifacts/analytics"),
+        routerPath : resolve(cwd, "src/typescript/react/src/lib/router.tsx"),
+        analyticsPath : resolve(cwd, "src/typescript/react/src/lib/analytics.ts"),
+        workspaceShellPath : resolve(cwd, "src/typescript/react/src/components/WorkspaceShell.tsx"),
+        strict : false,
+        minRouteCoverage : 1,
+        minEventCoverage : 1,
+    };
+
+    for (let i = 0; i < argv.length; i += 1)
+    {
+        const token = argv[i];
+        switch (token)
+        {
+        case "--manifest":
+            args.manifestPath = resolve(cwd, argv[++i]);
+            break;
+        case "--out-dir":
+            args.outDir = resolve(cwd, argv[++i]);
+            break;
+        case "--router-file":
+            args.routerPath = resolve(cwd, argv[++i]);
+            break;
+        case "--analytics-file":
+            args.analyticsPath = resolve(cwd, argv[++i]);
+            break;
+        case "--workspace-shell-file":
+            args.workspaceShellPath = resolve(cwd, argv[++i]);
+            break;
+        case "--strict":
+            args.strict = true;
+            break;
+        case "--min-route-coverage":
+            args.minRouteCoverage = Number(argv[++i]);
+            break;
+        case "--min-event-coverage":
+            args.minEventCoverage = Number(argv[++i]);
+            break;
+        default:
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    if (!Number.isFinite(args.minRouteCoverage) || args.minRouteCoverage < 0 ||
+        args.minRouteCoverage > 1)
+    {
+        throw new Error("--min-route-coverage must be a number between 0 and 1");
+    }
+    if (!Number.isFinite(args.minEventCoverage) || args.minEventCoverage < 0 ||
+        args.minEventCoverage > 1)
+    {
+        throw new Error("--min-event-coverage must be a number between 0 and 1");
+    }
+
+    return args;
+}
+
+function readUtf8(path: string): string
+{
+    return readFileSync(path, "utf-8");
+}
+
+function normalizeRoute(pathValue: string): string
+{
+    if (pathValue === "*")
+    {
+        return "/*";
+    }
+    return pathValue.startsWith("/") ? pathValue : `/${pathValue}`;
+}
+
+function extractRoutes(routerSource: string): string[]
+{
+    const routeSet = new Set<string>();
+
+    if (/\{\s*index\s*:\s*true\s*,/m.test(routerSource))
+    {
+        routeSet.add("/");
+    }
+
+    const pathRegex = /path\s*:\s*"([^"]+)"/g;
+    let match: RegExpExecArray|null;
+    while ((match = pathRegex.exec(routerSource)) != null)
+    {
+        routeSet.add(normalizeRoute(match[1]));
+    }
+
+    return [...routeSet ].sort((a, b) => a.localeCompare(b));
+}
+
+function extractEvents(source: string): string[]
+{
+    const eventSet = new Set<string>();
+    const eventRegex = /trackEvent\(\s*"([a-z0-9_\-]+)"/g;
+    let match: RegExpExecArray|null;
+    while ((match = eventRegex.exec(source)) != null)
+    {
+        eventSet.add(match[1]);
+    }
+    return [...eventSet ].sort((a, b) => a.localeCompare(b));
+}
+
+function unionSorted(values: string[][]): string[]
+{
+    const all = new Set<string>();
+    for (const list of values)
+    {
+        for (const item of list)
+        {
+            all.add(item);
+        }
+    }
+    return [...all ].sort((a, b) => a.localeCompare(b));
+}
+
+function ratio(covered: number, total: number): number
+{
+    if (total <= 0)
+    {
+        return 1;
+    }
+    return Number((covered / total).toFixed(4));
+}
+
+function toMarkdown(report: {
+    routeCoverage: RouteCoverage[]; eventCoverage : EventCoverage[]; requiredRoutes : string[];
+    requiredEvents : string[];
+    missingRoutes : string[];
+    missingEvents : string[];
+    routeCoveragePct : number;
+    eventCoveragePct : number;
+    strict : boolean;
+    minRouteCoverage : number;
+    minEventCoverage : number;
+}): string
+{
+    const lines: string[] = [];
+    lines.push("# Analytics Surface Coverage");
+    lines.push("");
+    lines.push(`- route_coverage: ${(report.routeCoveragePct * 100).toFixed(2)}% (${
+        report.requiredRoutes.length === 0
+            ? 0
+            : report.requiredRoutes.length -
+                  report.missingRoutes.length}/${report.requiredRoutes.length || 0})`);
+    lines.push(`- event_coverage: ${(report.eventCoveragePct * 100).toFixed(2)}% (${
+        report.requiredEvents.length === 0
+            ? 0
+            : report.requiredEvents.length -
+                  report.missingEvents.length}/${report.requiredEvents.length || 0})`);
+    lines.push(`- strict_mode: ${report.strict}`);
+    lines.push(
+        `- thresholds: route>=${report.minRouteCoverage}, event>=${report.minEventCoverage}`);
+    lines.push("");
+
+    lines.push("## Missing Required Routes");
+    lines.push("");
+    if (report.missingRoutes.length === 0)
+    {
+        lines.push("- None");
+    }
+    else
+    {
+        for (const route of report.missingRoutes)
+        {
+            lines.push(`- ${route}`);
+        }
+    }
+    lines.push("");
+
+    lines.push("## Missing Required Events");
+    lines.push("");
+    if (report.missingEvents.length === 0)
+    {
+        lines.push("- None");
+    }
+    else
+    {
+        for (const event of report.missingEvents)
+        {
+            lines.push(`- ${event}`);
+        }
+    }
+    lines.push("");
+
+    lines.push("## Route Coverage Details");
+    lines.push("");
+    lines.push("| Route | Required | Instrumented |");
+    lines.push("| --- | --- | --- |");
+    for (const entry of report.routeCoverage)
+    {
+        lines.push(`| ${entry.route} | ${entry.required} | ${entry.instrumented} |`);
+    }
+    lines.push("");
+
+    lines.push("## Event Coverage Details");
+    lines.push("");
+    lines.push("| Event | Required | Present |");
+    lines.push("| --- | --- | --- |");
+    for (const entry of report.eventCoverage)
+    {
+        lines.push(`| ${entry.event} | ${entry.required} | ${entry.present} |`);
+    }
+    lines.push("");
+
+    return `${lines.join("\n")}\n`;
+}
+
+function main(): number
+{
+    const args = parseArgs(process.argv.slice(2));
+
+    const manifest = JSON.parse(readUtf8(args.manifestPath)) as Manifest;
+    const routerSource = readUtf8(args.routerPath);
+    const analyticsSource = readUtf8(args.analyticsPath);
+    const shellSource = readUtf8(args.workspaceShellPath);
+
+    const discoveredRoutes = extractRoutes(routerSource);
+    const discoveredEvents =
+        unionSorted([ extractEvents(analyticsSource), extractEvents(shellSource) ]);
+
+    const requiredRoutes =
+        unionSorted(manifest.criticalWorkflows.map((item) => item.requiredRoutes));
+    const requiredEvents =
+        unionSorted(manifest.criticalWorkflows.map((item) => item.requiredEvents));
+
+    const hasPageViewInstrumentation = /trackPageView\(/.test(routerSource);
+
+    const routeCoverage: RouteCoverage[] =
+        discoveredRoutes.map((route) => ({
+                                 route,
+                                 required : requiredRoutes.includes(route),
+                                 instrumented : hasPageViewInstrumentation,
+                             }));
+
+    const allEvents = unionSorted([ discoveredEvents, requiredEvents ]);
+    const eventCoverage: EventCoverage[] =
+        allEvents.map((event) => ({
+                          event,
+                          required : requiredEvents.includes(event),
+                          present : discoveredEvents.includes(event),
+                      }));
+
+    const missingRoutes = requiredRoutes.filter((requiredRoute) => {
+        const match = routeCoverage.find((entry) => entry.route === requiredRoute);
+        return !match || !match.instrumented;
+    });
+    const missingEvents =
+        requiredEvents.filter((requiredEvent) => !discoveredEvents.includes(requiredEvent));
+
+    const coveredRequiredRouteCount = requiredRoutes.length - missingRoutes.length;
+    const coveredRequiredEventCount = requiredEvents.length - missingEvents.length;
+
+    const routeCoveragePct = ratio(coveredRequiredRouteCount, requiredRoutes.length);
+    const eventCoveragePct = ratio(coveredRequiredEventCount, requiredEvents.length);
+
+    const report = {
+        generatedAtUtc : DETERMINISTIC_GENERATED_AT,
+        scannerVersion : 1,
+        strict : args.strict,
+        thresholds : {
+            minRouteCoverage : args.minRouteCoverage,
+            minEventCoverage : args.minEventCoverage,
+        },
+        discovered : {
+            routes : discoveredRoutes,
+            events : discoveredEvents,
+        },
+        required : {
+            routes : requiredRoutes,
+            events : requiredEvents,
+        },
+        coverage : {
+            routeCoveragePct,
+            eventCoveragePct,
+            routeCoverage,
+            eventCoverage,
+            missingRoutes,
+            missingEvents,
+        },
+    };
+
+    mkdirSync(args.outDir, {recursive : true});
+    writeFileSync(join(args.outDir, "coverage.json"), `${JSON.stringify(report, null, 2)}\n`,
+                  "utf-8");
+    writeFileSync(join(args.outDir, "coverage.md"), toMarkdown({
+                      routeCoverage,
+                      eventCoverage,
+                      requiredRoutes,
+                      requiredEvents,
+                      missingRoutes,
+                      missingEvents,
+                      routeCoveragePct,
+                      eventCoveragePct,
+                      strict : args.strict,
+                      minRouteCoverage : args.minRouteCoverage,
+                      minEventCoverage : args.minEventCoverage,
+                  }),
+                  "utf-8");
+
+    const diagnostics: string[] = [];
+    if (routeCoveragePct < args.minRouteCoverage)
+    {
+        diagnostics.push(`Route coverage ${routeCoveragePct.toFixed(4)} below threshold ${
+            args.minRouteCoverage.toFixed(4)}`);
+    }
+    if (eventCoveragePct < args.minEventCoverage)
+    {
+        diagnostics.push(`Event coverage ${eventCoveragePct.toFixed(4)} below threshold ${
+            args.minEventCoverage.toFixed(4)}`);
+    }
+    if (missingRoutes.length > 0)
+    {
+        diagnostics.push(`Missing required routes: ${missingRoutes.join(", ")}`);
+    }
+    if (missingEvents.length > 0)
+    {
+        diagnostics.push(`Missing required events: ${missingEvents.join(", ")}`);
+    }
+
+    if (args.strict && diagnostics.length > 0)
+    {
+        console.error("[scan-web-analytics-surfaces] strict coverage failure");
+        for (const line of diagnostics)
+        {
+            console.error(`- ${line}`);
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+try
+{
+    process.exit(main());
+}
+catch (error)
+{
+    console.error(`[scan-web-analytics-surfaces] fatal: ${
+        error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+}

--- a/src/typescript/react/grade-school-uat.config.ts
+++ b/src/typescript/react/grade-school-uat.config.ts
@@ -1,0 +1,49 @@
+import {defineConfig, devices} from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "https://banana.engineer";
+const localBaseUrl = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?/i.test(baseURL);
+
+export default defineConfig({
+    testDir : "../../../tests/e2e/playwright/specs",
+    testMatch : "**/grade-school-quiz-qa.spec.ts",
+    outputDir : "./test-results/grade-school-uat",
+    fullyParallel : false,
+    forbidOnly : !!process.env.CI,
+    retries : process.env.CI ? 1 : 0,
+    workers : 1,
+    reporter : [
+        [ "list" ],
+        [ "html", {open : "never", outputFolder : "./playwright-report/grade-school-uat"} ]
+    ],
+    webServer : localBaseUrl ? {
+        command : "bun run dev -- --host 127.0.0.1 --port 5173",
+        url : baseURL,
+        reuseExistingServer : !process.env.CI,
+        timeout : 120_000,
+    }
+                             : undefined,
+    use : {
+        baseURL,
+        trace : "retain-on-failure",
+        screenshot : "only-on-failure",
+        video : "off",
+        navigationTimeout : 20_000,
+        actionTimeout : 10_000,
+    },
+    projects : [
+        {
+            name : "grade-school-uat-chromium",
+            use : {
+                ...devices["Desktop Chrome"],
+                viewport : {width : 1366, height : 900},
+                launchOptions : {
+                    args : [
+                        "--no-sandbox",
+                        "--disable-setuid-sandbox",
+                        "--disable-dev-shm-usage",
+                    ],
+                },
+            },
+        },
+    ],
+});

--- a/src/typescript/react/package.json
+++ b/src/typescript/react/package.json
@@ -11,6 +11,7 @@
         "postinstall": "node scripts/dedupe-react.mjs",
         "screenshots": "bunx playwright test --config ../../tests/e2e/playwright/playwright.config.ts --project=screenshots",
         "test:ds-e2e": "NODE_PATH=./node_modules bunx playwright test --config ds-pyodide.config.ts",
+        "test:grade-school-uat": "NODE_PATH=./node_modules bunx playwright test --config grade-school-uat.config.ts",
         "storybook": "storybook dev --port 6006",
         "build-storybook": "storybook build --output-dir storybook-static"
     },

--- a/src/typescript/react/src/components/WorkspaceShell.tsx
+++ b/src/typescript/react/src/components/WorkspaceShell.tsx
@@ -58,6 +58,7 @@ export function WorkspaceShell() {
                         <NavItem to="/api-docs" label="API Docs" />
                         <NavItem to="/data-science" label="Data Science" />
                         <NavItem to="/banana-ai" label="BananaAI" />
+                        <NavItem to="/quiz-qa" label="Quiz QA" />
                         <NavItem to="/review-spikes" label="Review Spikes" />
                     </Section>
 

--- a/src/typescript/react/src/lib/analytics.ts
+++ b/src/typescript/react/src/lib/analytics.ts
@@ -1,21 +1,25 @@
-import { track } from "@vercel/analytics";
+import {track} from "@vercel/analytics";
 
-const ANALYTICS_ENABLED =
-    import.meta.env.PROD || import.meta.env.VITE_ENABLE_ANALYTICS === "true";
+const ANALYTICS_ENABLED = import.meta.env.PROD || import.meta.env.VITE_ENABLE_ANALYTICS === "true";
 
-export function isAnalyticsEnabled(): boolean {
+export function isAnalyticsEnabled(): boolean
+{
     return ANALYTICS_ENABLED;
 }
 
-export function trackEvent(name: string, properties: Record<string, string | number | boolean> = {}): void {
-    if (!ANALYTICS_ENABLED || typeof window === "undefined") {
+export function trackEvent(name: string,
+                           properties: Record<string, string|number|boolean> = {}): void
+{
+    if (!ANALYTICS_ENABLED || typeof window === "undefined")
+    {
         return;
     }
 
     track(name, properties);
 }
 
-export function trackPageView(pathname: string, navigationType: string): void {
+export function trackPageView(pathname: string, navigationType: string): void
+{
     trackEvent("banana_page_view", {
         pathname,
         navigationType,

--- a/src/typescript/react/src/lib/quizBenchmark.test.ts
+++ b/src/typescript/react/src/lib/quizBenchmark.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, test} from "bun:test";
+
+import {analyzeQuizBenchmark, type QuizAttempt} from "./quizBenchmark";
+
+function attempt(id: number, score: number,
+                 humanGrade: "ungraded"|"pass"|"fail" = "ungraded"): QuizAttempt
+{
+    return {
+        id : `a-${id}`,
+        answeredAtUtc : `2026-05-${String(id).padStart(2, "0")}T00:00:00Z`,
+        autoScore : score,
+        humanGrade,
+    };
+}
+
+describe("quiz benchmark analysis", () => {
+    test("flags regression below floor", () => {
+        const summary = analyzeQuizBenchmark([
+            attempt(1, 0.9),
+            attempt(2, 0.8),
+            attempt(3, 0.4),
+            attempt(4, 0.45),
+            attempt(5, 0.5),
+        ]);
+
+        expect(summary.trend).toBe("regressed-below-floor");
+        expect(summary.gatePass).toBe(false);
+    });
+
+    test("detects growth when current window improves over previous", () => {
+        const summary = analyzeQuizBenchmark([
+            attempt(1, 0.6),
+            attempt(2, 0.6),
+            attempt(3, 0.7),
+            attempt(4, 0.7),
+            attempt(5, 0.72),
+            attempt(6, 0.75),
+            attempt(7, 0.78),
+            attempt(8, 0.79),
+            attempt(9, 0.8),
+            attempt(10, 0.82),
+        ]);
+
+        expect(summary.trend).toBe("growing");
+        expect(summary.gatePass).toBe(true);
+    });
+
+    test("honors human grading overrides", () => {
+        const summary = analyzeQuizBenchmark([
+            attempt(1, 0.2, "pass"),
+            attempt(2, 0.9, "fail"),
+            attempt(3, 0.8),
+            attempt(4, 0.9),
+            attempt(5, 0.9),
+        ]);
+
+        expect(summary.currentAverage).toBeGreaterThan(0.7);
+    });
+});

--- a/src/typescript/react/src/lib/quizBenchmark.ts
+++ b/src/typescript/react/src/lib/quizBenchmark.ts
@@ -1,0 +1,106 @@
+export type HumanGrade = "ungraded"|"pass"|"fail";
+
+export type QuizAttempt = {
+    id: string; answeredAtUtc : string; autoScore : number; humanGrade : HumanGrade;
+};
+
+export type QuizTrend =
+    |"insufficient-data"|"regressed-below-floor"|"growing"|"stable"|"meets-benchmark";
+
+export type QuizBenchmarkSummary = {
+    trend: QuizTrend; gatePass : boolean; currentAverage : number; previousAverage : number | null;
+    benchmarkTarget : number;
+    regressionFloor : number;
+};
+
+export type QuizBenchmarkOptions = {
+    benchmarkTarget?: number;
+    regressionFloor?: number;
+    windowSize?: number;
+};
+
+function clamp01(value: number): number
+{
+    return Math.max(0, Math.min(1, value));
+}
+
+function effectiveScore(attempt: QuizAttempt): number
+{
+    if (attempt.humanGrade === "pass")
+    {
+        return 1;
+    }
+    if (attempt.humanGrade === "fail")
+    {
+        return 0;
+    }
+    return clamp01(attempt.autoScore);
+}
+
+function average(values: number[]): number
+{
+    if (values.length === 0)
+    {
+        return 0;
+    }
+    const sum = values.reduce((acc, value) => acc + value, 0);
+    return Number((sum / values.length).toFixed(4));
+}
+
+export function analyzeQuizBenchmark(attempts: QuizAttempt[],
+                                     options: QuizBenchmarkOptions = {}): QuizBenchmarkSummary
+{
+    const benchmarkTarget = options.benchmarkTarget ?? 0.8;
+    const regressionFloor = options.regressionFloor ?? 0.65;
+    const windowSize = options.windowSize ?? 5;
+
+    if (attempts.length === 0)
+    {
+        return {
+            trend : "insufficient-data",
+            gatePass : false,
+            currentAverage : 0,
+            previousAverage : null,
+            benchmarkTarget,
+            regressionFloor,
+        };
+    }
+
+    const orderedAttempts =
+        [...attempts ].sort((a, b) => a.answeredAtUtc.localeCompare(b.answeredAtUtc));
+    const scores = orderedAttempts.map(effectiveScore);
+
+    const currentWindow = scores.slice(-windowSize);
+    const previousWindow = scores.slice(-windowSize * 2, -windowSize);
+
+    const currentAverage = average(currentWindow);
+    const previousAverage = previousWindow.length > 0 ? average(previousWindow) : null;
+
+    let trend: QuizTrend = "stable";
+    if (currentAverage < regressionFloor)
+    {
+        trend = "regressed-below-floor";
+    }
+    else if (currentAverage >= benchmarkTarget &&
+             (previousAverage == null || currentAverage >= previousAverage))
+    {
+        trend = "meets-benchmark";
+    }
+    else if (previousAverage != null && currentAverage > previousAverage)
+    {
+        trend = "growing";
+    }
+    else if (attempts.length < windowSize)
+    {
+        trend = "insufficient-data";
+    }
+
+    return {
+        trend,
+        gatePass : currentAverage >= regressionFloor,
+        currentAverage,
+        previousAverage,
+        benchmarkTarget,
+        regressionFloor,
+    };
+}

--- a/src/typescript/react/src/lib/router.tsx
+++ b/src/typescript/react/src/lib/router.tsx
@@ -28,6 +28,7 @@ import { FunctionsPage } from "../pages/FunctionsPage";
 import { KnowledgePage } from "../pages/KnowledgePage";
 import { NotFoundPage } from "../pages/NotFoundPage";
 import { OperatorPage } from "../pages/OperatorPage";
+import { QuizQaPage } from "../pages/QuizQaPage";
 import { ReviewSpikesPage } from "../pages/ReviewSpikesPage";
 import { WorkspacePage } from "../pages/WorkspacePage";
 
@@ -91,6 +92,7 @@ export const router = createBrowserRouter([
           { path: "api-docs", element: <ApiDocsPage /> },
           { path: "data-science", element: <DataSciencePage /> },
           { path: "banana-ai", element: <BananaAIPage /> },
+          { path: "quiz-qa", element: <QuizQaPage /> },
           { path: "review-spikes", element: <ReviewSpikesPage /> },
           { path: "classify", element: <ClassifyPage /> },
           { path: "operator", element: <OperatorPage /> },

--- a/src/typescript/react/src/pages/QuizQaPage.tsx
+++ b/src/typescript/react/src/pages/QuizQaPage.tsx
@@ -1,0 +1,342 @@
+import { useEffect, useMemo, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
+import { Button } from "../components/ui/button";
+import { Textarea } from "../components/ui/textarea";
+import { fetchEnsembleVerdict, resolveApiBaseUrl } from "../lib/api";
+import { trackEvent } from "../lib/analytics";
+import {
+    analyzeQuizBenchmark,
+    type HumanGrade,
+    type QuizAttempt,
+    type QuizTrend,
+} from "../lib/quizBenchmark";
+
+type QuizQuestion = {
+    id: string;
+    prompt: string;
+    expectedLabel: string;
+};
+
+type QuizAttemptRow = QuizAttempt & {
+    questionId: string;
+    prompt: string;
+    expectedLabel: string;
+    predictedLabel: string;
+    graderNotes: string;
+};
+
+const QUIZ_HISTORY_KEY = "banana.quizQa.history.v1";
+
+const quizQuestions: QuizQuestion[] = [
+    {
+        id: "q-001",
+        prompt: "A ripe yellow banana with a few brown spots.",
+        expectedLabel: "banana",
+    },
+    {
+        id: "q-002",
+        prompt: "A steel keyboard with RGB lights.",
+        expectedLabel: "not-banana",
+    },
+    {
+        id: "q-003",
+        prompt: "A banana smoothie in a clear cup.",
+        expectedLabel: "banana",
+    },
+];
+
+function readHistory(): QuizAttemptRow[] {
+    if (typeof window === "undefined") {
+        return [];
+    }
+
+    try {
+        const raw = window.localStorage.getItem(QUIZ_HISTORY_KEY);
+        if (!raw) {
+            return [];
+        }
+
+        const parsed = JSON.parse(raw) as QuizAttemptRow[];
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed;
+    } catch {
+        return [];
+    }
+}
+
+function writeHistory(history: QuizAttemptRow[]): void {
+    if (typeof window === "undefined") {
+        return;
+    }
+    window.localStorage.setItem(QUIZ_HISTORY_KEY, JSON.stringify(history));
+}
+
+function trendLabel(trend: QuizTrend): string {
+    switch (trend) {
+        case "meets-benchmark":
+            return "Meets benchmark";
+        case "growing":
+            return "Growing toward benchmark";
+        case "regressed-below-floor":
+            return "Regressed below floor";
+        case "insufficient-data":
+            return "Insufficient data";
+        default:
+            return "Stable";
+    }
+}
+
+export function QuizQaPage() {
+    const [selectedQuestionId, setSelectedQuestionId] = useState(quizQuestions[0]?.id ?? "");
+    const [questionText, setQuestionText] = useState(quizQuestions[0]?.prompt ?? "");
+    const [expectedLabel, setExpectedLabel] = useState(quizQuestions[0]?.expectedLabel ?? "banana");
+    const [history, setHistory] = useState<QuizAttemptRow[]>([]);
+    const [runningQuiz, setRunningQuiz] = useState(false);
+    const [runError, setRunError] = useState<string | null>(null);
+
+    useEffect(() => {
+        setHistory(readHistory());
+    }, []);
+
+    const benchmarkSummary = useMemo(() => analyzeQuizBenchmark(history), [history]);
+
+    const selectedQuestion = quizQuestions.find((item) => item.id === selectedQuestionId) ?? null;
+
+    function syncQuestionSelection(questionId: string) {
+        const question = quizQuestions.find((item) => item.id === questionId);
+        setSelectedQuestionId(questionId);
+        if (question) {
+            setQuestionText(question.prompt);
+            setExpectedLabel(question.expectedLabel);
+        }
+    }
+
+    function upsertHistory(next: QuizAttemptRow[]) {
+        setHistory(next);
+        writeHistory(next);
+    }
+
+    async function runQuizAgainstModel() {
+        if (!questionText.trim()) {
+            return;
+        }
+
+        setRunningQuiz(true);
+        setRunError(null);
+        try {
+            const base = resolveApiBaseUrl();
+            const verdict = await fetchEnsembleVerdict(base, questionText.trim());
+            const predictedLabel = verdict.label;
+            const autoScore = predictedLabel === expectedLabel ? 1 : 0;
+
+            const nextAttempt: QuizAttemptRow = {
+                id: `attempt-${Date.now()}`,
+                answeredAtUtc: new Date().toISOString(),
+                autoScore,
+                humanGrade: "ungraded",
+                questionId: selectedQuestion?.id ?? "custom",
+                prompt: questionText.trim(),
+                expectedLabel,
+                predictedLabel,
+                graderNotes: "",
+            };
+
+            const nextHistory = [nextAttempt, ...history].slice(0, 200);
+            upsertHistory(nextHistory);
+
+            trackEvent("banana_quiz_run", {
+                expectedLabel,
+                predictedLabel,
+                autoScore,
+            });
+        } catch (error) {
+            setRunError(error instanceof Error ? error.message : String(error));
+        } finally {
+            setRunningQuiz(false);
+        }
+    }
+
+    function addMockAttempt() {
+        const seed = history.length + 1;
+        const autoScore = seed % 3 === 0 ? 0 : 1;
+        const mock: QuizAttemptRow = {
+            id: `mock-${Date.now()}`,
+            answeredAtUtc: new Date().toISOString(),
+            autoScore,
+            humanGrade: "ungraded",
+            questionId: selectedQuestion?.id ?? "mock",
+            prompt: questionText.trim() || "Mock prompt",
+            expectedLabel,
+            predictedLabel: autoScore === 1 ? expectedLabel : expectedLabel === "banana" ? "not-banana" : "banana",
+            graderNotes: "",
+        };
+
+        const nextHistory = [mock, ...history].slice(0, 200);
+        upsertHistory(nextHistory);
+
+        trackEvent("banana_quiz_mock_attempt", {
+            autoScore,
+        });
+    }
+
+    function updateHumanGrade(id: string, humanGrade: HumanGrade) {
+        const nextHistory = history.map((item) =>
+            item.id === id
+                ? {
+                    ...item,
+                    humanGrade,
+                }
+                : item
+        );
+        upsertHistory(nextHistory);
+
+        trackEvent("banana_quiz_grade_update", {
+            humanGrade,
+        });
+    }
+
+    function updateGraderNotes(id: string, notes: string) {
+        const nextHistory = history.map((item) =>
+            item.id === id
+                ? {
+                    ...item,
+                    graderNotes: notes,
+                }
+                : item
+        );
+        upsertHistory(nextHistory);
+    }
+
+    return (
+        <div className="space-y-4" data-testid="quiz-qa-page">
+            <Card>
+                <CardHeader>
+                    <CardTitle>Model Quiz QA</CardTitle>
+                    <CardDescription>
+                        Run repeatable quiz checks against the model, track benchmark trend, and grade past answers with a human-in-the-loop workflow.
+                    </CardDescription>
+                </CardHeader>
+            </Card>
+
+            <Card data-testid="quiz-benchmark-card">
+                <CardHeader>
+                    <CardTitle className="text-base">Benchmark and Non-Regression Gate</CardTitle>
+                    <CardDescription>
+                        Target benchmark: {(benchmarkSummary.benchmarkTarget * 100).toFixed(0)}% · Regression floor: {(benchmarkSummary.regressionFloor * 100).toFixed(0)}%
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm">
+                    <div className="rounded border px-3 py-2" data-testid="quiz-benchmark-status">
+                        <p className="font-medium">{trendLabel(benchmarkSummary.trend)}</p>
+                        <p className="text-muted-foreground">
+                            Gate pass: {benchmarkSummary.gatePass ? "yes" : "no"}
+                        </p>
+                    </div>
+                    <div className="grid gap-2 md:grid-cols-2">
+                        <div className="rounded border px-3 py-2" data-testid="quiz-current-score">
+                            Current average: {(benchmarkSummary.currentAverage * 100).toFixed(2)}%
+                        </div>
+                        <div className="rounded border px-3 py-2" data-testid="quiz-previous-score">
+                            Previous average: {benchmarkSummary.previousAverage == null ? "n/a" : `${(benchmarkSummary.previousAverage * 100).toFixed(2)}%`}
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">Run Quiz Against Model</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                    <label className="text-sm" htmlFor="quiz-question-select">Quiz question</label>
+                    <select
+                        id="quiz-question-select"
+                        value={selectedQuestionId}
+                        onChange={(event) => syncQuestionSelection(event.target.value)}
+                        className="w-full rounded border bg-background px-3 py-2 text-sm"
+                        data-testid="quiz-question-select"
+                    >
+                        {quizQuestions.map((question) => (
+                            <option key={question.id} value={question.id}>{question.id} · {question.expectedLabel}</option>
+                        ))}
+                    </select>
+
+                    <Textarea
+                        value={questionText}
+                        onChange={(event) => setQuestionText(event.target.value)}
+                        rows={3}
+                        data-testid="quiz-question-prompt"
+                    />
+
+                    <label className="text-sm" htmlFor="quiz-expected-label">Expected label</label>
+                    <select
+                        id="quiz-expected-label"
+                        value={expectedLabel}
+                        onChange={(event) => setExpectedLabel(event.target.value)}
+                        className="w-full rounded border bg-background px-3 py-2 text-sm"
+                        data-testid="quiz-expected-label"
+                    >
+                        <option value="banana">banana</option>
+                        <option value="not-banana">not-banana</option>
+                    </select>
+
+                    <div className="flex flex-wrap gap-2">
+                        <Button data-testid="quiz-run-model-btn" onClick={runQuizAgainstModel} disabled={runningQuiz || !questionText.trim()}>
+                            {runningQuiz ? "Running..." : "Run Model Quiz"}
+                        </Button>
+                        <Button type="button" variant="outline" data-testid="quiz-add-mock-btn" onClick={addMockAttempt}>
+                            Add Mock Attempt
+                        </Button>
+                    </div>
+
+                    {runError ? <p className="text-sm text-destructive" data-testid="quiz-run-error">{runError}</p> : null}
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">Past Quiz Answers (Human Grading)</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3" data-testid="quiz-history-list">
+                    {history.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">No quiz attempts yet.</p>
+                    ) : (
+                        history.map((item) => (
+                            <div key={item.id} className="rounded border p-3 space-y-2" data-testid="quiz-history-item">
+                                <div className="grid gap-1 text-sm md:grid-cols-2">
+                                    <p><span className="font-medium">Expected:</span> {item.expectedLabel}</p>
+                                    <p><span className="font-medium">Predicted:</span> {item.predictedLabel}</p>
+                                    <p><span className="font-medium">Auto score:</span> {(item.autoScore * 100).toFixed(0)}%</p>
+                                    <p><span className="font-medium">Answered:</span> {item.answeredAtUtc}</p>
+                                </div>
+                                <p className="text-xs text-muted-foreground">{item.prompt}</p>
+                                <div className="grid gap-2 md:grid-cols-[180px_1fr]">
+                                    <select
+                                        value={item.humanGrade}
+                                        onChange={(event) => updateHumanGrade(item.id, event.target.value as HumanGrade)}
+                                        className="rounded border bg-background px-2 py-1 text-sm"
+                                        data-testid="quiz-human-grade-select"
+                                    >
+                                        <option value="ungraded">ungraded</option>
+                                        <option value="pass">pass</option>
+                                        <option value="fail">fail</option>
+                                    </select>
+                                    <input
+                                        value={item.graderNotes}
+                                        onChange={(event) => updateGraderNotes(item.id, event.target.value)}
+                                        placeholder="grader notes"
+                                        className="rounded border bg-background px-2 py-1 text-sm"
+                                        data-testid="quiz-grader-notes"
+                                    />
+                                </div>
+                            </div>
+                        ))
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/typescript/react/src/pages/WorkspacePage.tsx
+++ b/src/typescript/react/src/pages/WorkspacePage.tsx
@@ -28,6 +28,11 @@ const modules = [
         href: "/banana-ai",
     },
     {
+        title: "Quiz QA",
+        description: "Benchmark and non-regression quiz checks with human grading over historical model answers.",
+        href: "/quiz-qa",
+    },
+    {
         title: "Operator",
         description: "Live chat interface backed by the banana classification model.",
         href: "/operator",

--- a/tests/e2e/playwright/specs/grade-school-quiz-qa.spec.ts
+++ b/tests/e2e/playwright/specs/grade-school-quiz-qa.spec.ts
@@ -1,0 +1,30 @@
+import {expect, test} from "@playwright/test";
+
+test.describe("Quiz QA benchmark and grading", () => {
+    test.beforeEach(
+        async ({page}) => { await page.goto("/quiz-qa", {waitUntil : "domcontentloaded"}); });
+
+    test("shows benchmark panel and current score fields", async ({page}) => {
+        await expect(page.getByTestId("quiz-qa-page")).toBeVisible({timeout : 10_000});
+        await expect(page.getByTestId("quiz-benchmark-card")).toBeVisible();
+        await expect(page.getByTestId("quiz-benchmark-status")).toBeVisible();
+        await expect(page.getByTestId("quiz-current-score")).toBeVisible();
+        await expect(page.getByTestId("quiz-previous-score")).toBeVisible();
+    });
+
+    test("supports mock attempt creation and human grading", async ({page}) => {
+        const addMockButton = page.getByTestId("quiz-add-mock-btn");
+        await expect(addMockButton).toBeVisible();
+
+        await addMockButton.click();
+        await expect(page.getByTestId("quiz-history-item").first()).toBeVisible();
+
+        const firstGradeSelect = page.getByTestId("quiz-human-grade-select").first();
+        await firstGradeSelect.selectOption("pass");
+        await expect(firstGradeSelect).toHaveValue("pass");
+
+        const firstNotes = page.getByTestId("quiz-grader-notes").first();
+        await firstNotes.fill("Reviewed by QA teacher");
+        await expect(firstNotes).toHaveValue("Reviewed by QA teacher");
+    });
+});


### PR DESCRIPTION
## Summary
- Add a dedicated Quiz QA frontend surface for benchmark visibility and human grading of historical answers.
- Add deterministic quiz benchmark and trend gate scripts for CI release evidence.
- Wire grade-school UAT workflow to run quiz UI UAT + benchmark floor + trend-vs-previous-main checks with observe/enforce handling.

## User-facing behavior
- New Quiz QA page with benchmark status, current/previous score, mock attempts, and human grading controls.
- Quiz history entries now support grade and notes.

## CI and release-gate behavior
- `grade-school-uat.yml` now runs:
  - quiz UI UAT suite (`grade-school-quiz-qa.spec.ts`)
  - benchmark gate (`quiz-model-benchmark-gate.ts`)
  - trend gate (`quiz-benchmark-trend-gate.ts`)
- Gate summary/PR comment include quiz benchmark + trend outcomes.
- Artifacts published:
  - `grade-school-gate-report`
  - `quiz-benchmark-gate-report`
  - `quiz-benchmark-trend-gate-report`

## Validation performed
- React typecheck passed.
- `quizBenchmark` unit tests passed.
- Grade-school quiz UAT suite passed locally.
- Workflow YAML parse passed.

## Risks and rollback
- Risk: stricter enforce mode may block if quiz benchmark falls below floor or regresses below prior run while under target.
- Rollback: switch to observe mode in workflow, or revert quiz benchmark/trend steps and scripts.
