### PR TITLE
fix: production 404 on banana.engineer root (clean follow-up)

### DIFF
--- a/src/typescript/react/vercel.json
+++ b/src/typescript/react/vercel.json
@@ -1,6 +1,10 @@
 {
   "rewrites": [
     {
+      "source": "/",
+      "destination": "/index.html"
+    },
+    {
       "source": "/((?!_vercel/|assets/|notebooks/|.*\\..*).*)",
       "destination": "/index.html"
     }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "installCommand": "cd src/typescript/react && bun install",
+  "buildCommand": "cd src/typescript/react && bun run build",
+  "outputDirectory": "src/typescript/react/dist",
+  "rewrites": [
+    {
+      "source": "/",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/((?!_vercel/|assets/|notebooks/|.*\\..*).*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This PR supersedes #1082 due to merge conflicts and contains only Vercel routing/deploy config fixes designed to ensure the React app correctly handles the root path and SPA routing.