### PR TITLE
feat(telemetry): demo-seeded data and richer drilldown

### DIFF
--- a/src/typescript/react/src/pages/TelemetryDashboardPage.tsx
+++ b/src/typescript/react/src/pages/TelemetryDashboardPage.tsx
@@ -43,27 +43,27 @@ const SOURCE_STYLES: Record<
   runtime: {
     label: "Runtime",
     bar: "bg-cyan-500",
-    chip: "border-cyan-300 bg-cyan-50 text-cyan-700 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200",
+    chip: "border-cyan-300 bg-cyan-50 text-cyan-700",
   },
   api: {
     label: "API",
     bar: "bg-violet-500",
-    chip: "border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-800 dark:bg-violet-950/40 dark:text-violet-200",
+    chip: "border-violet-300 bg-violet-50 text-violet-700",
   },
   frontend: {
     label: "Frontend",
     bar: "bg-emerald-500",
-    chip: "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-200",
+    chip: "border-emerald-300 bg-emerald-50 text-emerald-700",
   },
   "wasm-worker": {
     label: "WASM",
     bar: "bg-amber-500",
-    chip: "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200",
+    chip: "border-amber-300 bg-amber-50 text-amber-700",
   },
   native: {
     label: "Native",
     bar: "bg-fuchsia-500",
-    chip: "border-fuchsia-300 bg-fuchsia-50 text-fuchsia-700 dark:border-fuchsia-800 dark:bg-fuchsia-950/40 dark:text-fuchsia-200",
+    chip: "border-fuchsia-300 bg-fuchsia-50 text-fuchsia-700",
   },
 };
 
