### PR TITLE
fix(ci): repair Banana Monorepo Gating YAML syntax

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -470,7 +470,8 @@ jobs:
 
       - name: Screenshot lane skipped
         if: steps.screenshot-gate.outputs.should_run != 'true'
-        run: echo "Skipping screenshot lane: ${{ steps.screenshot-gate.outputs.reason }}"
+        run: |
+          echo "Skipping screenshot lane: ${{ steps.screenshot-gate.outputs.reason }}"
 
       - name: Setup Bun
         if: steps.screenshot-gate.outputs.should_run == 'true'


### PR DESCRIPTION
Fix YAML parsing error at the screenshot skip step by using a block scalar for the run command.