### PR TITLE
Add Fly deploy path for self-hosted Neon

### DIFF
--- a/.specify/specs/001-steamworks-release-readiness/checklists/steam-storefront-readiness.md
+++ b/.specify/specs/001-steamworks-release-readiness/checklists/steam-storefront-readiness.md
@@ -28,6 +28,15 @@ Use `steam-storefront-copy.md` as the canonical claim target.
 - [ ] Confirm the disclosure does not overstate unimplemented generation paths.
 - [ ] Use the exact current disclosure line documented in the storefront contract.
 
+## Neon Database Management Lane
+
+- [ ] Confirm the open source self-hosted Neon integration matches the release target and the Fly.io deployment channel.
+- [ ] Verify self-hosted Neon project identifiers, database branches, and environment bindings match the release target.
+- [ ] Verify database management flows use the documented self-hosted Neon connection path for the active runtime channel.
+- [ ] Record self-hosted Neon access, migration, and rollback evidence for the release bundle.
+- [ ] Confirm any self-hosted Neon-backed data management claims stay within the shipped operational scope.
+- [ ] Use the exact current self-hosted Neon and Fly.io service language documented in the release contracts.
+
 ## System Requirements Lane
 
 - [ ] Reconcile minimum OS, CPU, memory, GPU, DirectX, network, and storage claims with the build target.
@@ -66,6 +75,7 @@ Use `steam-storefront-copy.md` as the canonical claim target.
 
 - [ ] Capture final store page screenshots after copy and asset updates.
 - [ ] Record the exact AI disclosure text used on the page.
+- [ ] Record the exact Fly.io and self-hosted Neon database management text used in the release evidence.
 - [ ] Record the exact minimum system requirements text used on the page.
 - [ ] Link the completed storefront checklist to the Steam UAT evidence bundle.
 - [ ] Confirm the final store page text is an exact match for the storefront contract or an approved revision.

--- a/.specify/specs/001-steamworks-release-readiness/contracts/steam-storefront-copy.md
+++ b/.specify/specs/001-steamworks-release-readiness/contracts/steam-storefront-copy.md
@@ -38,7 +38,7 @@ canonical storefront surface.
 ## Exact Current Store Page Strings
 
 - AI generated content disclosure: Machine Learning, Homebrew, Open Source MIT
-- Third-party service disclosure line: Open Source API Deployed on Fly.io
+- Third-party service disclosure line: Open Source API Deployed on Fly.io with self-hosted Neon-backed database integration
 - Controller support line: Partial Controller Support
 - Online content line: In-game chat, Online interactivity
 - Minimum OS line: Windows 10 64-bit or newer
@@ -52,7 +52,7 @@ canonical storefront surface.
 ## Required Disclosure Targets
 
 - AI-generated content disclosure target: Machine Learning, Homebrew, Open Source MIT
-- Third-party service disclosure target: Open Source API Deployed on Fly.io
+- Third-party service disclosure target: Open Source API Deployed on Fly.io with self-hosted Neon-backed database integration
 - Controller support target: Partial Controller Support
 - Online content target: In-game chat, Online interactivity
 

--- a/scripts/deploy-api-fly.sh
+++ b/scripts/deploy-api-fly.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+API_DIR="${ROOT_DIR}/src/typescript/api"
+APP_NAME="${FLY_APP_NAME:-banana-api}"
+DATABASE_URL_VALUE="${NEON_DATABASE_URL:-}"
+
+if ! command -v fly >/dev/null 2>&1; then
+  echo "[fly-deploy] ERROR: fly CLI is required but not installed or not on PATH." >&2
+  exit 1
+fi
+
+cd "${API_DIR}"
+
+if [[ -z "${DATABASE_URL_VALUE}" ]]; then
+  echo "[fly-deploy] ERROR: NEON_DATABASE_URL is required for the database cutover." >&2
+  exit 1
+fi
+
+echo "[fly-deploy] applying self-hosted Neon database secrets"
+fly secrets set -a "${APP_NAME}" \
+  NEON_DATABASE_URL="${DATABASE_URL_VALUE}" \
+  DATABASE_URL="${DATABASE_URL_VALUE}" \
+  BANANA_PG_CONNECTION="${DATABASE_URL_VALUE}" >/dev/null
+
+echo "[fly-deploy] deploying ${APP_NAME} from ${API_DIR}"
+fly deploy -a "${APP_NAME}" --config fly.toml

--- a/src/typescript/api/Dockerfile
+++ b/src/typescript/api/Dockerfile
@@ -1,0 +1,17 @@
+FROM oven/bun:1.2.13-debian
+
+WORKDIR /app/src/typescript/api
+
+COPY src/typescript/api/package.json src/typescript/api/bun.lock ./
+RUN bun install
+
+COPY src/typescript/api/src ./src
+COPY src/typescript/api/wasm ./wasm
+
+ENV HOST=0.0.0.0
+ENV PORT=8081
+ENV BANANA_ENGINE_ADAPTER=inmemory
+
+EXPOSE 8081
+
+CMD ["bun", "run", "start"]

--- a/src/typescript/api/README.md
+++ b/src/typescript/api/README.md
@@ -1,0 +1,36 @@
+# Banana API on Fly.io
+
+This package can be deployed to Fly.io with the bundled `fly.toml` and `Dockerfile`.
+
+## Local runtime
+
+```bash
+cd src/typescript/api
+BANANA_ENGINE_ADAPTER=inmemory HOST=0.0.0.0 PORT=8081 bun run dev
+```
+
+## Fly.io deployment
+
+Use `scripts/deploy-api-fly.sh` from the repo root. The helper targets the
+existing Fly app `banana-api` and requires this database URL input:
+
+- `NEON_DATABASE_URL`
+
+The helper treats `NEON_DATABASE_URL` as the replacement database connection
+for the Fly deployment and syncs it into `NEON_DATABASE_URL`, `DATABASE_URL`,
+and `BANANA_PG_CONNECTION` before running `fly deploy`.
+
+This repository does not provision Neon itself; it deploys the app against a
+self-hosted Neon-backed PostgreSQL endpoint.
+
+```bash
+bash scripts/deploy-api-fly.sh
+```
+
+For the database cutover, set `NEON_DATABASE_URL` from your self-hosted Neon
+instance before invoking the script.
+The deploy helper exits with an error if no replacement connection string is
+provided.
+
+The deployed service listens on port `8081` and serves `/health` for Fly health
+checks.

--- a/src/typescript/api/fly.toml
+++ b/src/typescript/api/fly.toml
@@ -1,0 +1,37 @@
+app = "banana-api"
+primary_region = "iad"
+kill_signal = "SIGINT"
+kill_timeout = "5s"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  HOST = "0.0.0.0"
+  PORT = "8081"
+  BANANA_ENGINE_ADAPTER = "inmemory"
+  BANANA_CORS_ORIGINS = "https://banana.engineer,http://localhost:5173,http://127.0.0.1:5173"
+  NODE_ENV = "production"
+
+[http_service]
+  internal_port = 8081
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 25
+    soft_limit = 20
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "2s"
+    method = "get"
+    path = "/health"
+    protocol = "http"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"


### PR DESCRIPTION
Summary:
- Align Banana API Fly infra with the existing banana-api app
- Add a Dockerfile and Fly config for the API package
- Require NEON_DATABASE_URL as the single cutover input for self-hosted Neon
- Update the storefront contract and readiness checklist to reflect self-hosted Neon deployment language

Validation:
- flyctl config validate -c src/typescript/api/fly.toml
- bash -n scripts/deploy-api-fly.sh
- flyctl deploy -a banana-api -c src/typescript/api/fly.toml