### PR TITLE
security: block remote wasm/bootstrap sources in desktop runtime

### DIFF
--- a/src/typescript/api/wasm/engine-binding.ts
+++ b/src/typescript/api/wasm/engine-binding.ts
@@ -34,17 +34,18 @@ export async function initializeEngine(
   options: EngineBindingOptions = {}
 ): Promise<BananaEngineModule> {
   const { scriptUrl = "/wasm/engine.js", canvasId = "canvas", timeoutMs = 10_000 } = options;
+  const resolvedScriptUrl = resolveTrustedEngineScriptUrl(scriptUrl);
 
   /* ── 1. Inject script tag ─────────────────────────────────────────────── */
-  const existing = document.querySelector<HTMLScriptElement>(`script[src="${scriptUrl}"]`);
+  const existing = document.querySelector<HTMLScriptElement>(`script[src="${resolvedScriptUrl}"]`);
 
   if (!existing) {
     await new Promise<void>((resolve, reject) => {
       const el = document.createElement("script");
-      el.src = scriptUrl;
+      el.src = resolvedScriptUrl;
       el.async = true;
       el.onload = () => resolve();
-      el.onerror = () => reject(new Error(`Failed to load engine script: ${scriptUrl}`));
+      el.onerror = () => reject(new Error(`Failed to load engine script: ${resolvedScriptUrl}`));
       document.head.appendChild(el);
     });
   }
@@ -104,4 +105,26 @@ async function waitForModule(globalName: string, timeoutMs: number): Promise<unk
 
 function sleep(ms: number) {
   return new Promise<void>((r) => setTimeout(r, ms));
+}
+
+function resolveTrustedEngineScriptUrl(rawUrl: string): string {
+  const candidate = rawUrl.trim();
+  if (candidate.length === 0) {
+    throw new Error("Engine script URL cannot be empty.");
+  }
+
+  const parsed = new URL(candidate, window.location.origin);
+  if (parsed.origin !== window.location.origin) {
+    throw new Error(
+      `Engine script URL must be same-origin. Received origin "${parsed.origin}" while app origin is "${window.location.origin}".`
+    );
+  }
+
+  if (!parsed.pathname.startsWith("/wasm/") || !parsed.pathname.endsWith("engine.js")) {
+    throw new Error(
+      `Engine script URL must target /wasm/engine.js on the same origin. Received path "${parsed.pathname}".`
+    );
+  }
+
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
 }

--- a/src/typescript/electron/main.js
+++ b/src/typescript/electron/main.js
@@ -5,11 +5,49 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+function isAllowedRendererUrl(rawUrl) {
+	if (typeof rawUrl !== "string" || rawUrl.trim().length === 0) {
+		return false;
+	}
+
+	let parsed;
+	try {
+		parsed = new URL(rawUrl);
+	} catch {
+		return false;
+	}
+
+	if (parsed.protocol === "file:") {
+		return true;
+	}
+
+	if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+		if (!LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase())) {
+			return false;
+		}
+		if (parsed.username || parsed.password) {
+			return false;
+		}
+		return true;
+	}
+
+	return false;
+}
+
 function resolveStartUrl() {
 	const configured = (process.env.BANANA_DESKTOP_START_URL ?? "").trim();
-	if (configured.length > 0) {
+	if (configured.length > 0 && isAllowedRendererUrl(configured)) {
 		return configured;
 	}
+
+	if (configured.length > 0) {
+		console.error(
+			`[security] Rejected BANANA_DESKTOP_START_URL; only file:// or loopback http(s) URLs are allowed. Received: ${configured}`
+		);
+	}
+
 	return "http://localhost:5173/game-engine";
 }
 
@@ -33,8 +71,20 @@ function createWindow() {
 	const startUrl = resolveStartUrl();
 	void window.loadURL(startUrl);
 
+	window.webContents.on("will-navigate", (event, url) => {
+		if (!isAllowedRendererUrl(url)) {
+			event.preventDefault();
+			console.error(`[security] Blocked navigation to disallowed URL: ${url}`);
+		}
+	});
+
 	window.webContents.setWindowOpenHandler(({ url }) => {
-		void shell.openExternal(url);
+		if (isAllowedRendererUrl(url)) {
+			void shell.openExternal(url);
+			return { action: "deny" };
+		}
+
+		console.error(`[security] Blocked window.open target: ${url}`);
 		return { action: "deny" };
 	});
 

--- a/src/typescript/react/src/pages/GameEnginePage.tsx
+++ b/src/typescript/react/src/pages/GameEnginePage.tsx
@@ -908,7 +908,8 @@ export function GameEnginePage() {
       try {
         const mod = await window.BananaEngine({
           canvas,
-          locateFile: (path, prefix) => `${prefix}${path}?v=${engineAssetVersion}`,
+          // Always resolve from local static assets, never script-origin prefixes.
+          locateFile: (path) => `/wasm/${path.replace(/^\/+/, "")}?v=${engineAssetVersion}`,
           printErr: (text) => {
             applyRuntimeFatal(text);
           },

--- a/src/typescript/shared/ui/src/game-engine/GameEnginePage.tsx
+++ b/src/typescript/shared/ui/src/game-engine/GameEnginePage.tsx
@@ -268,7 +268,8 @@ export function GameEnginePage() {
             try {
                 const mod = await window.BananaEngine({
                     canvas,
-                    locateFile: (path, prefix) => `${prefix}${path}?v=${engineAssetVersion}`,
+                    // Always resolve from local static assets, never script-origin prefixes.
+                    locateFile: (path) => `/wasm/${path.replace(/^\/+/, "")}?v=${engineAssetVersion}`,
                     printErr: (text) => {
                         applyRuntimeFatal(text);
                     },


### PR DESCRIPTION
## Summary
- block remote renderer bootstrap URLs in Electron
- block unsafe will-navigate/window.open targets
- force WASM locateFile to local /wasm paths
- enforce same-origin /wasm/engine.js in engine binding

## Risk
- hardens against remote WASM bootstrap in desktop runtime

## Validation
- get_errors clean on touched files