### PR TITLE
spec(001): Banana Engineer name + C generative asset compiler requirements

### DIFF
--- a/.specify/specs/001-react-portal-game-client/checklists/requirements.md
+++ b/.specify/specs/001-react-portal-game-client/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: React Portal Game Client Pivot
+# Specification Quality Checklist: Banana Engineer
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-05-09

--- a/.specify/specs/001-react-portal-game-client/plan.md
+++ b/.specify/specs/001-react-portal-game-client/plan.md
@@ -1,23 +1,23 @@
-# Implementation Plan: React Portal 2.5D Game Client Pivot
+# Implementation Plan: Banana Engineer
 
 **Branch**: `001-react-portal-game-client` | **Date**: 2026-05-09 | **Spec**: `.specify/specs/001-react-portal-game-client/spec.md`
 **Input**: Feature specification from `.specify/specs/001-react-portal-game-client/spec.md`
 
 ## Summary
 
-Refocus Banana toward a 2.5D game-client-style React portal by rebuilding the landing route as a WASM-rendered entry surface while preserving deployability and reducing active scope drift from legacy research-era surfaces.
+Refocus Banana toward Banana Engineer, a 2.5D game-client-style React portal experience, by rebuilding the landing route as a WASM-rendered entry surface and introducing a C-based procedural asset compiler that generates web-consumable visuals without manual art dependencies.
 
 ## Technical Context
 
-**Language/Version**: TypeScript, React, Vite, WASM runtime bindings, GitHub Actions YAML
-**Primary Dependencies**: Bun, React app toolchain, WASM build/bootstrap path, existing CI harness jobs
+**Language/Version**: TypeScript, React, Vite, C (native asset compiler), WASM runtime bindings, GitHub Actions YAML
+**Primary Dependencies**: Bun, React app toolchain, native C toolchain, WASM build/bootstrap path, existing CI harness jobs
 **Storage**: Repository files and build artifacts only
-**Testing**: Existing pre-commit, turbo typecheck/lint, screenshot/runtime lanes, landing bootstrap checks
+**Testing**: Existing pre-commit, turbo typecheck/lint, runtime lanes, landing bootstrap checks, deterministic asset generation checks
 **Target Platform**: Web portal (desktop/mobile browser), GitHub-hosted runners
 **Project Type**: Frontend rendering pivot + CI governance hardening
-**Performance Goals**: Maintain stable startup/build behavior while introducing WASM landing rendering
-**Constraints**: Preserve runtime contracts (`VITE_BANANA_API_BASE_URL`), keep cross-viewport usability, and avoid reintroducing workflow/spec sprawl
-**Scale/Scope**: `src/typescript/react`, `.github/workflows`, `.specify/specs`
+**Performance Goals**: Maintain stable startup/build behavior while introducing WASM landing rendering and generated asset ingestion
+**Constraints**: Preserve runtime contracts (`VITE_BANANA_API_BASE_URL`), keep cross-viewport usability, enforce deterministic asset outputs, and avoid reintroducing workflow/spec sprawl
+**Scale/Scope**: `src/typescript/react`, `src/native`, `.github/workflows`, `.specify/specs`
 
 ## Constitution Check
 
@@ -27,6 +27,7 @@ Refocus Banana toward a 2.5D game-client-style React portal by rebuilding the la
 - Treat warning/notice noise as QA-significant and fix forward.
 - Preserve existing runtime contracts and avoid unrelated domain churn.
 - Keep 2.5D + WASM rollout bounded to landing and shell presentation scope.
+- Keep procedural asset generation deterministic and consumable by the web build path.
 
 ## Project Structure
 
@@ -44,11 +45,12 @@ Refocus Banana toward a 2.5D game-client-style React portal by rebuilding the la
 ```text
 src/typescript/react/
 src/typescript/shared/ui/
+src/native/
 .github/workflows/
 .specify/specs/
 ```
 
-**Structure Decision**: Keep changes focused on React portal landing/shell rendering surfaces and supporting CI/spec governance surfaces.
+**Structure Decision**: Keep changes focused on React portal landing/shell rendering surfaces, C asset-generation tooling, and supporting CI/spec governance surfaces.
 
 ## Complexity Tracking
 

