### PR TITLE
chore(ci): move Banana-Monorepo harness to banana.yml

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 This repository uses a single workflow harness:
 
-- `.github/workflows/pre-commit.yml` with workflow name `Banana-Monorepo`
+- `.github/workflows/banana.yml` with workflow name `Banana-Monorepo`
 
 All managed CI/CD lanes must be orchestrated inside this harness so operators can
 triage one unified graph and one pass/fail summary.

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -328,7 +328,7 @@ jobs:
       - name: Run workflow runtime compatibility check
         run: |
           bash scripts/check-workflow-runtime-deprecations.sh \
-            --workflow .github/workflows/pre-commit.yml \
+            --workflow .github/workflows/banana.yml \
             --exceptions .github/runtime-compatibility-exceptions.yml \
             --output .artifacts/compose-ci/runtime-compatibility/runtime-compatibility.json \
             --text-output .artifacts/compose-ci/runtime-compatibility/runtime-compatibility.txt

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-    "feature_directory": ".specify/specs/001-game-engine-architecture"
+    "feature_directory": ".specify/specs/002-banana-monorepo-harness"
 }

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,6 @@
 <!--
 Sync Impact Report
-- Version change: 1.10.0 -> 1.10.1
+- Version change: 1.10.1 -> 1.10.2
 - Modified principles:
 	- Added X. Observable Infrastructure as Code
 	- Added XI. Spec-Driven Infrastructure Discovery
@@ -22,6 +22,7 @@ Sync Impact Report
 - Added workflow guidance: deferred-ledger closure when remaining specs are blocked/research-only
 - Added workflow guidance: mandatory targeted Q/A when confidence in the next code-improving step is below 70%
 - Added workflow guidance: single `Banana-Monorepo` harness requirement for all managed lanes
+- Added workflow guidance: canonical harness file path `.github/workflows/banana.yml`
 - Templates requiring updates:
 	- ✅ updated .specify/templates/plan-template.md
 	- ✅ compatible .specify/templates/spec-template.md
@@ -112,6 +113,7 @@ Banana-managed CI/CD lanes must be orchestrated through a single workflow harnes
 - each job has one clear responsibility,
 - new lanes extend the harness without creating parallel top-level workflow sprawl,
 - lane contracts remain stable and composable for the terminal pass/fail summary.
+The canonical harness file is `.github/workflows/banana.yml`.
 
 ## Platform Constraints
 
@@ -165,4 +167,4 @@ This constitution governs Spec Kit driven development and automation workflows i
 Amendments require a pull request that documents rationale, migration impact, and validation updates.
 Reviewers should block merges that violate these principles.
 
-**Version**: 1.10.1 | **Ratified**: 2026-04-24 | **Last Amended**: 2026-05-09
+**Version**: 1.10.2 | **Ratified**: 2026-04-24 | **Last Amended**: 2026-05-09

--- a/.specify/specs/002-banana-monorepo-harness/plan.md
+++ b/.specify/specs/002-banana-monorepo-harness/plan.md
@@ -1,0 +1,47 @@
+# Implementation Plan: Banana Monorepo Workflow Harness
+
+## Objective
+
+Establish `Banana-Monorepo` at `.github/workflows/banana.yml` as the single managed CI/CD harness with domain-driven lanes and SOLID-oriented orchestration guidance.
+
+## Scope
+
+- Rename canonical harness file to `banana.yml`.
+- Keep workflow name as `Banana-Monorepo`.
+- Update harness references and docs.
+- Update constitution memory for long-term policy retention.
+
+## Design
+
+1. Canonical entrypoint
+- Single workflow file in `.github/workflows/banana.yml`.
+- One terminal gate for pass/fail and summary.
+
+2. Domain lane structure
+- Lint/static lanes first.
+- Build lanes second.
+- Native/runtime integration lanes after foundational checks.
+- Terminal gate consumes all lane statuses.
+
+3. SOLID-inspired workflow composition
+- Single Responsibility: one job per domain concern.
+- Open/Closed: extend by adding jobs, not new top-level workflows.
+- Liskov-style contracts: stable lane outputs/semantics for summary consumption.
+- Interface Segregation: keep lane-local env/inputs minimal.
+- Dependency Inversion: defer complex logic to scripts under `scripts/`.
+
+## Validation
+
+- YAML parse succeeds for `banana.yml`.
+- `gh workflow list` shows canonical file path and expected workflow name after indexing.
+- PR checks run through the single harness path.
+
+## Risks
+
+- GitHub workflow metadata indexing may lag file rename in UI.
+- Legacy references in generated artifacts may trail until regenerated.
+
+## Mitigation
+
+- Keep canonical references in source docs and constitution.
+- Regenerate downstream artifacts in normal sync workflows.

