### PR TITLE
fix(react): correct GameEngine viewport on mobile

### DIFF
--- a/src/typescript/react/src/pages/GameEnginePage.tsx
+++ b/src/typescript/react/src/pages/GameEnginePage.tsx
@@ -288,22 +288,23 @@ export function GameEnginePage() {
   }, []);
 
   return (
-    <div className="relative h-screen w-full overflow-hidden bg-black">
+    <div className="relative h-[100dvh] min-h-[100svh] w-full overflow-hidden bg-black">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(34,211,238,0.10),_transparent_40%),linear-gradient(180deg,_rgba(2,6,23,0.25),_rgba(2,6,23,0.75))]" />
       <canvas
         ref={canvasRef}
         id="canvas"
         width={1280}
         height={720}
-        className="absolute inset-0 h-full w-full"
-        style={{ imageRendering: "pixelated" }}
+        className="absolute inset-0 h-full w-full object-contain"
+        style={{ imageRendering: "pixelated", objectPosition: "center" }}
       />
       <canvas
         ref={assetCanvasRef}
         aria-hidden="true"
         width={1280}
         height={720}
-        className="pointer-events-none absolute inset-0 h-full w-full opacity-80 mix-blend-screen"
+        className="pointer-events-none absolute inset-0 h-full w-full object-contain opacity-80 mix-blend-screen"
+        style={{ objectPosition: "center" }}
       />
       {(status === "loading" || !terrain || !palette) && !error && !assetError && (
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(15,23,42,0.08),_rgba(2,6,23,0.32))]" />


### PR DESCRIPTION
## What this fixes
On mobile portrait screens, the WASM game viewport looked distorted because the canvases were stretched to fill both width and height.

## Changes
- Update GameEnginePage container height to dynamic viewport units (100dvh + 100svh fallback)
- Set both canvases to object-contain and center positioning so the 1280x720 render keeps its aspect ratio
- Keep existing visual overlays and behavior unchanged

## Validation
- No TypeScript diagnostics in updated page
- bunx tsc -b executed in src/typescript/react without errors

## Notes
Local unrelated modifications were intentionally left unstaged and are not part of this PR.
