### PR TITLE
chore(ci): rename workflow to Banana Monorepo Gating

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,4 @@
-name: Monorepo
+name: Banana Monorepo Gating
 
 # Single orchestrator for all monorepo PR / push validation. Renders the
 # underlying lanes as a single workflow run with a single terminal pass/fail


### PR DESCRIPTION
Rename the monorepo orchestrator workflow display name for clearer Actions visibility and summary-first triage.