--- a/.specify/specs/001-react-portal-game-client/spec.md
+++ b/.specify/specs/001-react-portal-game-client/spec.md
@@ -1,9 +1,9 @@
-# Feature Specification: React Portal 2.5D Game Client Pivot
+# Feature Specification: Banana Engineer
 
 **Feature Branch**: `001-react-portal-game-client`
 **Created**: 2026-05-08
 **Status**: Draft
-**Input**: Re-align Banana from dashboard/research sprawl into a 2.5D game-client experience delivered through the existing React portal, starting with a WASM-rendered landing surface.
+**Input**: Re-align Banana from dashboard/research sprawl into a 2.5D game-client experience titled "Banana Engineer," delivered through the existing React portal and starting with a WASM-rendered landing surface.
 
 ## Problem Statement
 
@@ -13,6 +13,7 @@ The repository accumulated broad, research-heavy specs and workflows that are no
 
 - Preserve current runtime behavior and deployability of the existing React implementation.
 - Start over the landing entry surface as a WASM-rendered scene integrated into the React shell.
+- Generate core visual assets procedurally through a C-based compiler pipeline that outputs web-consumable asset bundles.
 - Adopt a 2.5D rendering style for the game-client presentation to improve cross-platform and cross-viewport consistency.
 - Reflow portal UX toward game-client framing (viewport-first shell, tactical overlays, mission-control language).
 - Keep only essential CI/CD workflows required to validate and ship the React portal.
@@ -29,7 +30,7 @@ The repository accumulated broad, research-heavy specs and workflows that are no
 
 ### User Story 1 - WASM Landing Entry (Priority: P1)
 
-As a user, I open the React portal and land in a WASM-rendered 2.5D entry scene that feels like a game client rather than a web page.
+As a user, I open the React portal and land in a WASM-rendered 2.5D entry scene for Banana Engineer that feels like a game client rather than a web page.
 
 **Independent Test**: Open the root route on desktop and mobile-sized viewports and confirm the landing surface is WASM-rendered, responsive, and visually consistent with the game-client direction.
 
@@ -45,10 +46,18 @@ As a maintainer, I can ship the pivot safely with explicit WASM build/runtime co
 
 **Independent Test**: Trigger CI and confirm React build/runtime checks pass with WASM assets and explicit env wiring, without reintroducing workflow/spec sprawl.
 
+### User Story 4 - Procedural Asset Generation (Priority: P1)
+
+As a maintainer without dedicated art production capacity, I can compile game-ready assets from deterministic C generation rules so the web client has a reliable visual asset set.
+
+**Independent Test**: Run the asset compiler with a fixed seed/profile and confirm the generated bundle is deterministic, valid, and consumed by the web landing/shell build path.
+
 ### Edge Cases
 
 - Landing fails to initialize when WASM bootstrap artifacts are missing or delayed.
 - Render quality degrades on narrow/mobile viewports if 2.5D scene scaling is not bounded.
+- Asset compiler output is non-deterministic between environments for the same input seed/profile.
+- Generated assets exceed acceptable size budgets and regress startup performance.
 - Legacy files are reintroduced accidentally by merge/conflict resolution.
 - Deploy credentials are unavailable in CI at run time.
 
@@ -63,12 +72,17 @@ As a maintainer, I can ship the pivot safely with explicit WASM build/runtime co
 - **FR-005**: System MUST preserve explicit runtime configuration contracts (including `VITE_BANANA_API_BASE_URL`) required by the portal.
 - **FR-006**: System MUST provide CI validation coverage sufficient to detect WASM/bootstrap or rendering-contract regressions.
 - **FR-007**: System MUST avoid reintroducing non-pivot workflows/specs into active roots without explicit scope approval.