@@ -164,11 +164,10 @@ function buildBuckets(events: TelemetryEvent[], range: RangePreset, now: number)
 function ReadinessBadge({ ok, label }: { ok: boolean; label: string }) {
   return (
     <span
-      className={`rounded-full border px-2 py-1 text-xs font-medium ${
-        ok
-          ? "border-green-500 bg-green-50 text-green-700 dark:border-green-700 dark:bg-green-950/30 dark:text-green-300"
-          : "border-red-400 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-950/30 dark:text-red-300"
-      }`}
+      className={`rounded-full border px-2 py-1 text-xs font-medium ${ok
+          ? "border-green-500 bg-green-50 text-green-700"
+          : "border-red-400 bg-red-50 text-red-700"
+        }`}
     >
       {label}
     </span>
@@ -650,7 +649,7 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
 
   return (
     <div className="space-y-6" data-testid="telemetry-dashboard-page">
-      <Card className="overflow-hidden border-slate-200 bg-gradient-to-br from-white via-sky-50 to-teal-50 shadow-sm dark:border-slate-700 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
+      <Card className="overflow-hidden border-slate-200 bg-gradient-to-br from-white via-sky-50 to-teal-50 shadow-sm">
         <CardHeader className="gap-4">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
@@ -660,16 +659,16 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
                 native layers.
               </CardDescription>
             </div>
-            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200">
+            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-600 shadow-sm">
               Window: {formatRangeLabel(rangePreset)}
             </div>
           </div>
 
           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
             <label className="space-y-1 text-xs">
-              <span className="font-medium text-slate-600 dark:text-slate-300">Source</span>
+              <span className="font-medium text-slate-600">Source</span>
               <select
-                className="h-9 w-full rounded-md border border-slate-300 bg-white px-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+                className="h-9 w-full rounded-md border border-slate-300 bg-white px-2 text-sm"
                 value={sourceFilter}
                 onChange={(event) =>
                   setSourceFilter(event.target.value as TelemetryEvent["source"] | "all")
@@ -685,9 +684,9 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
             </label>
 
             <label className="space-y-1 text-xs">
-              <span className="font-medium text-slate-600 dark:text-slate-300">Status</span>
+              <span className="font-medium text-slate-600">Status</span>
               <select
-                className="h-9 w-full rounded-md border border-slate-300 bg-white px-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+                className="h-9 w-full rounded-md border border-slate-300 bg-white px-2 text-sm"
                 value={statusFilter}
                 onChange={(event) => setStatusFilter(event.target.value as EventStatusFilter)}
               >
@@ -699,9 +698,9 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
             </label>
 
             <label className="space-y-1 text-xs">
-              <span className="font-medium text-slate-600 dark:text-slate-300">Window</span>
+              <span className="font-medium text-slate-600">Window</span>
               <select
-                className="h-9 w-full rounded-md border border-slate-300 bg-white px-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+                className="h-9 w-full rounded-md border border-slate-300 bg-white px-2 text-sm"
                 value={rangePreset}
                 onChange={(event) => setRangePreset(event.target.value as RangePreset)}
               >
@@ -713,9 +712,9 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
             </label>
 
             <label className="space-y-1 text-xs">
-              <span className="font-medium text-slate-600 dark:text-slate-300">Find event</span>
+              <span className="font-medium text-slate-600">Find event</span>
               <input
-                className="h-9 w-full rounded-md border border-slate-300 bg-white px-2 text-sm placeholder:text-slate-400 dark:border-slate-700 dark:bg-slate-950"
+                className="h-9 w-full rounded-md border border-slate-300 bg-white px-2 text-sm placeholder:text-slate-400"
                 value={eventQuery}
                 onChange={(event) => setEventQuery(event.target.value)}
                 placeholder="wasm.worker.call..."
@@ -724,27 +723,27 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
           </div>
 
           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-            <div className="rounded-lg border border-cyan-300/60 bg-cyan-50/80 p-3 dark:border-cyan-900/70 dark:bg-cyan-950/30">
-              <p className="text-xs text-cyan-800 dark:text-cyan-200">Visible Events</p>
-              <p className="text-2xl font-semibold text-cyan-950 dark:text-cyan-50">
+            <div className="rounded-lg border border-cyan-300/60 bg-cyan-50/80 p-3">
+              <p className="text-xs text-cyan-800">Visible Events</p>
+              <p className="text-2xl font-semibold text-cyan-950">
                 {filteredEvents.length}
               </p>
             </div>
-            <div className="rounded-lg border border-rose-300/60 bg-rose-50/80 p-3 dark:border-rose-900/70 dark:bg-rose-950/30">
-              <p className="text-xs text-rose-800 dark:text-rose-200">Error Rate</p>
-              <p className="text-2xl font-semibold text-rose-900 dark:text-rose-100">
+            <div className="rounded-lg border border-rose-300/60 bg-rose-50/80 p-3">
+              <p className="text-xs text-rose-800">Error Rate</p>
+              <p className="text-2xl font-semibold text-rose-900">
                 {formatPct(filteredErrorRate)}
               </p>
             </div>
-            <div className="rounded-lg border border-indigo-300/60 bg-indigo-50/80 p-3 dark:border-indigo-900/70 dark:bg-indigo-950/30">
-              <p className="text-xs text-indigo-800 dark:text-indigo-200">P95 Duration</p>
-              <p className="text-2xl font-semibold text-indigo-950 dark:text-indigo-50">
+            <div className="rounded-lg border border-indigo-300/60 bg-indigo-50/80 p-3">
+              <p className="text-xs text-indigo-800">P95 Duration</p>
+              <p className="text-2xl font-semibold text-indigo-950">
                 {Math.round(filteredP95)} ms
               </p>
             </div>
-            <div className="rounded-lg border border-emerald-300/60 bg-emerald-50/80 p-3 dark:border-emerald-900/70 dark:bg-emerald-950/30">
-              <p className="text-xs text-emerald-800 dark:text-emerald-200">Active Signals</p>
-              <p className="text-2xl font-semibold text-emerald-950 dark:text-emerald-50">
+            <div className="rounded-lg border border-emerald-300/60 bg-emerald-50/80 p-3">
+              <p className="text-xs text-emerald-800">Active Signals</p>
+              <p className="text-2xl font-semibold text-emerald-950">
                 {activeSignals}
               </p>
             </div>
@@ -774,8 +773,8 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
                     key={source}
                     type="button"
                     className={`rounded-full border px-2 py-1 text-[11px] transition ${selected
-                        ? styles.chip
-                        : "border-slate-300 text-slate-500 dark:border-slate-700 dark:text-slate-400"
+                      ? styles.chip
+                      : "border-slate-300 text-slate-500"
                       }`}
                     onClick={() => {
                       setVisibleTimelineSources((current) => ({
@@ -808,7 +807,7 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
                       className="group relative flex h-full flex-1 items-end"
                     >
                       <div
-                        className="w-full rounded-t bg-slate-300/60 transition-colors dark:bg-slate-700/70"
+                        className="w-full rounded-t bg-slate-300/60 transition-colors"
                         style={{ height: `${totalHeight}px` }}
                       />
                       <div className="absolute bottom-0 flex w-full items-end gap-px px-[1px]">
@@ -869,7 +868,7 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
                     <span className="font-medium">{source}</span>
                     <span>{count}</span>
                   </div>
-                  <div className="h-2 rounded bg-slate-100 dark:bg-slate-800">
+                  <div className="h-2 rounded bg-slate-100">
                     <div
                       className={`h-2 rounded ${SOURCE_STYLES[source].bar}`}
                       style={{ width: `${width}%` }}
@@ -981,14 +980,14 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
                 {latestEvents.map((event, index) => (
                   <div
                     key={`${event.event}-${event.timestamp}-${index}`}
-                    className="rounded border border-slate-200 bg-white p-2 shadow-sm dark:border-slate-700 dark:bg-slate-900/60"
+                    className="rounded border border-slate-200 bg-white p-2 shadow-sm"
                   >
                     <div className="flex items-center justify-between gap-2 text-[11px]">
                       <span className="font-mono">{event.event}</span>
                       <span
                         className={`rounded-full px-2 py-0.5 ${event.status === "error"
-                            ? "bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-200"
-                            : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200"
+                          ? "bg-rose-100 text-rose-700"
+                          : "bg-emerald-100 text-emerald-700"
                           }`}
                       >
                         {event.status}
@@ -1067,25 +1066,25 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
         <CardContent>
           <div className="space-y-4">
             <div className="grid gap-3 md:grid-cols-4">
-              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm">
                 <p className="text-xs text-muted-foreground">Init Success</p>
                 <p className="text-lg font-semibold" data-testid="wasm-init-success-rate">
                   {formatPct(initSuccessRate)}
                 </p>
               </div>
-              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm">
                 <p className="text-xs text-muted-foreground">Fallback Rate</p>
                 <p className="text-lg font-semibold" data-testid="wasm-fallback-rate">
                   {formatPct(fallbackRate)}
                 </p>
               </div>
-              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm">
                 <p className="text-xs text-muted-foreground">Timeout Rate</p>
                 <p className="text-lg font-semibold" data-testid="wasm-timeout-rate">
                   {formatPct(timeoutRate)}
                 </p>
               </div>
-              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm">
                 <p className="text-xs text-muted-foreground">P95 Call Duration</p>
                 <p className="text-lg font-semibold" data-testid="wasm-p95-duration">
                   {Math.round(wasmP95)} ms
@@ -1094,19 +1093,19 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
             </div>
 
             <div className="grid gap-3 md:grid-cols-3" data-testid="wasm-latency-percentiles">
-              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm">
                 <p className="text-xs text-muted-foreground">WASM p50</p>
                 <p className="text-base font-semibold">
                   {Math.round(wasmLatencyPercentiles.p50)} ms
                 </p>
               </div>
-              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm">
                 <p className="text-xs text-muted-foreground">WASM p95</p>
                 <p className="text-base font-semibold">
                   {Math.round(wasmLatencyPercentiles.p95)} ms
                 </p>
               </div>
-              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+              <div className="rounded border border-slate-200 bg-white p-3 shadow-sm">
                 <p className="text-xs text-muted-foreground">WASM p99</p>
                 <p className="text-base font-semibold">
                   {Math.round(wasmLatencyPercentiles.p99)} ms
@@ -1144,33 +1143,33 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
           ) : (
             <div className="space-y-3">
               <div className="grid gap-3 md:grid-cols-3">
-                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40" data-testid="native-wrapper-count">
+                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm" data-testid="native-wrapper-count">
                   <p className="text-xs text-muted-foreground">Wrapper Events</p>
                   <p className="text-lg font-semibold">{nativeLayerBreakdown.wrapper}</p>
                 </div>
-                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40" data-testid="native-core-count">
+                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm" data-testid="native-core-count">
                   <p className="text-xs text-muted-foreground">Core Events</p>
                   <p className="text-lg font-semibold">{nativeLayerBreakdown.core}</p>
                 </div>
-                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40" data-testid="native-dal-count">
+                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm" data-testid="native-dal-count">
                   <p className="text-xs text-muted-foreground">DAL Events</p>
                   <p className="text-lg font-semibold">{nativeLayerBreakdown.dal}</p>
                 </div>
               </div>
               <div className="grid gap-3 md:grid-cols-3" data-testid="native-latency-percentiles">
-                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm">
                   <p className="text-xs text-muted-foreground">Native p50</p>
                   <p className="text-base font-semibold">
                     {Math.round(nativeLatencyPercentiles.p50)} ms
                   </p>
                 </div>
-                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm">
                   <p className="text-xs text-muted-foreground">Native p95</p>
                   <p className="text-base font-semibold">
                     {Math.round(nativeLatencyPercentiles.p95)} ms
                   </p>
                 </div>
-                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+                <div className="rounded border border-slate-200 bg-white p-3 shadow-sm">
                   <p className="text-xs text-muted-foreground">Native p99</p>
                   <p className="text-base font-semibold">
                     {Math.round(nativeLatencyPercentiles.p99)} ms

--- a/src/typescript/react/src/pages/TelemetryDashboardPage.tsx
+++ b/src/typescript/react/src/pages/TelemetryDashboardPage.tsx
@@ -179,6 +179,183 @@ type HydrationState = {
   message: string;
 };
 
+function buildDemoTelemetryEvents(now: number): TelemetryEvent[] {
+  const minute = 60 * 1000;
+  return [
+    {
+      source: "frontend",
+      event: "telemetry.dashboard.session.started",
+      timestamp: now - 58 * minute,
+      status: "info",
+      details: { route: "/telemetry", session: "demo-seed" },
+    },
+    {
+      source: "runtime",
+      event: "runtime.service.root.ok",
+      timestamp: now - 56 * minute,
+      status: "ok",
+      durationMs: 32,
+      details: { service: "banana-api", status: "healthy" },
+    },
+    {
+      source: "api",
+      event: "api.health.check.ok",
+      timestamp: now - 55 * minute,
+      status: "ok",
+      durationMs: 48,
+      details: { status: "healthy" },
+    },
+    {
+      source: "api",
+      event: "api.telemetry.config.loaded",
+      timestamp: now - 54 * minute,
+      status: "ok",
+      durationMs: 65,
+      details: { sample_rate: 1, unit: "ms" },
+    },
+    {
+      source: "wasm-worker",
+      event: "wasm.worker.init.ready",
+      timestamp: now - 49 * minute,
+      status: "ok",
+      durationMs: 212,
+      variant: "simd",
+      details: { runtime: "webworker", region: "local" },
+    },
+    {
+      source: "wasm-worker",
+      event: "wasm.worker.call.started",
+      timestamp: now - 45 * minute,
+      status: "info",
+      durationMs: 6,
+      variant: "simd",
+      details: { id: "demo-call-1", model: "banana-classifier" },
+    },
+    {
+      source: "wasm-worker",
+      event: "wasm.worker.call.completed",
+      timestamp: now - 44 * minute,
+      status: "ok",
+      durationMs: 88,
+      variant: "simd",
+      details: { id: "demo-call-1", score: 0.93 },
+    },
+    {
+      source: "native",
+      event: "native.wrapper.call.completed",
+      timestamp: now - 40 * minute,
+      status: "ok",
+      durationMs: 17,
+      layer: "wrapper",
+      details: { id: "native-1", channel: "inference" },
+    },
+    {
+      source: "native",
+      event: "native.core.eval.completed",
+      timestamp: now - 39 * minute,
+      status: "ok",
+      durationMs: 11,
+      layer: "core",
+      details: { id: "native-1", stage: "score" },
+    },
+    {
+      source: "native",
+      event: "native.dal.fetch.completed",
+      timestamp: now - 38 * minute,
+      status: "ok",
+      durationMs: 21,
+      layer: "dal",
+      details: { id: "native-1", rows: 3 },
+    },
+    {
+      source: "wasm-worker",
+      event: "wasm.worker.call.started",
+      timestamp: now - 34 * minute,
+      status: "info",
+      durationMs: 4,
+      variant: "simd",
+      details: { id: "demo-call-2", model: "banana-classifier" },
+    },
+    {
+      source: "wasm-worker",
+      event: "wasm.worker.call.error",
+      timestamp: now - 33 * minute,
+      status: "error",
+      durationMs: 615,
+      code: 1001,
+      variant: "simd",
+      details: { id: "demo-call-2", reason: "wasm_timeout", message: "execution_timeout" },
+    },
+    {
+      source: "wasm-worker",
+      event: "wasm.worker.fallback.triggered",
+      timestamp: now - 32 * minute,
+      status: "info",
+      durationMs: 12,
+      variant: "simd",
+      details: { id: "demo-call-2", fallback: "native" },
+    },
+    {
+      source: "native",
+      event: "native.wrapper.call.completed",
+      timestamp: now - 31 * minute,
+      status: "ok",
+      durationMs: 26,
+      layer: "wrapper",
+      details: { id: "native-fallback-2", from: "wasm_timeout" },
+    },
+    {
+      source: "native",
+      event: "native.core.eval.completed",
+      timestamp: now - 30 * minute,
+      status: "ok",
+      durationMs: 14,
+      layer: "core",
+      details: { id: "native-fallback-2", stage: "score" },
+    },
+    {
+      source: "api",
+      event: "api.inference.request.completed",
+      timestamp: now - 24 * minute,
+      status: "ok",
+      durationMs: 171,
+      details: { endpoint: "/api/v1/classify", status: 200 },
+    },
+    {
+      source: "runtime",
+      event: "runtime.model.cache.hit",
+      timestamp: now - 19 * minute,
+      status: "ok",
+      durationMs: 9,
+      details: { model: "banana", key: "banana-v2" },
+    },
+    {
+      source: "frontend",
+      event: "telemetry.dashboard.filters.updated",
+      timestamp: now - 13 * minute,
+      status: "info",
+      details: { source: "all", status: "all", window: "60m" },
+    },
+    {
+      source: "api",
+      event: "api.health.check.ok",
+      timestamp: now - 9 * minute,
+      status: "ok",
+      durationMs: 43,
+      details: { status: "healthy" },
+    },
+    {
+      source: "wasm-worker",
+      event: "wasm.worker.call.completed",
+      timestamp: now - 5 * minute,
+      status: "ok",
+      durationMs: 74,
+      variant: "simd",
+      details: { id: "demo-call-3", score: 0.88 },
+    },
+  ];
+}
+
 export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: boolean }) {
   const snapshot = useTelemetrySnapshot();
   const [remoteEvents, setRemoteEvents] = useState<TelemetryEvent[] | null>(null);
@@ -187,6 +364,7 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
   const [sourceFilter, setSourceFilter] = useState<TelemetryEvent["source"] | "all">("all");
   const [statusFilter, setStatusFilter] = useState<EventStatusFilter>("all");
   const [eventQuery, setEventQuery] = useState("");
+  const [selectedSignal, setSelectedSignal] = useState<string | null>(null);
   const [visibleTimelineSources, setVisibleTimelineSources] = useState<
     Record<TelemetryEvent["source"], boolean>
   >({
@@ -405,14 +583,29 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
     };
   }, [autoHydrate]);
 
+  const now = Date.now();
   const telemetryEvents = remoteEvents && remoteEvents.length > 0 ? remoteEvents : snapshot.events;
   const usingRemoteEvents = !!remoteEvents && remoteEvents.length > 0;
-  const now = Date.now();
+  const demoEvents = useMemo(() => buildDemoTelemetryEvents(now), [now]);
+  const usingDemoEvents = autoHydrate && telemetryEvents.length < 12;
+  const displayEvents = useMemo(() => {
+    if (!usingDemoEvents) {
+      return telemetryEvents;
+    }
+
+    const existing = new Set(
+      telemetryEvents.map((event) => `${event.source}|${event.event}|${event.timestamp}`)
+    );
+    const seeded = demoEvents.filter(
+      (event) => !existing.has(`${event.source}|${event.event}|${event.timestamp}`)
+    );
+    return [...telemetryEvents, ...seeded];
+  }, [usingDemoEvents, telemetryEvents, demoEvents]);
   const rangeStart = now - RANGE_PRESETS[rangePreset];
 
   const filteredEvents = useMemo(() => {
     const query = eventQuery.trim().toLowerCase();
-    return telemetryEvents.filter((event) => {
+    return displayEvents.filter((event) => {
       if (event.timestamp < rangeStart || event.timestamp > now) {
         return false;
       }
@@ -432,7 +625,7 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
       const detailsText = JSON.stringify(event.details ?? {}).toLowerCase();
       return event.event.toLowerCase().includes(query) || detailsText.includes(query);
     });
-  }, [telemetryEvents, sourceFilter, statusFilter, eventQuery, rangeStart, now]);
+  }, [displayEvents, sourceFilter, statusFilter, eventQuery, rangeStart, now]);
 
   const sourceBreakdown = useMemo(() => {
     const counts: Record<TelemetryEvent["source"], number> = {
@@ -495,11 +688,11 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
       .slice(0, 8);
   }, [filteredEvents]);
 
-  const runtimeEvents = telemetryEvents.filter((event) => event.source === "runtime");
-  const apiEvents = telemetryEvents.filter((event) => event.source === "api");
-  const frontendEvents = telemetryEvents.filter((event) => event.source === "frontend");
-  const wasmEvents = telemetryEvents.filter((event) => event.source === "wasm-worker");
-  const nativeEvents = telemetryEvents.filter((event) => event.source === "native");
+  const runtimeEvents = displayEvents.filter((event) => event.source === "runtime");
+  const apiEvents = displayEvents.filter((event) => event.source === "api");
+  const frontendEvents = displayEvents.filter((event) => event.source === "frontend");
+  const wasmEvents = displayEvents.filter((event) => event.source === "wasm-worker");
+  const nativeEvents = displayEvents.filter((event) => event.source === "native");
 
   const wasmCallStarts = wasmEvents.filter((event) => event.event === "wasm.worker.call.started");
   const wasmAttemptIds = new Set(
@@ -643,13 +836,44 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
       .slice(0, 12);
   }, [filteredEvents]);
 
+  const selectedSignalEvents = useMemo(() => {
+    if (!selectedSignal) {
+      return [];
+    }
+
+    return filteredEvents
+      .filter((event) => event.event === selectedSignal)
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, 8);
+  }, [filteredEvents, selectedSignal]);
+
+  const selectedSignalSourceCounts = useMemo(() => {
+    const counts: Record<TelemetryEvent["source"], number> = {
+      runtime: 0,
+      api: 0,
+      frontend: 0,
+      "wasm-worker": 0,
+      native: 0,
+    };
+
+    for (const event of selectedSignalEvents) {
+      counts[event.source] += 1;
+    }
+
+    return counts;
+  }, [selectedSignalEvents]);
+
+  const slowEventCount = filteredEvents.filter(
+    (event) => typeof event.durationMs === "number" && event.durationMs > 250
+  ).length;
+
   const lastUpdatedMs = usingRemoteEvents
     ? (remoteUpdatedAt ?? snapshot.updatedAt)
     : snapshot.updatedAt;
 
   return (
     <div className="space-y-6" data-testid="telemetry-dashboard-page">
-      <Card className="overflow-hidden border-slate-200 bg-gradient-to-br from-white via-sky-50 to-teal-50 shadow-sm">
+      <Card className="overflow-hidden border-slate-200 bg-gradient-to-br from-white via-slate-50 to-sky-100 shadow-sm">
         <CardHeader className="gap-4">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
@@ -752,6 +976,44 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
           <p className="text-xs text-muted-foreground" data-testid="telemetry-api-hydration-status">
             API feed: {hydration.message}
           </p>
+          {usingDemoEvents ? (
+            <p className="text-xs text-amber-700" data-testid="telemetry-demo-seed-notice">
+              Demo mode active: sparse live feed detected, seeded telemetry events are layered in
+              for drill-down exploration.
+            </p>
+          ) : null}
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="rounded-full border border-rose-200 bg-rose-50 px-3 py-1 text-xs font-medium text-rose-700"
+              onClick={() => setStatusFilter("error")}
+            >
+              Focus Errors ({filteredErrorCount})
+            </button>
+            <button
+              type="button"
+              className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-700"
+              onClick={() => setEventQuery("call")}
+            >
+              Calls Only
+            </button>
+            <button
+              type="button"
+              className="rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-700"
+              onClick={() => {
+                setStatusFilter("all");
+                setSourceFilter("all");
+                setEventQuery("");
+                setSelectedSignal(null);
+              }}
+            >
+              Reset Filters
+            </button>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-600">
+              Slow events &gt; 250ms: {slowEventCount}
+            </span>
+          </div>
         </CardHeader>
       </Card>
 
@@ -863,7 +1125,12 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
                 Math.min(100, percent(count, Math.max(1, filteredEvents.length)))
               );
               return (
-                <div key={source} className="space-y-1">
+                <button
+                  key={source}
+                  type="button"
+                  className="w-full space-y-1 text-left"
+                  onClick={() => setSourceFilter(source)}
+                >
                   <div className="flex items-center justify-between text-xs">
                     <span className="font-medium">{source}</span>
                     <span>{count}</span>
@@ -874,7 +1141,7 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
                       style={{ width: `${width}%` }}
                     />
                   </div>
-                </div>
+                </button>
               );
             })}
           </CardContent>
@@ -951,7 +1218,16 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
                   </thead>
                   <tbody>
                     {topEventSignatures.map((signal) => (
-                      <tr key={signal.eventName} className="border-b last:border-b-0">
+                      <tr
+                        key={signal.eventName}
+                        className={`cursor-pointer border-b last:border-b-0 ${
+                          selectedSignal === signal.eventName ? "bg-sky-50" : ""
+                        }`}
+                        onClick={() => {
+                          setSelectedSignal(signal.eventName);
+                          setEventQuery(signal.eventName);
+                        }}
+                      >
                         <td className="py-2 pr-2 font-mono text-[11px]">{signal.eventName}</td>
                         <td className="py-2 pr-2">{signal.count}</td>
                         <td className="py-2 pr-2">{signal.errors}</td>
@@ -1007,6 +1283,79 @@ export function TelemetryDashboardPage({ autoHydrate = true }: { autoHydrate?: b
           </CardContent>
         </Card>
       </div>
+
+      <Card data-testid="telemetry-signal-drilldown">
+        <CardHeader>
+          <CardTitle className="text-base">Signal Drilldown</CardTitle>
+          <CardDescription>
+            Click any signal in the Top Signals table to inspect recent occurrences and source
+            distribution.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!selectedSignal ? (
+            <p className="text-sm text-muted-foreground">
+              No signal selected yet. Choose a row from Top Signals to populate this panel.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              <div className="rounded border border-slate-200 bg-white p-3">
+                <p className="text-xs text-slate-500">Selected Signal</p>
+                <p className="font-mono text-sm text-slate-800">{selectedSignal}</p>
+              </div>
+              <div className="grid gap-3 md:grid-cols-5">
+                {DASHBOARD_SOURCES.map((source) => (
+                  <div key={source} className="rounded border border-slate-200 bg-white p-3">
+                    <p className="text-xs text-slate-500">{SOURCE_STYLES[source].label}</p>
+                    <p className="text-lg font-semibold text-slate-800">
+                      {selectedSignalSourceCounts[source]}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              {selectedSignalEvents.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  The selected signal is outside the current filter scope.
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-left text-xs">
+                    <thead>
+                      <tr className="border-b text-muted-foreground">
+                        <th className="py-2 pr-2 font-medium">Time</th>
+                        <th className="py-2 pr-2 font-medium">Source</th>
+                        <th className="py-2 pr-2 font-medium">Status</th>
+                        <th className="py-2 pr-2 font-medium">Duration</th>
+                        <th className="py-2 font-medium">Details</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {selectedSignalEvents.map((event) => (
+                        <tr
+                          key={`${event.source}-${event.timestamp}-${event.event}`}
+                          className="border-b last:border-b-0"
+                        >
+                          <td className="py-2 pr-2">{new Date(event.timestamp).toLocaleTimeString()}</td>
+                          <td className="py-2 pr-2">{event.source}</td>
+                          <td className="py-2 pr-2">{event.status}</td>
+                          <td className="py-2 pr-2">
+                            {typeof event.durationMs === "number"
+                              ? `${Math.round(event.durationMs)} ms`
+                              : "-"}
+                          </td>
+                          <td className="max-w-[360px] truncate py-2" title={JSON.stringify(event.details ?? {})}>
+                            {JSON.stringify(event.details ?? {})}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>


### PR DESCRIPTION
## Summary
- improves light-theme header contrast for readability
- adds demo-seeded telemetry when live feed is sparse (for demoability)
- adds deeper drilldown interactions:
  - quick filter pills (errors/calls/reset)
  - clickable source mix bars to filter by source
  - clickable Top Signals rows to focus a signal
  - new Signal Drilldown panel with source distribution and recent occurrences

## Validation
- bunx biome format --write src/pages/TelemetryDashboardPage.tsx
- bun test src/pages/TelemetryDashboardPage.test.tsx (2/2 passing)

## Notes
Demo seeding is only active when telemetry is sparse and hydration is enabled.