--- a/.specify/specs/002-banana-monorepo-harness/spec.md
+++ b/.specify/specs/002-banana-monorepo-harness/spec.md
@@ -1,0 +1,69 @@
+# Feature Specification: Banana Monorepo Workflow Harness
+
+**Feature Branch**: `002-banana-monorepo-harness`
+**Created**: 2026-05-09
+**Status**: Draft
+**Input**: Consolidate all managed CI/CD stages into a single `Banana-Monorepo` harness backed by `.github/workflows/banana.yml`, with domain-driven lane composition and SOLID orchestration rules.
+
+## Problem Statement
+
+Workflow sprawl and inconsistent naming reduce observability and make failure triage harder. Banana needs one canonical workflow harness that presents all managed CI/CD lanes as a single orchestrated graph and terminal summary gate.
+
+## In Scope
+
+- Canonical workflow file path: `.github/workflows/banana.yml`.
+- Canonical workflow display name: `Banana-Monorepo`.
+- Single-harness orchestration pattern for managed CI/CD lanes.
+- Domain-driven lane boundaries and SOLID-style lane composition rules.
+- Constitution and workflow docs updates that lock this policy.
+
+## Out of Scope
+
+- GitHub-managed dynamic workflows (for example Copilot internal dynamic workflows).
+- Reintroduction of stage-specific standalone workflow files.
+- Deep refactors of lane implementation scripts unless required for harness wiring.
+
+## User Scenarios & Testing
+
+### User Story 1 - Single Pane Failure Triage (Priority: P1)
+
+As a maintainer, I can open one monorepo workflow run and understand which domain lane failed and why.
+
+**Independent Test**: Trigger CI on a PR and confirm all managed lanes appear under one `Banana-Monorepo` run with a single terminal pass/fail gate.
+
+### User Story 2 - Stable Orchestration Contract (Priority: P1)
+
+As a workflow author, I can add a new lane without adding a new top-level workflow file.
+
+**Independent Test**: Add a lane job in `banana.yml` with explicit `needs` and verify summary output includes the lane result.
+
+### User Story 3 - Memory-Persistent Governance (Priority: P2)
+
+As a team member, I can rely on Spec Kit constitution rules to prevent workflow sprawl from returning.
+
+**Independent Test**: Constitution and workflow README explicitly reference `Banana-Monorepo` and `.github/workflows/banana.yml` as the canonical harness.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The repository MUST use `.github/workflows/banana.yml` as the single managed CI/CD harness file.
+- **FR-002**: The harness workflow name MUST be `Banana-Monorepo`.
+- **FR-003**: Managed lanes MUST be modeled as domain jobs within the harness and orchestrated with explicit `needs` dependencies.
+- **FR-004**: The harness MUST publish a terminal summary/pass-fail stage that reports lane-level outcomes.
+- **FR-005**: Governance docs and constitution memory MUST codify the single-harness policy and DDD/SOLID composition rules.
+
+### Key Entities
+
+- **WorkflowHarness**: The single orchestrator workflow (`banana.yml`) that coordinates all managed CI/CD lanes.
+- **DomainLane**: A bounded workflow job representing one domain responsibility (lint, build, native, runtime, etc.).
+- **TerminalGate**: The summary/pass-fail step that consolidates lane outcomes into merge readiness.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Only one repository-managed workflow file remains active for managed CI/CD orchestration (`banana.yml`).
+- **SC-002**: CI runs present all managed stages under workflow name `Banana-Monorepo`.
+- **SC-003**: Terminal gate output includes lane-by-lane result rows and deterministic failure semantics.
+- **SC-004**: Constitution and workflow docs include explicit canonical harness name/path and DDD/SOLID rules.

--- a/.specify/specs/002-banana-monorepo-harness/tasks.md
+++ b/.specify/specs/002-banana-monorepo-harness/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Banana Monorepo Workflow Harness
+
+## Phase 1 - Canonical Harness Path
+
+- [x] Rename `.github/workflows/pre-commit.yml` to `.github/workflows/banana.yml`.
+- [x] Update internal self-reference in runtime compatibility lane.
+- [x] Validate YAML syntax after rename.
+
+## Phase 2 - Governance and Documentation
+
+- [x] Update `.github/workflows/README.md` with canonical harness file path.
+- [x] Amend `.specify/memory/constitution.md` with canonical `banana.yml` path policy.
+- [x] Bump constitution version for traceability.
+
+## Phase 3 - Spec Kit Scaffolding
+
+- [x] Create feature spec in `.specify/specs/002-banana-monorepo-harness/spec.md`.
+- [x] Add implementation plan in `.specify/specs/002-banana-monorepo-harness/plan.md`.
+- [x] Add task scaffold in `.specify/specs/002-banana-monorepo-harness/tasks.md`.
+- [ ] Update `.specify/feature.json` to point to this feature when execution moves to implementation mode.
+
+## Phase 4 - Verification
+
+- [ ] Verify Actions UI reflects `Banana-Monorepo` naming after workflow indexing refresh.
+- [ ] Confirm only the canonical harness remains for repository-managed CI/CD lanes.

--- a/.specify/specs/002-banana-monorepo-harness/tasks.md
+++ b/.specify/specs/002-banana-monorepo-harness/tasks.md
@@ -17,7 +17,7 @@
 - [x] Create feature spec in `.specify/specs/002-banana-monorepo-harness/spec.md`.
 - [x] Add implementation plan in `.specify/specs/002-banana-monorepo-harness/plan.md`.
 - [x] Add task scaffold in `.specify/specs/002-banana-monorepo-harness/tasks.md`.
-- [ ] Update `.specify/feature.json` to point to this feature when execution moves to implementation mode.
+- [x] Update `.specify/feature.json` to point to this feature when execution moves to implementation mode.
 
 ## Phase 4 - Verification
 


### PR DESCRIPTION
## Summary
- rename monorepo harness file to .github/workflows/banana.yml
- keep workflow name as Banana-Monorepo
- update workflow docs and constitution memory for canonical harness path
- scaffold spec-kit feature 002-banana-monorepo-harness (spec/plan/tasks)
- point .specify/feature.json to the new feature directory

## Intent
Use one domain-driven monorepo workflow harness and retain this policy in Spec Kit memory.