+- **FR-008**: System MUST provide a C-based generative asset compiler that produces web-consumable assets for Banana Engineer landing/shell scenes.
+- **FR-009**: System MUST support deterministic asset generation based on explicit input parameters (including seed/profile) so repeated runs produce equivalent outputs.
+- **FR-010**: System MUST include generated asset bundles in the React/WASM build contract without requiring manual art asset authoring for baseline scenes.
 
 ### Key Entities
 
 - **WasmLandingSurface**: The WASM-rendered landing entry scene presented at the root route.
 - **ViewportRenderProfile**: A bounded 2.5D layout and scaling profile for desktop, tablet, and mobile-sized viewports.
 - **PortalBuildContract**: Required build inputs, assets, and commands for `src/typescript/react` deployment.
+- **ProceduralAssetCompiler**: Native C tool that compiles deterministic visual assets from rule-based generation inputs.
+- **GeneratedAssetBundle**: Versioned web-consumable output package (for example sprites/textures/metadata) produced by the compiler and consumed by the portal build.
 - **ActiveSpecRoot**: The set of currently active specs in `.specify/specs`.
 
 ## Success Criteria
@@ -79,10 +93,12 @@ As a maintainer, I can ship the pivot safely with explicit WASM build/runtime co
 - **SC-002**: 2.5D shell presentation remains usable across defined desktop and mobile-sized viewport profiles.
 - **SC-003**: React portal build succeeds in CI with explicit API base URL and WASM asset contracts.
 - **SC-004**: Active scope remains constrained to pivot-approved spec/workflow surfaces.
+- **SC-005**: Deterministic C asset compilation produces a valid generated asset bundle that is consumed by landing/shell flows in local and CI validation.
 
 ## Assumptions
 
 - Existing React implementation remains the primary runtime delivery surface.
 - WASM landing rendering is feasible within current frontend deployment/runtime constraints.
+- Native C compilation for procedural assets can run within supported local/CI toolchains.
 - Vercel remains the deploy target for the React portal.
 - Additional specs/workflows can be introduced later only through explicit scope decisions.

--- a/.specify/specs/001-react-portal-game-client/tasks.md
+++ b/.specify/specs/001-react-portal-game-client/tasks.md
@@ -1,4 +1,4 @@
-# Tasks: React Portal 2.5D Game Client Pivot
+# Tasks: Banana Engineer
 
 **Input**: Design documents from `.specify/specs/001-react-portal-game-client/`
 **Prerequisites**: plan.md, spec.md
@@ -27,3 +27,10 @@
 - [ ] T011 [US2] Run screenshot/runtime checks proving 2.5D continuity across viewport profiles. (FR-002, FR-003)
 - [ ] T012 [US3] Run CI lane(s) proving minimal automation contract remains intact for this pivot. (FR-006, FR-007)
 - [ ] T013 [US3] Record feature evidence and residual risk notes in this spec directory. (FR-007)
+
+## Phase 5: Procedural Asset Compiler (C)
+
+- [ ] T014 [US4] Define deterministic generation inputs (seed/profile/rules) for baseline Banana Engineer landing and shell asset sets. (FR-009)
+- [ ] T015 [US4] Implement a C-based procedural asset compiler that emits web-consumable generated asset bundles for the React/WASM client. (FR-008, FR-010)
+- [ ] T016 [US4] Integrate generated bundle ingestion into the React build/bootstrap path without requiring manual art authoring for baseline scenes. (FR-004, FR-010)
+- [ ] T017 [US4] Add CI/local validation that re-runs compiler generation and verifies deterministic output + bundle compatibility with landing/shell runtime. (FR-006, FR-009, FR-010)


### PR DESCRIPTION
## Summary\n- rename the active game title in Spec 001 artifacts to Banana Engineer\n- add explicit procedural asset generation requirements using a C-based compiler pipeline\n- add deterministic generation contracts (seed/profile), generated bundle entity definitions, and measurable outcomes\n- add implementation tasks for compiler implementation, web bundle ingestion, and CI/local determinism checks\n\n## Validation\n- spec boundary validation passed\n- task traceability validation passed (17/17 mapped, drift 0)\n\n## Notes\n- this follows PR #1062 and carries the subsequent spec-only update commit (e29a1f6)