### PR TITLE
Native DDD/SOLID refactor: camera, orchestration, and objective policy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,13 +2,13 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Banana: Native DX12 POC",
+      "name": "Banana: Native DX12 POC (Ctrl+F5 No Debug)",
       "type": "cppvsdbg",
       "request": "launch",
       "program": "${workspaceFolder}/out/v3-native/engine/Debug/banana_engine_win32_dx12_poc.exe",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "Native: build (v3)",
-      "console": "integratedTerminal"
+      "console": "externalTerminal"
     },
     {
       "name": "Banana: Native DX12 POC (Autotest 5s)",
@@ -17,7 +17,7 @@
       "program": "${workspaceFolder}/out/v3-native/engine/Debug/banana_engine_win32_dx12_poc.exe",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "Native: build (v3)",
-      "console": "integratedTerminal",
+      "console": "externalTerminal",
       "environment": [
         {
           "name": "BANANA_DX12_POC_AUTOTEST",
@@ -31,7 +31,7 @@
     },
     {
       "name": "Banana: Overworld (Compose + Browser)",
-      "type": "pwa-msedge",
+      "type": "msedge",
       "request": "launch",
       "url": "http://localhost:5173/session-room",
       "webRoot": "${workspaceFolder}/src/typescript/react",
@@ -40,7 +40,7 @@
     },
     {
       "name": "Banana: Overworld (Attach Browser Only)",
-      "type": "pwa-msedge",
+      "type": "msedge",
       "request": "launch",
       "url": "http://localhost:5173/session-room",
       "webRoot": "${workspaceFolder}/src/typescript/react"

--- a/docs/native-ddd-solid-refactor-plan.md
+++ b/docs/native-ddd-solid-refactor-plan.md
@@ -114,3 +114,11 @@ For each TODO slice: keep ABI stable, refactor one seam at a time, build immedia
 - [x] Remove `runtime/merchant_abi` compatibility wrapper after all production callers migrate to query/trade facades.
 - [x] Remove obsolete `runtime_merchant_abi_test` target and source after facade seam tests supersede wrapper coverage.
 - [ ] Run focused + full native CTest sweep and archive evidence for compatibility retirement.
+
+### Phase 13: Runtime Orchestration Decoupling (In Progress)
+- [x] Remove hidden per-tick orchestration globals in `runtime/engine_composition.c` by introducing explicit context-passing callbacks through `runtime/engine_tick` and `runtime/tick_phases`.
+- [x] Introduce bounded-context orchestration modules (`runtime/orchestration/player_tick`, `runtime/orchestration/terrain_tick`, `runtime/orchestration/render_tick`) and migrate composition callbacks from monolithic `engine_composition.c`.
+- [x] Split camera policy from camera application: `runtime/camera_follow_policy` computes target eye/target, while render adapter applies camera state to backend.
+- [x] Isolate DX12 fallback projection policy from backend transport (`backend_dx12_projection_policy`), including explicit tests for camera-centered fallback quads.
+- [x] Move win32 POC objective logic behind a dedicated gameplay objective policy service to avoid ad-hoc scene transitions in `win32_dx12_poc/main.c`.
+- [ ] Add architecture guard tests enforcing dependency direction: orchestration -> domain services -> render/infra adapters (never reverse).

--- a/src/native/engine/CMakeLists.txt
+++ b/src/native/engine/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.20)
 set(ENGINE_RENDER_SOURCES
   render/backend.c
   render/backend_dx12.c
+  render/backend_dx12_projection_policy.c
   render/window.c
   render/shader.c
   render/mesh.c
@@ -58,9 +59,13 @@ set(ENGINE_UI_SOURCES
 
 set(ENGINE_RUNTIME_SOURCES
   runtime/application_service_ports.c
+  runtime/orchestration/player_tick_orchestration.c
+  runtime/orchestration/render_tick_orchestration.c
+  runtime/orchestration/terrain_tick_orchestration.c
   runtime/controller_kind_domain.c
   runtime/camera_basis.c
   runtime/camera_follow.c
+  runtime/camera_follow_policy.c
   runtime/controller_attach.c
   runtime/controller_runtime.c
   runtime/controller_sync.c
@@ -232,6 +237,9 @@ if(NOT EMSCRIPTEN)
   if(WIN32)
     add_executable(banana_engine_win32_dx12_poc
       win32_dx12_poc/main.c
+      win32_dx12_poc/objective_policy.c
+      win32_dx12_poc/scene_overlay.c
+      win32_dx12_poc/scene_flow.c
     )
 
     target_link_libraries(banana_engine_win32_dx12_poc PRIVATE
@@ -599,6 +607,77 @@ if(BUILD_TESTING AND NOT EMSCRIPTEN)
       ENVIRONMENT "BANANA_DX12_POC_AUTOTEST=1;BANANA_DX12_POC_AUTOTEST_SECONDS=2"
       TIMEOUT 10
     )
+
+    add_executable(banana_dx12_scene_overlay_frame_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/native/dx12_scene_overlay_frame_test.c
+      win32_dx12_poc/scene_overlay.c
+    )
+    target_link_libraries(banana_dx12_scene_overlay_frame_test PRIVATE banana_engine_core)
+    target_include_directories(banana_dx12_scene_overlay_frame_test PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/render
+      ${CMAKE_CURRENT_SOURCE_DIR}/physics
+      ${CMAKE_CURRENT_SOURCE_DIR}/ai
+      ${CMAKE_CURRENT_SOURCE_DIR}/world
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtime
+      ${CMAKE_CURRENT_SOURCE_DIR}/win32_dx12_poc
+    )
+    add_test(NAME banana_dx12_scene_overlay_frame_test COMMAND banana_dx12_scene_overlay_frame_test)
+
+    add_executable(banana_dx12_projection_policy_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/native/dx12_projection_policy_test.c
+    )
+    target_link_libraries(banana_dx12_projection_policy_test PRIVATE banana_engine_core)
+    target_include_directories(banana_dx12_projection_policy_test PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/render
+      ${CMAKE_CURRENT_SOURCE_DIR}/physics
+      ${CMAKE_CURRENT_SOURCE_DIR}/ai
+      ${CMAKE_CURRENT_SOURCE_DIR}/world
+    )
+    add_test(NAME banana_dx12_projection_policy_test COMMAND banana_dx12_projection_policy_test)
+
+    add_executable(banana_dx12_objective_policy_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/native/dx12_objective_policy_test.c
+      win32_dx12_poc/objective_policy.c
+    )
+    target_include_directories(banana_dx12_objective_policy_test PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/win32_dx12_poc
+    )
+    add_test(NAME banana_dx12_objective_policy_test COMMAND banana_dx12_objective_policy_test)
+
+    add_executable(banana_dx12_scene_flow_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/native/dx12_scene_flow_test.c
+      win32_dx12_poc/scene_flow.c
+    )
+    target_include_directories(banana_dx12_scene_flow_test PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/win32_dx12_poc
+    )
+    add_test(NAME banana_dx12_scene_flow_test COMMAND banana_dx12_scene_flow_test)
+
+    add_executable(banana_dx12_gameplay_lane_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/native/dx12_gameplay_lane_test.c
+      win32_dx12_poc/scene_flow.c
+    )
+    target_link_libraries(banana_dx12_gameplay_lane_test PRIVATE banana_engine_core)
+    target_include_directories(banana_dx12_gameplay_lane_test PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/win32_dx12_poc
+    )
+    add_test(NAME banana_dx12_gameplay_lane_test COMMAND banana_dx12_gameplay_lane_test)
+
+    add_executable(banana_dx12_gameplay_click_lane_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/native/dx12_gameplay_click_lane_test.c
+      win32_dx12_poc/scene_flow.c
+    )
+    target_link_libraries(banana_dx12_gameplay_click_lane_test PRIVATE banana_engine_core)
+    target_include_directories(banana_dx12_gameplay_click_lane_test PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/win32_dx12_poc
+    )
+    add_test(NAME banana_dx12_gameplay_click_lane_test COMMAND banana_dx12_gameplay_click_lane_test)
   endif()
 
   add_executable(banana_runtime_physics_world_abi_test
@@ -652,6 +731,20 @@ if(BUILD_TESTING AND NOT EMSCRIPTEN)
     ${CMAKE_CURRENT_SOURCE_DIR}/world
   )
   add_test(NAME banana_runtime_engine_tick_test COMMAND banana_runtime_engine_tick_test)
+
+  add_executable(banana_runtime_camera_follow_policy_test
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/native/runtime_camera_follow_policy_test.c
+  )
+  target_link_libraries(banana_runtime_camera_follow_policy_test PRIVATE banana_engine_core)
+  target_include_directories(banana_runtime_camera_follow_policy_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/render
+    ${CMAKE_CURRENT_SOURCE_DIR}/physics
+    ${CMAKE_CURRENT_SOURCE_DIR}/ai
+    ${CMAKE_CURRENT_SOURCE_DIR}/world
+    ${CMAKE_CURRENT_SOURCE_DIR}/runtime
+  )
+  add_test(NAME banana_runtime_camera_follow_policy_test COMMAND banana_runtime_camera_follow_policy_test)
 
   add_executable(banana_runtime_move_target_domain_test
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/native/runtime_move_target_domain_test.c

--- a/src/native/engine/engine.c
+++ b/src/native/engine/engine.c
@@ -471,6 +471,11 @@ int engine_get_pbj_pickup_position(float *out_x, float *out_z)
     return 0;
 }
 
+float engine_get_terrain_half_span(void)
+{
+    return ((float)BANANA_TERRAIN_SIZE - 1.0f) * 0.5f;
+}
+
 int engine_player_build_set_class(const char *player_guid, int class_type)
 {
     return runtime_player_build_abi_set_class(player_guid, class_type);

--- a/src/native/engine/engine.h
+++ b/src/native/engine/engine.h
@@ -158,6 +158,9 @@ extern "C"
     /* Query active PBJ pickup world-space x/z position. Returns 1 on success. */
     int engine_get_pbj_pickup_position(float *out_x, float *out_z);
 
+    /* Query world half-span used for terrain-space mapping (centered at origin). */
+    float engine_get_terrain_half_span(void);
+
     /* ── Player Build & Combo Systems ───────────────────────────────────── */
 
     /* Set player class (0=vanguard, 1=arcanist, 2=ranger). */

--- a/src/native/engine/render/backend_dx12.c
+++ b/src/native/engine/render/backend_dx12.c
@@ -1,4 +1,5 @@
 #include "backend_dx12.h"
+#include "backend_dx12_projection_policy.h"
 
 #if defined(BANANA_ENGINE_RENDER_BACKEND_DX12) && defined(_WIN32)
 #define COBJMACROS
@@ -6,13 +7,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <stddef.h>
 #include <windows.h>
 #include <d3d12.h>
 #include <d3dcompiler.h>
 #include <dxgi1_6.h>
 
 #define BANANA_DX12_BACK_BUFFER_COUNT 2
-#define BANANA_DX12_DEBUG_MAX_VERTICES 24576
+#define BANANA_DX12_DEBUG_MAX_VERTICES 262144
 
 typedef struct BananaDx12DebugVertex
 {
@@ -115,6 +117,20 @@ typedef struct BananaDx12Runtime
     UINT scene_vertex_count;
     UINT scene_vertex_capacity;
     int scene_pipeline_ready;
+    unsigned char *ui_overlay_rgba;
+    size_t ui_overlay_capacity;
+    int ui_overlay_width;
+    int ui_overlay_height;
+    int ui_overlay_dirty;
+    unsigned int ui_overlay_quads_last;
+    unsigned int ui_overlay_rows_last;
+    unsigned int ui_overlay_vertices_last;
+    float camera_eye[3];
+    float camera_target[3];
+    float camera_up[3];
+    float camera_fov_degrees;
+    float camera_aspect;
+    int camera_valid;
 } BananaDx12Runtime;
 
 static BananaDx12Runtime s_dx12_runtime = {0};
@@ -154,6 +170,15 @@ static void banana_dx12_runtime_update_telemetry(void)
              (unsigned long long)s_dx12_runtime.scene_draw_calls_total,
              s_dx12_runtime.present_interval,
              (unsigned long)s_dx12_runtime.last_present_result);
+    snprintf(s_dx12_telemetry + strlen(s_dx12_telemetry),
+             sizeof(s_dx12_telemetry) - strlen(s_dx12_telemetry),
+             " ui=%dx%d dirty=%d rows=%u quads=%u verts=%u",
+             s_dx12_runtime.ui_overlay_width,
+             s_dx12_runtime.ui_overlay_height,
+             s_dx12_runtime.ui_overlay_dirty,
+             s_dx12_runtime.ui_overlay_rows_last,
+             s_dx12_runtime.ui_overlay_quads_last,
+             s_dx12_runtime.ui_overlay_vertices_last);
 }
 
 static void banana_dx12_runtime_release_depth_target(void)
@@ -217,71 +242,29 @@ static void banana_dx12_project_world_to_clip(float wx,
                                                float *out_z,
                                                float *out_view_depth)
 {
-    const float camera_x = 16.0f;
-    const float camera_y = 14.0f;
-    const float camera_z = -16.0f;
-    const float target_x = 0.0f;
-    const float target_y = 0.0f;
-    const float target_z = 0.0f;
-    const float world_up_x = 0.0f;
-    const float world_up_y = 1.0f;
-    const float world_up_z = 0.0f;
-    float forward_x = target_x - camera_x;
-    float forward_y = target_y - camera_y;
-    float forward_z = target_z - camera_z;
-    float right_x = 0.0f;
-    float right_y = 0.0f;
-    float right_z = 0.0f;
-    float up_x = 0.0f;
-    float up_y = 1.0f;
-    float up_z = 0.0f;
-    float dx = wx - camera_x;
-    float dy = wy - camera_y;
-    float dz = wz - camera_z;
-    float view_x = 0.0f;
-    float view_y = 0.0f;
-    float view_z = 0.0f;
-    float perspective = 1.0f;
+    BananaDx12ProjectionCamera camera = {0};
 
-    banana_dx12_vec3_normalize(&forward_x, &forward_y, &forward_z);
-    banana_dx12_vec3_cross(forward_x,
-                           forward_y,
-                           forward_z,
-                           world_up_x,
-                           world_up_y,
-                           world_up_z,
-                           &right_x,
-                           &right_y,
-                           &right_z);
-    banana_dx12_vec3_normalize(&right_x, &right_y, &right_z);
-    banana_dx12_vec3_cross(right_x,
-                           right_y,
-                           right_z,
-                           forward_x,
-                           forward_y,
-                           forward_z,
-                           &up_x,
-                           &up_y,
-                           &up_z);
-    banana_dx12_vec3_normalize(&up_x, &up_y, &up_z);
+    camera.eye[0] = s_dx12_runtime.camera_eye[0];
+    camera.eye[1] = s_dx12_runtime.camera_eye[1];
+    camera.eye[2] = s_dx12_runtime.camera_eye[2];
+    camera.target[0] = s_dx12_runtime.camera_target[0];
+    camera.target[1] = s_dx12_runtime.camera_target[1];
+    camera.target[2] = s_dx12_runtime.camera_target[2];
+    camera.up[0] = s_dx12_runtime.camera_up[0];
+    camera.up[1] = s_dx12_runtime.camera_up[1];
+    camera.up[2] = s_dx12_runtime.camera_up[2];
+    camera.fov_degrees = s_dx12_runtime.camera_fov_degrees;
+    camera.aspect = s_dx12_runtime.camera_aspect;
+    camera.valid = s_dx12_runtime.camera_valid;
 
-    view_x = banana_dx12_vec3_dot(dx, dy, dz, right_x, right_y, right_z);
-    view_y = banana_dx12_vec3_dot(dx, dy, dz, up_x, up_y, up_z);
-    view_z = banana_dx12_vec3_dot(dx, dy, dz, forward_x, forward_y, forward_z);
-    if (view_z < 0.01f)
-    {
-        view_z = 0.01f;
-    }
-
-    perspective = 1.0f / (1.0f + (view_z * 0.030f));
-
-    *out_x = banana_dx12_clampf(view_x * 0.110f * perspective, -1.25f, 1.25f);
-    *out_y = banana_dx12_clampf(view_y * 0.165f * perspective, -1.25f, 1.25f);
-    *out_z = banana_dx12_clampf(0.04f + (view_z * 0.0115f), 0.02f, 0.98f);
-    if (out_view_depth)
-    {
-        *out_view_depth = view_z;
-    }
+    banana_dx12_projection_world_to_clip(&camera,
+                                         wx,
+                                         wy,
+                                         wz,
+                                         out_x,
+                                         out_y,
+                                         out_z,
+                                         out_view_depth);
 }
 
 static void banana_dx12_runtime_release_scene_pipeline(void)
@@ -425,6 +408,126 @@ static int banana_dx12_runtime_push_triangle(float x0,
 
     s_dx12_runtime.scene_vertex_count += 3u;
     return 1;
+}
+
+static int banana_dx12_runtime_ensure_ui_overlay_capacity(size_t required)
+{
+    unsigned char *resized = NULL;
+
+    if (required == 0)
+        return 1;
+
+    if (s_dx12_runtime.ui_overlay_capacity >= required && s_dx12_runtime.ui_overlay_rgba)
+        return 1;
+
+    resized = (unsigned char *)realloc(s_dx12_runtime.ui_overlay_rgba, required);
+    if (!resized)
+        return 0;
+
+    s_dx12_runtime.ui_overlay_rgba = resized;
+    s_dx12_runtime.ui_overlay_capacity = required;
+    return 1;
+}
+
+static void banana_dx12_runtime_append_ui_overlay_vertices(void)
+{
+    int width = s_dx12_runtime.ui_overlay_width;
+    int height = s_dx12_runtime.ui_overlay_height;
+    int y = 0;
+    unsigned int row_count = 0;
+    unsigned int quad_count = 0;
+    unsigned int vertices_before = s_dx12_runtime.scene_vertex_count;
+
+    if (!s_dx12_runtime.ui_overlay_dirty ||
+        !s_dx12_runtime.ui_overlay_rgba ||
+        width <= 0 ||
+        height <= 0)
+    {
+        s_dx12_runtime.ui_overlay_rows_last = 0;
+        s_dx12_runtime.ui_overlay_quads_last = 0;
+        s_dx12_runtime.ui_overlay_vertices_last = 0;
+        return;
+    }
+
+    for (y = 0; y < height; y++)
+    {
+        int x = 0;
+        int row_has_overlay = 0;
+        while (x < width)
+        {
+            size_t pixel_index = ((size_t)y * (size_t)width + (size_t)x) * 4u;
+            const unsigned char *p = &s_dx12_runtime.ui_overlay_rgba[pixel_index];
+            unsigned char r = p[0];
+            unsigned char g = p[1];
+            unsigned char b = p[2];
+            unsigned char a = p[3];
+            int run_end = x + 1;
+            float left = 0.0f;
+            float right = 0.0f;
+            float top = 0.0f;
+            float bottom = 0.0f;
+            float center_x = 0.0f;
+            float center_y = 0.0f;
+            float half_width = 0.0f;
+            float half_height = 0.0f;
+
+            if (a == 0)
+            {
+                x++;
+                continue;
+            }
+
+            while (run_end < width)
+            {
+                size_t run_idx = ((size_t)y * (size_t)width + (size_t)run_end) * 4u;
+                const unsigned char *rp = &s_dx12_runtime.ui_overlay_rgba[run_idx];
+                if (rp[0] != r || rp[1] != g || rp[2] != b || rp[3] != a)
+                    break;
+                run_end++;
+            }
+
+            left = (((float)x / (float)width) * 2.0f) - 1.0f;
+            right = (((float)run_end / (float)width) * 2.0f) - 1.0f;
+            top = 1.0f - (((float)y / (float)height) * 2.0f);
+            bottom = 1.0f - (((float)(y + 1) / (float)height) * 2.0f);
+
+            center_x = (left + right) * 0.5f;
+            center_y = (top + bottom) * 0.5f;
+            half_width = (right - left) * 0.5f;
+            half_height = (top - bottom) * 0.5f;
+
+            if (!banana_dx12_runtime_push_quad(center_x,
+                                               center_y,
+                                               half_width,
+                                               half_height,
+                                               0.01f,
+                                               (float)r / 255.0f,
+                                               (float)g / 255.0f,
+                                               (float)b / 255.0f,
+                                               (float)a / 255.0f))
+            {
+                s_dx12_runtime.ui_overlay_rows_last = row_count;
+                s_dx12_runtime.ui_overlay_quads_last = quad_count;
+                s_dx12_runtime.ui_overlay_vertices_last = s_dx12_runtime.scene_vertex_count - vertices_before;
+                s_dx12_runtime.ui_overlay_dirty = 0;
+                return;
+            }
+
+            row_has_overlay = 1;
+            quad_count++;
+
+            run_end = run_end < (x + 1) ? (x + 1) : run_end;
+            x = run_end;
+        }
+
+        if (row_has_overlay)
+            row_count++;
+    }
+
+    s_dx12_runtime.ui_overlay_rows_last = row_count;
+    s_dx12_runtime.ui_overlay_quads_last = quad_count;
+    s_dx12_runtime.ui_overlay_vertices_last = s_dx12_runtime.scene_vertex_count - vertices_before;
+    s_dx12_runtime.ui_overlay_dirty = 0;
 }
 
 static int banana_dx12_runtime_push_mesh(const Mesh *mesh,
@@ -741,13 +844,13 @@ static int banana_dx12_runtime_create_scene_pipeline(void)
     ZeroMemory(&blend_desc, sizeof(blend_desc));
     blend_desc.AlphaToCoverageEnable = FALSE;
     blend_desc.IndependentBlendEnable = FALSE;
-    blend_desc.RenderTarget[0].BlendEnable = FALSE;
+    blend_desc.RenderTarget[0].BlendEnable = TRUE;
     blend_desc.RenderTarget[0].LogicOpEnable = FALSE;
-    blend_desc.RenderTarget[0].SrcBlend = D3D12_BLEND_ONE;
-    blend_desc.RenderTarget[0].DestBlend = D3D12_BLEND_ZERO;
+    blend_desc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA;
+    blend_desc.RenderTarget[0].DestBlend = D3D12_BLEND_INV_SRC_ALPHA;
     blend_desc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
     blend_desc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
-    blend_desc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
+    blend_desc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_INV_SRC_ALPHA;
     blend_desc.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
     blend_desc.RenderTarget[0].LogicOp = D3D12_LOGIC_OP_NOOP;
     blend_desc.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
@@ -1131,6 +1234,15 @@ static void banana_dx12_runtime_release_all(void)
     s_dx12_runtime.frame_counter = 0;
     s_dx12_runtime.frames_presented = 0;
     s_dx12_runtime.last_present_result = S_OK;
+    free(s_dx12_runtime.ui_overlay_rgba);
+    s_dx12_runtime.ui_overlay_rgba = NULL;
+    s_dx12_runtime.ui_overlay_capacity = 0;
+    s_dx12_runtime.ui_overlay_width = 0;
+    s_dx12_runtime.ui_overlay_height = 0;
+    s_dx12_runtime.ui_overlay_dirty = 0;
+    s_dx12_runtime.ui_overlay_rows_last = 0;
+    s_dx12_runtime.ui_overlay_quads_last = 0;
+    s_dx12_runtime.ui_overlay_vertices_last = 0;
     banana_dx12_runtime_update_telemetry();
 }
 
@@ -1736,6 +1848,8 @@ int banana_dx12_runtime_end_frame(void)
         return 0;
     }
 
+    banana_dx12_runtime_append_ui_overlay_vertices();
+
     if (s_dx12_runtime.scene_pipeline_ready && s_dx12_runtime.scene_vertex_count > 0)
     {
         ID3D12GraphicsCommandList_SetGraphicsRootSignature(s_dx12_runtime.command_list,
@@ -1813,6 +1927,71 @@ int banana_dx12_runtime_end_frame(void)
 #endif
 }
 
+void banana_dx12_runtime_set_ui_overlay(const unsigned char *rgba,
+                                        int width,
+                                        int height)
+{
+#if defined(BANANA_ENGINE_RENDER_BACKEND_DX12) && defined(_WIN32)
+    size_t required = 0;
+
+    if (!rgba || width <= 0 || height <= 0)
+    {
+        s_dx12_runtime.ui_overlay_width = 0;
+        s_dx12_runtime.ui_overlay_height = 0;
+        s_dx12_runtime.ui_overlay_dirty = 0;
+        return;
+    }
+
+    required = (size_t)width * (size_t)height * 4u;
+    if (!banana_dx12_runtime_ensure_ui_overlay_capacity(required))
+        return;
+
+    memcpy(s_dx12_runtime.ui_overlay_rgba, rgba, required);
+    s_dx12_runtime.ui_overlay_width = width;
+    s_dx12_runtime.ui_overlay_height = height;
+    s_dx12_runtime.ui_overlay_dirty = 1;
+    banana_dx12_runtime_update_telemetry();
+#else
+    (void)rgba;
+    (void)width;
+    (void)height;
+#endif
+}
+
+void banana_dx12_runtime_set_camera(const float *eye,
+                                    const float *target,
+                                    const float *up,
+                                    float fov_degrees,
+                                    float aspect)
+{
+#if defined(BANANA_ENGINE_RENDER_BACKEND_DX12) && defined(_WIN32)
+    if (!eye || !target || !up)
+    {
+        s_dx12_runtime.camera_valid = 0;
+        return;
+    }
+
+    s_dx12_runtime.camera_eye[0] = eye[0];
+    s_dx12_runtime.camera_eye[1] = eye[1];
+    s_dx12_runtime.camera_eye[2] = eye[2];
+    s_dx12_runtime.camera_target[0] = target[0];
+    s_dx12_runtime.camera_target[1] = target[1];
+    s_dx12_runtime.camera_target[2] = target[2];
+    s_dx12_runtime.camera_up[0] = up[0];
+    s_dx12_runtime.camera_up[1] = up[1];
+    s_dx12_runtime.camera_up[2] = up[2];
+    s_dx12_runtime.camera_fov_degrees = fov_degrees;
+    s_dx12_runtime.camera_aspect = aspect;
+    s_dx12_runtime.camera_valid = 1;
+#else
+    (void)eye;
+    (void)target;
+    (void)up;
+    (void)fov_degrees;
+    (void)aspect;
+#endif
+}
+
 void banana_dx12_runtime_shutdown(void)
 {
 #if defined(BANANA_ENGINE_RENDER_BACKEND_DX12) && defined(_WIN32)
@@ -1831,9 +2010,10 @@ void banana_dx12_runtime_submit_scene_draw(const Mesh *mesh,
                                            float color_b)
 {
 #if defined(BANANA_ENGINE_RENDER_BACKEND_DX12) && defined(_WIN32)
-    float world_span = 24.0f;
     float ndc_x = 0.0f;
     float ndc_y = 0.0f;
+    float ndc_z = 0.20f;
+    float view_depth = 0.0f;
     float half_width = 0.030f;
     float half_height = 0.030f;
     float r = uses_texture ? 0.95f : 0.35f;
@@ -1860,17 +2040,22 @@ void banana_dx12_runtime_submit_scene_draw(const Mesh *mesh,
         return;
     }
 
-    ndc_x = banana_dx12_clampf(position[0] / world_span, -1.0f, 1.0f);
-    ndc_y = banana_dx12_clampf(-position[2] / world_span, -1.0f, 1.0f);
+    banana_dx12_project_world_to_clip(position[0],
+                                      position[1] + (scale[1] * 0.50f),
+                                      position[2],
+                                      &ndc_x,
+                                      &ndc_y,
+                                      &ndc_z,
+                                      &view_depth);
 
-    half_width = banana_dx12_clampf(scale[0] / 16.0f, 0.018f, 0.080f);
-    half_height = banana_dx12_clampf(scale[2] / 16.0f, 0.018f, 0.080f);
+    half_width = banana_dx12_clampf(scale[0] / (6.0f + (view_depth * 0.36f)), 0.014f, 0.080f);
+    half_height = banana_dx12_clampf(scale[2] / (6.0f + (view_depth * 0.36f)), 0.014f, 0.080f);
 
     if (!banana_dx12_runtime_push_quad(ndc_x,
                                        ndc_y,
                                        half_width,
                                        half_height,
-                                       0.20f,
+                                       ndc_z,
                                        r,
                                        g,
                                        b,

--- a/src/native/engine/render/backend_dx12.h
+++ b/src/native/engine/render/backend_dx12.h
@@ -25,6 +25,14 @@ extern "C"
                                                float color_r,
                                                float color_g,
                                                float color_b);
+    void banana_dx12_runtime_set_camera(const float *eye,
+                                        const float *target,
+                                        const float *up,
+                                        float fov_degrees,
+                                        float aspect);
+    void banana_dx12_runtime_set_ui_overlay(const unsigned char *rgba,
+                                            int width,
+                                            int height);
     int banana_dx12_runtime_end_frame(void);
     void banana_dx12_runtime_shutdown(void);
 

--- a/src/native/engine/render/backend_dx12_projection_policy.c
+++ b/src/native/engine/render/backend_dx12_projection_policy.c
@@ -1,0 +1,171 @@
+#include "backend_dx12_projection_policy.h"
+
+#include <math.h>
+
+static float banana_dx12_projection_clampf(float value, float min_value, float max_value)
+{
+    if (value < min_value)
+        return min_value;
+    if (value > max_value)
+        return max_value;
+    return value;
+}
+
+static float banana_dx12_projection_vec3_dot(float ax,
+                                             float ay,
+                                             float az,
+                                             float bx,
+                                             float by,
+                                             float bz)
+{
+    return (ax * bx) + (ay * by) + (az * bz);
+}
+
+static void banana_dx12_projection_vec3_cross(float ax,
+                                               float ay,
+                                               float az,
+                                               float bx,
+                                               float by,
+                                               float bz,
+                                               float *out_x,
+                                               float *out_y,
+                                               float *out_z)
+{
+    *out_x = (ay * bz) - (az * by);
+    *out_y = (az * bx) - (ax * bz);
+    *out_z = (ax * by) - (ay * bx);
+}
+
+static void banana_dx12_projection_vec3_normalize(float *x, float *y, float *z)
+{
+    float length = sqrtf((*x * *x) + (*y * *y) + (*z * *z));
+    if (length <= 0.00001f)
+    {
+        *x = 0.0f;
+        *y = 1.0f;
+        *z = 0.0f;
+        return;
+    }
+
+    *x /= length;
+    *y /= length;
+    *z /= length;
+}
+
+void banana_dx12_projection_world_to_clip(const BananaDx12ProjectionCamera *camera,
+                                          float wx,
+                                          float wy,
+                                          float wz,
+                                          float *out_x,
+                                          float *out_y,
+                                          float *out_z,
+                                          float *out_view_depth)
+{
+    float camera_x = 16.0f;
+    float camera_y = 14.0f;
+    float camera_z = -16.0f;
+    float target_x = 0.0f;
+    float target_y = 0.0f;
+    float target_z = 0.0f;
+    float world_up_x = 0.0f;
+    float world_up_y = 1.0f;
+    float world_up_z = 0.0f;
+    float tan_half_fov = 0.404026f; /* tan(44deg/2) default */
+    float aspect = 1.0f;
+    float forward_x = 0.0f;
+    float forward_y = 0.0f;
+    float forward_z = 0.0f;
+    float right_x = 0.0f;
+    float right_y = 0.0f;
+    float right_z = 0.0f;
+    float up_x = 0.0f;
+    float up_y = 1.0f;
+    float up_z = 0.0f;
+    float dx = 0.0f;
+    float dy = 0.0f;
+    float dz = 0.0f;
+    float view_x = 0.0f;
+    float view_y = 0.0f;
+    float view_z = 0.0f;
+    float clip_x = 0.0f;
+    float clip_y = 0.0f;
+
+    if (camera && camera->valid)
+    {
+        camera_x = camera->eye[0];
+        camera_y = camera->eye[1];
+        camera_z = camera->eye[2];
+        target_x = camera->target[0];
+        target_y = camera->target[1];
+        target_z = camera->target[2];
+        world_up_x = camera->up[0];
+        world_up_y = camera->up[1];
+        world_up_z = camera->up[2];
+
+        if (camera->fov_degrees > 1.0f && camera->fov_degrees < 179.0f)
+        {
+            float half_rad = (camera->fov_degrees * 0.5f) *
+                             (3.14159265358979323846f / 180.0f);
+            tan_half_fov = tanf(half_rad);
+            if (tan_half_fov < 0.05f)
+                tan_half_fov = 0.05f;
+            if (tan_half_fov > 8.0f)
+                tan_half_fov = 8.0f;
+        }
+
+        aspect = camera->aspect;
+        if (aspect < 0.25f)
+            aspect = 0.25f;
+        if (aspect > 4.0f)
+            aspect = 4.0f;
+    }
+
+    forward_x = target_x - camera_x;
+    forward_y = target_y - camera_y;
+    forward_z = target_z - camera_z;
+    banana_dx12_projection_vec3_normalize(&forward_x, &forward_y, &forward_z);
+
+    banana_dx12_projection_vec3_cross(forward_x,
+                                      forward_y,
+                                      forward_z,
+                                      world_up_x,
+                                      world_up_y,
+                                      world_up_z,
+                                      &right_x,
+                                      &right_y,
+                                      &right_z);
+    banana_dx12_projection_vec3_normalize(&right_x, &right_y, &right_z);
+
+    banana_dx12_projection_vec3_cross(right_x,
+                                      right_y,
+                                      right_z,
+                                      forward_x,
+                                      forward_y,
+                                      forward_z,
+                                      &up_x,
+                                      &up_y,
+                                      &up_z);
+    banana_dx12_projection_vec3_normalize(&up_x, &up_y, &up_z);
+
+    dx = wx - camera_x;
+    dy = wy - camera_y;
+    dz = wz - camera_z;
+
+    view_x = banana_dx12_projection_vec3_dot(dx, dy, dz, right_x, right_y, right_z);
+    view_y = banana_dx12_projection_vec3_dot(dx, dy, dz, up_x, up_y, up_z);
+    view_z = banana_dx12_projection_vec3_dot(dx, dy, dz, forward_x, forward_y, forward_z);
+    if (view_z < 0.01f)
+        view_z = 0.01f;
+
+    clip_x = (view_x / (view_z * tan_half_fov * aspect));
+    clip_y = (view_y / (view_z * tan_half_fov));
+
+    if (out_x)
+        *out_x = banana_dx12_projection_clampf(clip_x, -1.25f, 1.25f);
+    if (out_y)
+        *out_y = banana_dx12_projection_clampf(clip_y, -1.25f, 1.25f);
+    if (out_z)
+        *out_z = banana_dx12_projection_clampf(0.02f + (view_z * 0.0045f), 0.02f, 0.98f);
+    if (out_view_depth)
+        *out_view_depth = view_z;
+}

--- a/src/native/engine/render/backend_dx12_projection_policy.h
+++ b/src/native/engine/render/backend_dx12_projection_policy.h
@@ -1,0 +1,32 @@
+#ifndef BANANA_ENGINE_RENDER_BACKEND_DX12_PROJECTION_POLICY_H
+#define BANANA_ENGINE_RENDER_BACKEND_DX12_PROJECTION_POLICY_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct BananaDx12ProjectionCamera
+    {
+        float eye[3];
+        float target[3];
+        float up[3];
+        float fov_degrees;
+        float aspect;
+        int valid;
+    } BananaDx12ProjectionCamera;
+
+    void banana_dx12_projection_world_to_clip(const BananaDx12ProjectionCamera *camera,
+                                              float wx,
+                                              float wy,
+                                              float wz,
+                                              float *out_x,
+                                              float *out_y,
+                                              float *out_z,
+                                              float *out_view_depth);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/native/engine/render/renderer.c
+++ b/src/native/engine/render/renderer.c
@@ -257,7 +257,21 @@ void renderer_attach_native_window(Renderer *r, void *native_window)
 
 void renderer_set_camera(Renderer *r, const Camera *cam)
 {
+    if (!r || !cam)
+        return;
+
     r->camera = *cam;
+
+#ifdef BANANA_ENGINE_RENDER_BACKEND_DX12
+    if (r->dx12_runtime_active)
+    {
+        banana_dx12_runtime_set_camera(r->camera.position,
+                                       r->camera.target,
+                                       r->camera.up,
+                                       r->camera.fov_degrees,
+                                       r->camera.aspect);
+    }
+#endif
 }
 
 void renderer_begin_frame(Renderer *r)

--- a/src/native/engine/render/window.c
+++ b/src/native/engine/render/window.c
@@ -217,6 +217,10 @@ static LRESULT CALLBACK window_dx12_proc(HWND hwnd, UINT message, WPARAM w_param
             window->right_click_y = (float)(short)HIWORD(l_param);
         }
         return 0;
+    case WM_SETCURSOR:
+        /* Always show a normal pointer in gameplay/runtime windows. */
+        SetCursor(LoadCursor(NULL, IDC_ARROW));
+        return TRUE;
     case WM_CLOSE:
         if (window)
             window->open = 0;
@@ -261,6 +265,7 @@ Window *window_create(int width, int height, const char *title)
     window_class.style = CS_HREDRAW | CS_VREDRAW;
     window_class.lpfnWndProc = window_dx12_proc;
     window_class.hInstance = instance;
+    window_class.hCursor = LoadCursor(NULL, IDC_ARROW);
     window_class.lpszClassName = BANANA_DX12_WINDOW_CLASS;
     if (!RegisterClassA(&window_class) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS)
     {

--- a/src/native/engine/runtime/application_service_ports.c
+++ b/src/native/engine/runtime/application_service_ports.c
@@ -186,12 +186,28 @@ static void runtime_render_command_for_actor(const Entity *entity,
                                              Material resolved_material,
                                              RendererDrawCommand *out_command)
 {
+    float render_y = 0.0f;
+
     if (!entity || !resolved_mesh || !out_command)
         return;
 
     out_command->mesh = resolved_mesh;
     out_command->position[0] = entity->position[0];
-    out_command->position[1] = entity->position[1];
+    render_y = entity->position[1];
+
+    /* Keep non-player actors visibly above terrain even if runtime state drifts below slopes.
+       This prevents "green box corners" from poking through terrain edges. */
+    if (s_mutation_state && entity->type != ENTITY_TYPE_PLAYER)
+    {
+        float ground_y = terrain_sample_height_port(s_mutation_state,
+                                                    entity->position[0],
+                                                    entity->position[2]);
+        float min_visual_y = ground_y + (entity->scale[1] * 0.45f) + 0.12f;
+        if (render_y < min_visual_y)
+            render_y = min_visual_y;
+    }
+
+    out_command->position[1] = render_y;
     out_command->position[2] = entity->position[2];
     out_command->rotation[0] = 0.f;
     out_command->rotation[1] = 0.f;

--- a/src/native/engine/runtime/camera_basis.c
+++ b/src/native/engine/runtime/camera_basis.c
@@ -1,34 +1,10 @@
 #include "camera_basis.h"
 
-#include <math.h>
-
 static void vec3_set(float *out, float x, float y, float z)
 {
     out[0] = x;
     out[1] = y;
     out[2] = z;
-}
-
-static float vec3_len(const float *v)
-{
-    return sqrtf(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
-}
-
-static void vec3_normalize(float *v)
-{
-    float len = vec3_len(v);
-    if (len <= 1e-6f)
-        return;
-    v[0] /= len;
-    v[1] /= len;
-    v[2] /= len;
-}
-
-static void vec3_cross(const float *a, const float *b, float *out)
-{
-    out[0] = a[1] * b[2] - a[2] * b[1];
-    out[1] = a[2] * b[0] - a[0] * b[2];
-    out[2] = a[0] * b[1] - a[1] * b[0];
 }
 
 int runtime_camera_compute_ground_basis(const float *camera_eye,
@@ -37,24 +13,15 @@ int runtime_camera_compute_ground_basis(const float *camera_eye,
                                         float *forward,
                                         float *right)
 {
-    if (!camera_eye || !camera_target || !forward || !right || !camera_valid)
+    if (!forward || !right)
         return 0;
 
-    vec3_set(forward,
-             camera_target[0] - camera_eye[0],
-             0.f,
-             camera_target[2] - camera_eye[2]);
-    if (vec3_len(forward) <= 1e-6f)
-        vec3_set(forward, 0.f, 0.f, -1.f);
-    vec3_normalize(forward);
+    (void)camera_eye;
+    (void)camera_target;
+    (void)camera_valid;
 
-    {
-        float world_up[3] = {0.f, 1.f, 0.f};
-        vec3_cross(forward, world_up, right);
-    }
-    if (vec3_len(right) <= 1e-6f)
-        vec3_set(right, 1.f, 0.f, 0.f);
-    vec3_normalize(right);
+    vec3_set(forward, 0.f, 0.f, -1.f);
+    vec3_set(right, 1.f, 0.f, 0.f);
 
     return 1;
 }

--- a/src/native/engine/runtime/camera_follow.c
+++ b/src/native/engine/runtime/camera_follow.c
@@ -24,21 +24,21 @@ void runtime_camera_follow_player(Renderer *renderer,
     if (!player || !player->active)
         return;
 
-    camera = camera_create(44.f, (float)viewport_width / (float)viewport_height, 0.1f, 1000.f);
+    camera = camera_create(52.f, (float)viewport_width / (float)viewport_height, 0.1f, 1000.f);
     camera_look_at(&camera,
-                   player->position[0] + 7.0f,
-                   player->position[1] + 10.5f,
-                   player->position[2] + 7.0f,
                    player->position[0],
-                   player->position[1] - 0.35f,
+                   player->position[1] + 14.0f,
+                   player->position[2] + 11.0f,
+                   player->position[0],
+                   player->position[1],
                    player->position[2]);
 
-    camera_eye[0] = player->position[0] + 7.0f;
-    camera_eye[1] = player->position[1] + 10.5f;
-    camera_eye[2] = player->position[2] + 7.0f;
+    camera_eye[0] = player->position[0];
+    camera_eye[1] = player->position[1] + 14.0f;
+    camera_eye[2] = player->position[2] + 11.0f;
 
     camera_target[0] = player->position[0];
-    camera_target[1] = player->position[1] - 0.35f;
+    camera_target[1] = player->position[1];
     camera_target[2] = player->position[2];
 
     *camera_valid = 1;

--- a/src/native/engine/runtime/camera_follow.c
+++ b/src/native/engine/runtime/camera_follow.c
@@ -1,5 +1,7 @@
 #include "camera_follow.h"
 
+#include "camera_follow_policy.h"
+
 #include "../render/camera.h"
 
 #include <stddef.h>
@@ -15,6 +17,7 @@ void runtime_camera_follow_player(Renderer *renderer,
 {
     Entity *player = NULL;
     Camera camera = {0};
+    RuntimeCameraFollowPose pose = {0};
 
     if (!renderer || !world || !player_id || viewport_width <= 0 || viewport_height <= 0 ||
         !camera_eye || !camera_target || !camera_valid)
@@ -24,22 +27,31 @@ void runtime_camera_follow_player(Renderer *renderer,
     if (!player || !player->active)
         return;
 
-    camera = camera_create(52.f, (float)viewport_width / (float)viewport_height, 0.1f, 1000.f);
+    if (!runtime_camera_follow_policy_compute(player->position,
+                                              viewport_width,
+                                              viewport_height,
+                                              &pose))
+        return;
+
+    camera = camera_create(pose.fov_degrees,
+                           pose.aspect,
+                           pose.near_plane,
+                           pose.far_plane);
     camera_look_at(&camera,
-                   player->position[0],
-                   player->position[1] + 14.0f,
-                   player->position[2] + 11.0f,
-                   player->position[0],
-                   player->position[1],
-                   player->position[2]);
+                   pose.eye[0],
+                   pose.eye[1],
+                   pose.eye[2],
+                   pose.target[0],
+                   pose.target[1],
+                   pose.target[2]);
 
-    camera_eye[0] = player->position[0];
-    camera_eye[1] = player->position[1] + 14.0f;
-    camera_eye[2] = player->position[2] + 11.0f;
+    camera_eye[0] = pose.eye[0];
+    camera_eye[1] = pose.eye[1];
+    camera_eye[2] = pose.eye[2];
 
-    camera_target[0] = player->position[0];
-    camera_target[1] = player->position[1];
-    camera_target[2] = player->position[2];
+    camera_target[0] = pose.target[0];
+    camera_target[1] = pose.target[1];
+    camera_target[2] = pose.target[2];
 
     *camera_valid = 1;
     renderer_set_camera(renderer, &camera);

--- a/src/native/engine/runtime/camera_follow_policy.c
+++ b/src/native/engine/runtime/camera_follow_policy.c
@@ -1,0 +1,29 @@
+#include "camera_follow_policy.h"
+
+int runtime_camera_follow_policy_compute(const float *player_position,
+                                         int viewport_width,
+                                         int viewport_height,
+                                         RuntimeCameraFollowPose *out_pose)
+{
+    float aspect = 1.0f;
+
+    if (!player_position || viewport_width <= 0 || viewport_height <= 0 || !out_pose)
+        return 0;
+
+    aspect = (float)viewport_width / (float)viewport_height;
+
+    out_pose->eye[0] = player_position[0] - 10.0f;
+    out_pose->eye[1] = player_position[1] + 13.5f;
+    out_pose->eye[2] = player_position[2] - 10.0f;
+
+    out_pose->target[0] = player_position[0];
+    out_pose->target[1] = player_position[1] + 1.35f;
+    out_pose->target[2] = player_position[2];
+
+    out_pose->fov_degrees = 52.0f;
+    out_pose->near_plane = 0.1f;
+    out_pose->far_plane = 1000.0f;
+    out_pose->aspect = aspect;
+
+    return 1;
+}

--- a/src/native/engine/runtime/camera_follow_policy.h
+++ b/src/native/engine/runtime/camera_follow_policy.h
@@ -1,0 +1,28 @@
+#ifndef BANANA_ENGINE_RUNTIME_CAMERA_FOLLOW_POLICY_H
+#define BANANA_ENGINE_RUNTIME_CAMERA_FOLLOW_POLICY_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct RuntimeCameraFollowPose
+    {
+        float eye[3];
+        float target[3];
+        float fov_degrees;
+        float near_plane;
+        float far_plane;
+        float aspect;
+    } RuntimeCameraFollowPose;
+
+    int runtime_camera_follow_policy_compute(const float *player_position,
+                                             int viewport_width,
+                                             int viewport_height,
+                                             RuntimeCameraFollowPose *out_pose);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/native/engine/runtime/engine_composition.c
+++ b/src/native/engine/runtime/engine_composition.c
@@ -2,6 +2,8 @@
 
 #include "application_service_ports.h"
 
+#include "orchestration/runtime_tick_orchestration.h"
+
 #include "../ai/npc_merchant.h"
 #include "../ai/wildlife_controller.h"
 #include "../render/backend.h"
@@ -9,7 +11,6 @@
 #include "engine_serialize.h"
 #include "engine_lifecycle.h"
 #include "engine_tick.h"
-#include "gameplay_service.h"
 #include "input_contract.h"
 #include "player_builds.h"
 #include "player_registry.h"
@@ -17,66 +18,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
-static EngineRuntimeState *s_active_state = NULL;
-static RuntimeTerrainSampleHeightFn s_active_sample_height = NULL;
 static const RuntimeApplicationServicePorts *s_service_ports = NULL;
-
-static int terrain_rebuild_dirty_chunks_runtime(int max_chunks)
-{
-    if (!s_active_state || !s_service_ports || !s_service_ports->terrain.rebuild_dirty_chunks)
-        return 0;
-
-    return s_service_ports->terrain.rebuild_dirty_chunks(s_active_state, max_chunks);
-}
-
-static void update_player_motion(float dt)
-{
-    if (!s_active_state || !s_active_sample_height || !s_service_ports || !s_service_ports->player.update_motion)
-        return;
-
-    s_service_ports->player.update_motion(s_active_state, dt, s_active_sample_height);
-}
-
-static void follow_player_camera(void)
-{
-    if (!s_active_state || !s_service_ports || !s_service_ports->player.follow_camera)
-        return;
-
-    s_service_ports->player.follow_camera(s_active_state);
-}
-
-static void apply_click_move_input(float normalized_x, float normalized_y)
-{
-    if (!s_active_state || !s_active_sample_height || !s_service_ports || !s_service_ports->player.apply_click_input)
-        return;
-
-    s_service_ports->player.apply_click_input(s_active_state,
-                                              normalized_x,
-                                              normalized_y,
-                                              s_active_sample_height);
-}
-
-static void tick_phase_gameplay(void)
-{
-    if (!s_active_state)
-        return;
-
-    runtime_gameplay_service_tick(s_active_state->world,
-                                  s_active_state->controllers,
-                                  s_active_state->controller_count,
-                                  s_active_state->player_id,
-                                  &s_active_state->pbj_pickup_collected,
-                                  6.0f,
-                                  1.55f);
-}
-
-static void tick_phase_render_scene(void)
-{
-    if (!s_active_state || !s_service_ports || !s_service_ports->render.submit_scene)
-        return;
-
-    s_service_ports->render.submit_scene(s_active_state);
-}
 
 int runtime_engine_composition_init(EngineRuntimeState *state,
                                     int width,
@@ -178,12 +120,15 @@ int runtime_engine_composition_tick(EngineRuntimeState *state,
                                     RuntimeTerrainSampleHeightFn sample_height)
 {
     int result = 0;
+    RuntimeTickOrchestrationContext context = {0};
 
     if (!state || !sample_height)
         return -1;
 
-    s_active_state = state;
-    s_active_sample_height = sample_height;
+    context.state = state;
+    context.sample_height = sample_height;
+
+    context.service_ports = s_service_ports;
 
     result = runtime_engine_tick_execute(state->window,
                                          state->renderer,
@@ -191,18 +136,16 @@ int runtime_engine_composition_tick(EngineRuntimeState *state,
                                          state->world,
                                          &state->viewport_width,
                                          &state->viewport_height,
-                                         terrain_rebuild_dirty_chunks_runtime,
+                                         runtime_tick_orchestration_rebuild_dirty_chunks,
                                          state->controllers,
                                          state->controller_count,
                                          dt,
-                                         update_player_motion,
-                                         follow_player_camera,
-                                         apply_click_move_input,
-                                         tick_phase_gameplay,
-                                         tick_phase_render_scene);
-
-    s_active_sample_height = NULL;
-    s_active_state = NULL;
+                                         &context,
+                                         runtime_tick_orchestration_update_player_motion,
+                                         runtime_tick_orchestration_follow_player_camera,
+                                         runtime_tick_orchestration_apply_click_move_input,
+                                         runtime_tick_orchestration_gameplay,
+                                         runtime_tick_orchestration_render_scene);
     return result;
 }
 

--- a/src/native/engine/runtime/engine_lifecycle.c
+++ b/src/native/engine/runtime/engine_lifecycle.c
@@ -18,6 +18,35 @@ static float runtime_spawn_jitter(unsigned int seed)
     return (((float)(seed & 0xFFu) / 255.0f) - 0.5f) * 2.4f;
 }
 
+/* Sample center + footprint corners and return the highest ground point.
+   This avoids actor corners clipping out of sloped terrain near map edges. */
+static float runtime_spawn_sample_max_ground(RuntimeTerrainSampleFn terrain_sample_height,
+                                             float x,
+                                             float z,
+                                             float sx,
+                                             float sz)
+{
+    float half_x = sx * 0.5f;
+    float half_z = sz * 0.5f;
+    float max_h = terrain_sample_height(x, z);
+    float h = 0.0f;
+
+    h = terrain_sample_height(x - half_x, z - half_z);
+    if (h > max_h)
+        max_h = h;
+    h = terrain_sample_height(x + half_x, z - half_z);
+    if (h > max_h)
+        max_h = h;
+    h = terrain_sample_height(x - half_x, z + half_z);
+    if (h > max_h)
+        max_h = h;
+    h = terrain_sample_height(x + half_x, z + half_z);
+    if (h > max_h)
+        max_h = h;
+
+    return max_h;
+}
+
 int runtime_engine_lifecycle_build_terrain(unsigned char *height_grid,
                                            int terrain_size,
                                            int terrain_max_layers,
@@ -93,7 +122,8 @@ int runtime_engine_lifecycle_spawn_default_actors(World *world,
         { 0.66f, -0.42f, 0.55f, ENTITY_TYPE_NPC,     1.05f, 1.05f, 1.05f, "combat",   1},
         { 0.82f, -0.06f, 0.55f, ENTITY_TYPE_NPC,     0.95f, 1.10f, 0.95f, "wildlife", 1},
         {-0.56f,  0.66f, 0.45f, ENTITY_TYPE_TRIGGER, 0.95f, 1.30f, 0.95f, "quest",    0},
-        {-0.82f,  0.78f, 0.35f, ENTITY_TYPE_STATIC,  1.40f, 0.60f, 1.40f, "camp",     0},
+        /* Camp scaffold prop: keep it visibly above terrain so it does not read as a buried box. */
+        {-0.82f,  0.78f, 0.72f, ENTITY_TYPE_STATIC,  1.20f, 0.90f, 1.20f, "camp",     0},
         { 0.22f,  0.18f, 0.42f, ENTITY_TYPE_STATIC,  1.25f, 1.05f, 1.25f, "pbj_pickup", 0},
         { 0.88f,  0.62f, 0.55f, ENTITY_TYPE_NPC,     1.00f, 1.00f, 1.00f, "wildlife", 1},
     };
@@ -110,7 +140,12 @@ int runtime_engine_lifecycle_spawn_default_actors(World *world,
         unsigned int hash = runtime_spawn_hash((unsigned int)(i + 1));
         float x = (archetype->x * spread_radius) + runtime_spawn_jitter(hash);
         float z = (archetype->z * spread_radius) + runtime_spawn_jitter(hash >> 8);
-        float y = terrain_sample_height(x, z) + archetype->y_offset;
+        float base_ground = runtime_spawn_sample_max_ground(terrain_sample_height,
+                                    x,
+                                    z,
+                                    archetype->sx,
+                                    archetype->sz);
+        float y = base_ground + archetype->y_offset;
         EntityId actor_id = world_spawn_entity(world, archetype->type, x, y, z);
         Entity *actor = world_get_entity(world, actor_id);
         if (actor)

--- a/src/native/engine/runtime/engine_lifecycle.c
+++ b/src/native/engine/runtime/engine_lifecycle.c
@@ -6,6 +6,18 @@
 #include <stddef.h>
 #include <string.h>
 
+static unsigned int runtime_spawn_hash(unsigned int value)
+{
+    unsigned int n = value * 374761393u + 20260523u;
+    n = (n ^ (n >> 13)) * 1274126177u;
+    return n ^ (n >> 16);
+}
+
+static float runtime_spawn_jitter(unsigned int seed)
+{
+    return (((float)(seed & 0xFFu) / 255.0f) - 0.5f) * 2.4f;
+}
+
 int runtime_engine_lifecycle_build_terrain(unsigned char *height_grid,
                                            int terrain_size,
                                            int terrain_max_layers,
@@ -75,16 +87,17 @@ int runtime_engine_lifecycle_spawn_default_actors(World *world,
     } RuntimeActorArchetype;
 
     static const RuntimeActorArchetype actor_archetypes[] = {
-        {-4.2f, -2.8f, 0.55f, ENTITY_TYPE_NPC,     1.15f, 1.00f, 1.15f, "merchant", 0},
-        {-2.6f, -3.4f, 0.40f, ENTITY_TYPE_DYNAMIC, 0.75f, 0.75f, 0.75f, "resource", 0},
-        {-1.4f, -2.0f, 0.45f, ENTITY_TYPE_DYNAMIC, 0.85f, 0.90f, 0.85f, "resource", 0},
-        { 3.2f, -2.9f, 0.55f, ENTITY_TYPE_NPC,     1.05f, 1.05f, 1.05f, "combat",   1},
-        { 4.0f, -1.8f, 0.55f, ENTITY_TYPE_NPC,     0.95f, 1.10f, 0.95f, "wildlife", 1},
-        {-2.4f,  2.8f, 0.45f, ENTITY_TYPE_TRIGGER, 0.95f, 1.30f, 0.95f, "quest",    0},
-        {-3.7f,  3.6f, 0.35f, ENTITY_TYPE_STATIC,  1.40f, 0.60f, 1.40f, "camp",     0},
-        { 1.8f,  1.6f, 0.42f, ENTITY_TYPE_STATIC,  1.25f, 1.05f, 1.25f, "pbj_pickup", 0},
-        { 2.8f,  2.9f, 0.55f, ENTITY_TYPE_NPC,     1.00f, 1.00f, 1.00f, "wildlife", 1},
+        {-0.20f, -0.16f, 0.55f, ENTITY_TYPE_NPC,     1.15f, 1.00f, 1.15f, "merchant", 0},
+        {-0.62f, -0.38f, 0.40f, ENTITY_TYPE_DYNAMIC, 0.75f, 0.75f, 0.75f, "resource", 0},
+        {-0.18f, -0.56f, 0.45f, ENTITY_TYPE_DYNAMIC, 0.85f, 0.90f, 0.85f, "resource", 0},
+        { 0.66f, -0.42f, 0.55f, ENTITY_TYPE_NPC,     1.05f, 1.05f, 1.05f, "combat",   1},
+        { 0.82f, -0.06f, 0.55f, ENTITY_TYPE_NPC,     0.95f, 1.10f, 0.95f, "wildlife", 1},
+        {-0.56f,  0.66f, 0.45f, ENTITY_TYPE_TRIGGER, 0.95f, 1.30f, 0.95f, "quest",    0},
+        {-0.82f,  0.78f, 0.35f, ENTITY_TYPE_STATIC,  1.40f, 0.60f, 1.40f, "camp",     0},
+        { 0.22f,  0.18f, 0.42f, ENTITY_TYPE_STATIC,  1.25f, 1.05f, 1.25f, "pbj_pickup", 0},
+        { 0.88f,  0.62f, 0.55f, ENTITY_TYPE_NPC,     1.00f, 1.00f, 1.00f, "wildlife", 1},
     };
+    const float spread_radius = 18.0f;
     int spawned = 0;
     int i = 0;
 
@@ -94,8 +107,11 @@ int runtime_engine_lifecycle_spawn_default_actors(World *world,
     for (i = 0; i < (int)(sizeof(actor_archetypes) / sizeof(actor_archetypes[0])); i++)
     {
         const RuntimeActorArchetype *archetype = &actor_archetypes[i];
-        float y = terrain_sample_height(archetype->x, archetype->z) + archetype->y_offset;
-        EntityId actor_id = world_spawn_entity(world, archetype->type, archetype->x, y, archetype->z);
+        unsigned int hash = runtime_spawn_hash((unsigned int)(i + 1));
+        float x = (archetype->x * spread_radius) + runtime_spawn_jitter(hash);
+        float z = (archetype->z * spread_radius) + runtime_spawn_jitter(hash >> 8);
+        float y = terrain_sample_height(x, z) + archetype->y_offset;
+        EntityId actor_id = world_spawn_entity(world, archetype->type, x, y, z);
         Entity *actor = world_get_entity(world, actor_id);
         if (actor)
         {

--- a/src/native/engine/runtime/engine_tick.c
+++ b/src/native/engine/runtime/engine_tick.c
@@ -13,6 +13,7 @@ int runtime_engine_tick_execute(Window *window,
                                 ControllerInstance **controllers,
                                 int controller_count,
                                 float dt,
+                                void *context,
                                 RuntimeTickUpdateFn update_player_motion,
                                 RuntimeTickVoidFn follow_player_camera,
                                 RuntimeTickClickInputFn apply_click_input,
@@ -45,7 +46,7 @@ int runtime_engine_tick_execute(Window *window,
                 normalized_y = 1.f - (click_y / (float)input_height) * 2.f;
                 runtime_input_contract_handle_right_click_normalized(normalized_x, normalized_y);
                 if (apply_click_input)
-                    apply_click_input(normalized_x, normalized_y);
+                    apply_click_input(context, normalized_x, normalized_y);
             }
         }
     }
@@ -53,21 +54,22 @@ int runtime_engine_tick_execute(Window *window,
     world_tick(world, dt);
 
     if (update_player_motion)
-        update_player_motion(dt);
-    if (follow_player_camera)
-        follow_player_camera();
+        update_player_motion(context, dt);
 
     runtime_phase_viewport_resize(window, renderer, viewport_width, viewport_height);
-    if (runtime_phase_terrain_budget(terrain_rebuild, 2) != 0)
+    if (runtime_phase_terrain_budget(context, terrain_rebuild, 2) != 0)
         return -1;
 
     if (run_gameplay)
-        run_gameplay();
+        run_gameplay(context);
 
     runtime_sync_controller_positions(world, controllers, controller_count, dt);
 
+    if (follow_player_camera)
+        follow_player_camera(context);
+
     if (render_scene)
-        render_scene();
+        render_scene(context);
 
     return 0;
 }

--- a/src/native/engine/runtime/engine_tick.h
+++ b/src/native/engine/runtime/engine_tick.h
@@ -13,10 +13,10 @@ extern "C"
 {
 #endif
 
-    typedef void (*RuntimeTickUpdateFn)(float dt);
-    typedef void (*RuntimeTickVoidFn)(void);
-    typedef void (*RuntimeTickGameplayFn)(void);
-    typedef void (*RuntimeTickClickInputFn)(float normalized_x, float normalized_y);
+    typedef void (*RuntimeTickUpdateFn)(void *context, float dt);
+    typedef void (*RuntimeTickVoidFn)(void *context);
+    typedef void (*RuntimeTickGameplayFn)(void *context);
+    typedef void (*RuntimeTickClickInputFn)(void *context, float normalized_x, float normalized_y);
 
     int runtime_engine_tick_execute(Window *window,
                                     Renderer *renderer,
@@ -28,6 +28,7 @@ extern "C"
                                     ControllerInstance **controllers,
                                     int controller_count,
                                     float dt,
+                                    void *context,
                                     RuntimeTickUpdateFn update_player_motion,
                                     RuntimeTickVoidFn follow_player_camera,
                                     RuntimeTickClickInputFn apply_click_input,

--- a/src/native/engine/runtime/move_target_domain.c
+++ b/src/native/engine/runtime/move_target_domain.c
@@ -1,6 +1,5 @@
 #include "move_target_domain.h"
 
-#include "camera_basis.h"
 #include "input_contract.h"
 
 #include <math.h>
@@ -47,8 +46,6 @@ int runtime_move_target_compute_steering(const RuntimeMoveTargetState *state,
                                          float arrival_threshold,
                                          RuntimeMoveTargetSteering *out_steering)
 {
-    float forward[3] = {0.f, 0.f, -1.f};
-    float right[3] = {1.f, 0.f, 0.f};
     float dx = 0.f;
     float dz = 0.f;
     float distance = 0.f;
@@ -80,14 +77,12 @@ int runtime_move_target_compute_steering(const RuntimeMoveTargetState *state,
     world_dir_x = dx / distance;
     world_dir_z = dz / distance;
 
-    runtime_camera_compute_ground_basis(camera_eye,
-                                       camera_target,
-                                       camera_valid,
-                                       forward,
-                                       right);
+    (void)camera_eye;
+    (void)camera_target;
+    (void)camera_valid;
 
-    out_steering->move_x = world_dir_x * right[0] + world_dir_z * right[2];
-    out_steering->move_z = world_dir_x * forward[0] + world_dir_z * forward[2];
+    out_steering->move_x = world_dir_x;
+    out_steering->move_z = world_dir_z;
     runtime_input_contract_sanitize_move_input(out_steering->move_x,
                                                out_steering->move_z,
                                                &out_steering->move_x,

--- a/src/native/engine/runtime/orchestration/player_tick_orchestration.c
+++ b/src/native/engine/runtime/orchestration/player_tick_orchestration.c
@@ -1,0 +1,44 @@
+#include "runtime_tick_orchestration.h"
+
+void runtime_tick_orchestration_update_player_motion(void *context, float dt)
+{
+    RuntimeTickOrchestrationContext *orchestration =
+        (RuntimeTickOrchestrationContext *)context;
+
+    if (!orchestration || !orchestration->state || !orchestration->sample_height ||
+        !orchestration->service_ports || !orchestration->service_ports->player.update_motion)
+        return;
+
+    orchestration->service_ports->player.update_motion(orchestration->state,
+                                                       dt,
+                                                       orchestration->sample_height);
+}
+
+void runtime_tick_orchestration_follow_player_camera(void *context)
+{
+    RuntimeTickOrchestrationContext *orchestration =
+        (RuntimeTickOrchestrationContext *)context;
+
+    if (!orchestration || !orchestration->state || !orchestration->service_ports ||
+        !orchestration->service_ports->player.follow_camera)
+        return;
+
+    orchestration->service_ports->player.follow_camera(orchestration->state);
+}
+
+void runtime_tick_orchestration_apply_click_move_input(void *context,
+                                                       float normalized_x,
+                                                       float normalized_y)
+{
+    RuntimeTickOrchestrationContext *orchestration =
+        (RuntimeTickOrchestrationContext *)context;
+
+    if (!orchestration || !orchestration->state || !orchestration->sample_height ||
+        !orchestration->service_ports || !orchestration->service_ports->player.apply_click_input)
+        return;
+
+    orchestration->service_ports->player.apply_click_input(orchestration->state,
+                                                           normalized_x,
+                                                           normalized_y,
+                                                           orchestration->sample_height);
+}

--- a/src/native/engine/runtime/orchestration/render_tick_orchestration.c
+++ b/src/native/engine/runtime/orchestration/render_tick_orchestration.c
@@ -1,0 +1,32 @@
+#include "runtime_tick_orchestration.h"
+
+#include "../gameplay_service.h"
+
+void runtime_tick_orchestration_gameplay(void *context)
+{
+    RuntimeTickOrchestrationContext *orchestration =
+        (RuntimeTickOrchestrationContext *)context;
+
+    if (!orchestration || !orchestration->state)
+        return;
+
+    runtime_gameplay_service_tick(orchestration->state->world,
+                                  orchestration->state->controllers,
+                                  orchestration->state->controller_count,
+                                  orchestration->state->player_id,
+                                  &orchestration->state->pbj_pickup_collected,
+                                  6.0f,
+                                  1.55f);
+}
+
+void runtime_tick_orchestration_render_scene(void *context)
+{
+    RuntimeTickOrchestrationContext *orchestration =
+        (RuntimeTickOrchestrationContext *)context;
+
+    if (!orchestration || !orchestration->state || !orchestration->service_ports ||
+        !orchestration->service_ports->render.submit_scene)
+        return;
+
+    orchestration->service_ports->render.submit_scene(orchestration->state);
+}

--- a/src/native/engine/runtime/orchestration/runtime_tick_orchestration.h
+++ b/src/native/engine/runtime/orchestration/runtime_tick_orchestration.h
@@ -1,0 +1,36 @@
+#ifndef BANANA_ENGINE_RUNTIME_ORCHESTRATION_RUNTIME_TICK_ORCHESTRATION_H
+#define BANANA_ENGINE_RUNTIME_ORCHESTRATION_RUNTIME_TICK_ORCHESTRATION_H
+
+#include "../application_service_ports.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct RuntimeTickOrchestrationContext
+    {
+        EngineRuntimeState *state;
+        RuntimeTerrainSampleHeightFn sample_height;
+        const RuntimeApplicationServicePorts *service_ports;
+    } RuntimeTickOrchestrationContext;
+
+    int runtime_tick_orchestration_rebuild_dirty_chunks(void *context, int max_chunks);
+
+    void runtime_tick_orchestration_update_player_motion(void *context, float dt);
+
+    void runtime_tick_orchestration_follow_player_camera(void *context);
+
+    void runtime_tick_orchestration_apply_click_move_input(void *context,
+                                                           float normalized_x,
+                                                           float normalized_y);
+
+    void runtime_tick_orchestration_gameplay(void *context);
+
+    void runtime_tick_orchestration_render_scene(void *context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/native/engine/runtime/orchestration/terrain_tick_orchestration.c
+++ b/src/native/engine/runtime/orchestration/terrain_tick_orchestration.c
@@ -1,0 +1,14 @@
+#include "runtime_tick_orchestration.h"
+
+int runtime_tick_orchestration_rebuild_dirty_chunks(void *context, int max_chunks)
+{
+    RuntimeTickOrchestrationContext *orchestration =
+        (RuntimeTickOrchestrationContext *)context;
+
+    if (!orchestration || !orchestration->state || !orchestration->service_ports ||
+        !orchestration->service_ports->terrain.rebuild_dirty_chunks)
+        return 0;
+
+    return orchestration->service_ports->terrain.rebuild_dirty_chunks(orchestration->state,
+                                                                       max_chunks);
+}

--- a/src/native/engine/runtime/player_motion_host.c
+++ b/src/native/engine/runtime/player_motion_host.c
@@ -1,6 +1,5 @@
 #include "player_motion_host.h"
 
-#include "camera_basis.h"
 #include "player_registry.h"
 
 void runtime_player_motion_tick(World *world,
@@ -17,26 +16,16 @@ void runtime_player_motion_tick(World *world,
 {
     NativePlayerBinding *bindings[BANANA_MAX_NATIVE_PLAYERS] = {0};
     int binding_count = runtime_player_registry_count();
-    float forward[3] = {0.f, 0.f, 0.f};
-    float right[3] = {0.f, 0.f, 0.f};
+    float forward[3] = {0.f, 0.f, 1.f};
+    float right[3] = {1.f, 0.f, 0.f};
     int i = 0;
 
     if (!world)
         return;
 
-    if (!runtime_camera_compute_ground_basis(camera_eye,
-                                             camera_target,
-                                             camera_valid,
-                                             forward,
-                                             right))
-    {
-        forward[0] = 0.f;
-        forward[1] = 0.f;
-        forward[2] = -1.f;
-        right[0] = 1.f;
-        right[1] = 0.f;
-        right[2] = 0.f;
-    }
+    (void)camera_eye;
+    (void)camera_target;
+    (void)camera_valid;
 
     if (binding_count > BANANA_MAX_NATIVE_PLAYERS)
         binding_count = BANANA_MAX_NATIVE_PLAYERS;

--- a/src/native/engine/runtime/terrain_chunks.c
+++ b/src/native/engine/runtime/terrain_chunks.c
@@ -42,39 +42,82 @@ static uint32_t chunk_hash(int cx, int cz)
     return h;
 }
 
+static float clampf_local(float v, float lo, float hi)
+{
+    if (v < lo)
+        return lo;
+    if (v > hi)
+        return hi;
+    return v;
+}
+
+static float lerpf_local(float a, float b, float t)
+{
+    return a + (b - a) * t;
+}
+
+static float smoothstep_local(float t)
+{
+    t = clampf_local(t, 0.0f, 1.0f);
+    return t * t * (3.0f - (2.0f * t));
+}
+
+static uint32_t hash_noise2_i32(int x, int z, uint32_t salt)
+{
+    uint32_t h = g_terrain_chunks.seed ^ salt;
+    h ^= (uint32_t)x * 374761393U;
+    h ^= (uint32_t)z * 668265263U;
+    h = (h ^ (h >> 13)) * 1274126177U;
+    return h ^ (h >> 16);
+}
+
+static float noise2_world(int world_x, int world_z, int frequency, uint32_t salt)
+{
+    int cell_x = world_x / frequency;
+    int cell_z = world_z / frequency;
+    int frac_x = world_x % frequency;
+    int frac_z = world_z % frequency;
+    float tx = (float)frac_x / (float)frequency;
+    float tz = (float)frac_z / (float)frequency;
+
+    float v00 = (float)(hash_noise2_i32(cell_x, cell_z, salt) & 0xFFFFU) / 65535.0f;
+    float v10 = (float)(hash_noise2_i32(cell_x + 1, cell_z, salt) & 0xFFFFU) / 65535.0f;
+    float v01 = (float)(hash_noise2_i32(cell_x, cell_z + 1, salt) & 0xFFFFU) / 65535.0f;
+    float v11 = (float)(hash_noise2_i32(cell_x + 1, cell_z + 1, salt) & 0xFFFFU) / 65535.0f;
+
+    tx = smoothstep_local(tx);
+    tz = smoothstep_local(tz);
+
+    return lerpf_local(lerpf_local(v00, v10, tx),
+                       lerpf_local(v01, v11, tx),
+                       tz);
+}
+
 /**
  * Procedural heightfield generation for a chunk.
  * Uses simple pseudo-random noise based on chunk hash.
  */
 static void generate_heightfield(int chunk_x, int chunk_z, uint8_t heights[TERRAIN_CHUNK_SIZE][TERRAIN_CHUNK_SIZE])
 {
-    uint32_t base_hash = chunk_hash(chunk_x, chunk_z);
+    const int chunk_world_x = chunk_x * TERRAIN_CHUNK_SIZE;
+    const int chunk_world_z = chunk_z * TERRAIN_CHUNK_SIZE;
 
     for (int z = 0; z < TERRAIN_CHUNK_SIZE; z++)
     {
         for (int x = 0; x < TERRAIN_CHUNK_SIZE; x++)
         {
-            /* Mix hash with local position for variation within chunk */
-            uint32_t h = base_hash;
-            h ^= (uint32_t)(x + z * TERRAIN_CHUNK_SIZE) * 2654435769U;
-
-            /* Simple height gradient: higher in center, lower at edges */
-            int dx = x - TERRAIN_CHUNK_SIZE / 2;
-            int dz = z - TERRAIN_CHUNK_SIZE / 2;
-            int dist_sq = dx * dx + dz * dz;
-
-            /* Base elevation from hash */
-            int base_elev = (int)((h >> 8) & 0xFF);
-
-            /* Blend with distance-based gradient */
-            int max_dist_sq = (TERRAIN_CHUNK_SIZE / 2) * (TERRAIN_CHUNK_SIZE / 2);
-            int gradient = 100 - (dist_sq * 100) / max_dist_sq;
-            if (gradient < 0)
-                gradient = 0;
-
-            int final_height = (base_elev * 60 + gradient * 60) / 120;
-            if (final_height > 255)
-                final_height = 255;
+            int world_x = chunk_world_x + x;
+            int world_z = chunk_world_z + z;
+            float macro_noise = noise2_world(world_x, world_z, 96, 17U);
+            float medium_noise = noise2_world(world_x, world_z, 28, 53U);
+            float detail_noise = noise2_world(world_x, world_z, 8, 131U);
+            float ridged = 1.0f - fabsf((detail_noise * 2.0f) - 1.0f);
+            float radius = sqrtf((float)((world_x * world_x) + (world_z * world_z))) / 300.0f;
+            float origin_bias = 1.0f - smoothstep_local((radius - 0.78f) / 0.56f);
+            float land = (macro_noise * 0.56f) + (medium_noise * 0.22f) + (ridged * 0.18f) +
+                         (origin_bias * 0.30f);
+            float normalized = clampf_local(land, 0.0f, 1.0f);
+            int final_height = (int)(normalized * 255.0f);
 
             heights[z][x] = (uint8_t)final_height;
         }
@@ -87,32 +130,39 @@ static void generate_heightfield(int chunk_x, int chunk_z, uint8_t heights[TERRA
 static void generate_biomes(int chunk_x, int chunk_z, const uint8_t heights[TERRAIN_CHUNK_SIZE][TERRAIN_CHUNK_SIZE],
                              uint8_t biomes[TERRAIN_CHUNK_SIZE][TERRAIN_CHUNK_SIZE])
 {
-    uint32_t base_hash = chunk_hash(chunk_x, chunk_z);
+    const int chunk_world_x = chunk_x * TERRAIN_CHUNK_SIZE;
+    const int chunk_world_z = chunk_z * TERRAIN_CHUNK_SIZE;
 
     for (int z = 0; z < TERRAIN_CHUNK_SIZE; z++)
     {
         for (int x = 0; x < TERRAIN_CHUNK_SIZE; x++)
         {
+            int world_x = chunk_world_x + x;
+            int world_z = chunk_world_z + z;
             uint8_t height = heights[z][x];
+            float humidity = noise2_world(world_x, world_z, 36, 181U);
+            float roughness = noise2_world(world_x, world_z, 18, 227U);
+            float coast = noise2_world(world_x, world_z, 14, 269U);
 
-            /* Biome based on height and position hash */
-            uint32_t h = base_hash;
-            h ^= (uint32_t)(x + z * TERRAIN_CHUNK_SIZE) * 2654435769U;
-
-            if (height < 80)
+            if (height < 62)
             {
-                /* Low areas: plains or water */
-                biomes[z][x] = (h & 1) ? BIOME_PLAINS : BIOME_WATER;
+                biomes[z][x] = BIOME_WATER;
             }
-            else if (height < 150)
+            else if (height < 92)
             {
-                /* Mid areas: forest or plains */
-                biomes[z][x] = (h & 1) ? BIOME_FOREST : BIOME_PLAINS;
+                biomes[z][x] = (coast > 0.52f) ? BIOME_PLAINS : BIOME_WATER;
+            }
+            else if (height < 148)
+            {
+                biomes[z][x] = (humidity > 0.55f) ? BIOME_FOREST : BIOME_PLAINS;
+            }
+            else if (height < 200)
+            {
+                biomes[z][x] = (roughness > 0.60f) ? BIOME_RIDGE : BIOME_HILL;
             }
             else
             {
-                /* High areas: hills or ridges */
-                biomes[z][x] = (h & 1) ? BIOME_RIDGE : BIOME_HILL;
+                biomes[z][x] = BIOME_RIDGE;
             }
         }
     }

--- a/src/native/engine/runtime/tick_phases.c
+++ b/src/native/engine/runtime/tick_phases.c
@@ -20,11 +20,12 @@ void runtime_phase_viewport_resize(Window *window,
     }
 }
 
-int runtime_phase_terrain_budget(RuntimeTerrainRebuildFn rebuild_dirty_chunks,
+int runtime_phase_terrain_budget(void *context,
+                                 RuntimeTerrainRebuildFn rebuild_dirty_chunks,
                                  int max_chunks)
 {
     if (!rebuild_dirty_chunks)
         return -1;
 
-    return rebuild_dirty_chunks(max_chunks) ? 0 : -1;
+    return rebuild_dirty_chunks(context, max_chunks) ? 0 : -1;
 }

--- a/src/native/engine/runtime/tick_phases.h
+++ b/src/native/engine/runtime/tick_phases.h
@@ -9,14 +9,15 @@ extern "C"
 {
 #endif
 
-    typedef int (*RuntimeTerrainRebuildFn)(int max_chunks);
+    typedef int (*RuntimeTerrainRebuildFn)(void *context, int max_chunks);
 
     void runtime_phase_viewport_resize(Window *window,
                                        Renderer *renderer,
                                        int *viewport_width,
                                        int *viewport_height);
 
-    int runtime_phase_terrain_budget(RuntimeTerrainRebuildFn rebuild_dirty_chunks,
+    int runtime_phase_terrain_budget(void *context,
+                                     RuntimeTerrainRebuildFn rebuild_dirty_chunks,
                                      int max_chunks);
 
 #ifdef __cplusplus

--- a/src/native/engine/ui/ui.c
+++ b/src/native/engine/ui/ui.c
@@ -153,7 +153,8 @@ void ui_text(UIContext *ctx, float x, float y, const char *text) {
     elem->type = UI_ELEM_TEXT;
     elem->x = x;
     elem->y = y;
-    elem->data.text.text = text;
+    strncpy(elem->data.text.text, text, sizeof(elem->data.text.text) - 1);
+    elem->data.text.text[sizeof(elem->data.text.text) - 1] = '\0';
 }
 
 int ui_text_field(UIContext *ctx, float x, float y, float width, float height,

--- a/src/native/engine/ui/ui_internal.h
+++ b/src/native/engine/ui/ui_internal.h
@@ -34,7 +34,7 @@ typedef struct {
         } button;
 
         struct {
-            const char *text;
+            char text[256];
         } text;
 
         struct {

--- a/src/native/engine/win32_dx12_poc/main.c
+++ b/src/native/engine/win32_dx12_poc/main.c
@@ -1,6 +1,9 @@
 #if defined(_WIN32)
 
 #include "../engine.h"
+#include "scene_overlay.h"
+#include "scene_flow.h"
+#include "objective_policy.h"
 #include "../render/backend.h"
 #include "../render/backend_dx12.h"
 
@@ -11,20 +14,10 @@
 #include <windows.h>
 
 static const char *BANANA_DX12_WINDOW_CLASS = "BananaDx12RuntimeWindow";
-static const int BANANA_POC_WIDTH = 1280;
-static const int BANANA_POC_HEIGHT = 720;
 
 static unsigned char *s_ui_bgra_buffer = NULL;
 static size_t s_ui_bgra_capacity = 0;
-
-typedef enum BananaPocScene
-{
-    BANANA_POC_SCENE_MAIN_MENU = 0,
-    BANANA_POC_SCENE_CHARACTER_SELECT = 1,
-    BANANA_POC_SCENE_WORLD = 2,
-    BANANA_POC_SCENE_LEVEL_EDITOR = 3,
-    BANANA_POC_SCENE_OPTIONS = 4,
-} BananaPocScene;
+static char s_profile_path[MAX_PATH] = {0};
 
 static int consume_key_press(int vk, int *last_down)
 {
@@ -51,7 +44,7 @@ static float axis_value(int positive_key, int negative_key)
 static void update_keyboard_move_input(void)
 {
     float move_x = axis_value('D', 'A');
-    float move_z = axis_value('W', 'S');
+    float move_z = axis_value('S', 'W');
     float length = sqrtf((move_x * move_x) + (move_z * move_z));
 
     if (length > 1.0f)
@@ -61,6 +54,124 @@ static void update_keyboard_move_input(void)
     }
 
     engine_set_move_input(move_x, move_z);
+}
+
+static int point_in_rect(int x, int y, int left, int top, int right, int bottom)
+{
+    return (x >= left && x <= right && y >= top && y <= bottom) ? 1 : 0;
+}
+
+static void apply_menu_mouse_input(BananaPocScene scene,
+                                   int mouse_x,
+                                   int mouse_y,
+                                   int click_edge,
+                                   BananaPocSceneFlowState *state,
+                                   BananaPocSceneFlowInput *input)
+{
+    int i = 0;
+
+    if (!state || !input)
+        return;
+
+    if (scene == BANANA_POC_SCENE_MAIN_MENU)
+    {
+        for (i = 0; i <= 6; i++)
+        {
+            int item_y = 230 + (i * 36);
+            if (point_in_rect(mouse_x, mouse_y, 220, item_y - 8, 1040, item_y + 22))
+            {
+                state->menu_index = i;
+                if (click_edge)
+                    input->enter_pressed = 1;
+                break;
+            }
+        }
+        return;
+    }
+
+    if (scene == BANANA_POC_SCENE_CHARACTER_SELECT)
+    {
+        if (!click_edge)
+            return;
+
+        if (point_in_rect(mouse_x, mouse_y, 230, 238, 1040, 268))
+        {
+            if (mouse_x < 640)
+                input->left_pressed = 1;
+            else
+                input->right_pressed = 1;
+            return;
+        }
+
+        if (point_in_rect(mouse_x, mouse_y, 230, 278, 1040, 308))
+        {
+            if (mouse_x < 640)
+                input->up_pressed = 1;
+            else
+                input->down_pressed = 1;
+            return;
+        }
+
+        if (point_in_rect(mouse_x, mouse_y, 230, 318, 1040, 348))
+        {
+            input->tab_pressed = 1;
+            return;
+        }
+
+        if (point_in_rect(mouse_x, mouse_y, 230, 362, 1040, 392))
+        {
+            input->enter_pressed = 1;
+            return;
+        }
+        return;
+    }
+
+    if (scene == BANANA_POC_SCENE_OPTIONS)
+    {
+        for (i = 0; i <= 4; i++)
+        {
+            int item_y = 246 + (i * 40);
+            if (point_in_rect(mouse_x, mouse_y, 220, item_y - 10, 1060, item_y + 20))
+            {
+                state->options_index = i;
+                if (click_edge)
+                    input->enter_pressed = 1;
+                break;
+            }
+        }
+        return;
+    }
+
+    if (scene == BANANA_POC_SCENE_SCENE_BROWSER)
+    {
+        for (i = 0; i < 4; i++)
+        {
+            int item_y = 230 + (i * 40);
+            if (point_in_rect(mouse_x, mouse_y, 220, item_y - 10, 1060, item_y + 20))
+            {
+                state->proto_config.scene_browser_index = i;
+                if (click_edge)
+                    input->enter_pressed = 1;
+                break;
+            }
+        }
+        return;
+    }
+
+    if (scene == BANANA_POC_SCENE_CONFIG_LAB)
+    {
+        for (i = 0; i < 4; i++)
+        {
+            int item_y = 230 + (i * 40);
+            if (point_in_rect(mouse_x, mouse_y, 220, item_y - 10, 1060, item_y + 20))
+            {
+                state->proto_config.config_lab_index = i;
+                if (click_edge)
+                    input->enter_pressed = 1;
+                break;
+            }
+        }
+    }
 }
 
 static int parse_env_int(const char *name, int fallback, int min_value, int max_value)
@@ -106,6 +217,136 @@ static int parse_env_flag(const char *name)
     return 1;
 }
 
+static void init_profile_path(void)
+{
+    DWORD length = GetModuleFileNameA(NULL, s_profile_path, MAX_PATH);
+    char *last_slash = NULL;
+
+    if (length == 0 || length >= MAX_PATH)
+    {
+        strcpy(s_profile_path, "banana_dx12_poc_profile.cfg");
+        return;
+    }
+
+    last_slash = strrchr(s_profile_path, '\\');
+    if (last_slash)
+    {
+        last_slash[1] = '\0';
+        strncat(s_profile_path,
+                "banana_dx12_poc_profile.cfg",
+                MAX_PATH - strlen(s_profile_path) - 1);
+    }
+    else
+    {
+        strcpy(s_profile_path, "banana_dx12_poc_profile.cfg");
+    }
+}
+
+static int load_int_value(const char *line, const char *key, int fallback)
+{
+    size_t key_len = strlen(key);
+
+    if (strncmp(line, key, key_len) != 0 || line[key_len] != '=')
+        return fallback;
+
+    return atoi(line + key_len + 1);
+}
+
+static void load_profile(int *menu_index,
+                         int *character_index,
+                         int *class_index,
+                         int *options_index,
+                         int *auto_target_enabled,
+                         int *target_hotkey_enabled,
+                         int *telemetry_enabled,
+                         int *level_editor_height,
+                         BananaPocProtoConfig *proto)
+{
+    FILE *file = NULL;
+    char line[128];
+
+    if (!menu_index || !character_index || !class_index || !options_index ||
+        !auto_target_enabled || !target_hotkey_enabled || !telemetry_enabled ||
+        !level_editor_height || !proto || s_profile_path[0] == '\0')
+        return;
+
+    file = fopen(s_profile_path, "r");
+    if (!file)
+        return;
+
+    while (fgets(line, sizeof(line), file))
+    {
+        char *newline = strpbrk(line, "\r\n");
+        if (newline)
+            *newline = '\0';
+
+        *menu_index = load_int_value(line, "menu_index", *menu_index);
+        *character_index = load_int_value(line, "character_index", *character_index);
+        *class_index = load_int_value(line, "class_index", *class_index);
+        *options_index = load_int_value(line, "options_index", *options_index);
+        *auto_target_enabled = load_int_value(line, "auto_target_enabled", *auto_target_enabled);
+        *target_hotkey_enabled = load_int_value(line, "target_hotkey_enabled", *target_hotkey_enabled);
+        *telemetry_enabled = load_int_value(line, "telemetry_enabled", *telemetry_enabled);
+        *level_editor_height = load_int_value(line, "level_editor_height", *level_editor_height);
+        proto->scene_browser_index = load_int_value(line, "scene_browser_index", proto->scene_browser_index);
+        proto->config_lab_index = load_int_value(line, "config_lab_index", proto->config_lab_index);
+        proto->character_loadout_index = load_int_value(line, "character_loadout_index", proto->character_loadout_index);
+        proto->level_editor_brush_radius = load_int_value(line, "level_editor_brush_radius", proto->level_editor_brush_radius);
+        proto->level_editor_paint_mode = load_int_value(line, "level_editor_paint_mode", proto->level_editor_paint_mode);
+        proto->option_input_assist = load_int_value(line, "option_input_assist", proto->option_input_assist);
+        proto->option_compact_hud = load_int_value(line, "option_compact_hud", proto->option_compact_hud);
+        proto->active_world_variant = load_int_value(line, "active_world_variant", proto->active_world_variant);
+        proto->render_debug_overlay = load_int_value(line, "render_debug_overlay", proto->render_debug_overlay);
+        proto->physics_wireframe = load_int_value(line, "physics_wireframe", proto->physics_wireframe);
+        proto->world_seed_index = load_int_value(line, "world_seed_index", proto->world_seed_index);
+        proto->frame_cap_index = load_int_value(line, "frame_cap_index", proto->frame_cap_index);
+    }
+
+    fclose(file);
+}
+
+static void save_profile(int menu_index,
+                         int character_index,
+                         int class_index,
+                         int options_index,
+                         int auto_target_enabled,
+                         int target_hotkey_enabled,
+                         int telemetry_enabled,
+                         int level_editor_height,
+                         const BananaPocProtoConfig *proto)
+{
+    FILE *file = NULL;
+
+    if (s_profile_path[0] == '\0')
+        return;
+
+    file = fopen(s_profile_path, "w");
+    if (!file)
+        return;
+
+    fprintf(file, "menu_index=%d\n", menu_index);
+    fprintf(file, "character_index=%d\n", character_index);
+    fprintf(file, "class_index=%d\n", class_index);
+    fprintf(file, "options_index=%d\n", options_index);
+    fprintf(file, "auto_target_enabled=%d\n", auto_target_enabled);
+    fprintf(file, "target_hotkey_enabled=%d\n", target_hotkey_enabled);
+    fprintf(file, "telemetry_enabled=%d\n", telemetry_enabled);
+    fprintf(file, "level_editor_height=%d\n", level_editor_height);
+    fprintf(file, "scene_browser_index=%d\n", proto ? proto->scene_browser_index : 0);
+    fprintf(file, "config_lab_index=%d\n", proto ? proto->config_lab_index : 0);
+    fprintf(file, "character_loadout_index=%d\n", proto ? proto->character_loadout_index : 0);
+    fprintf(file, "level_editor_brush_radius=%d\n", proto ? proto->level_editor_brush_radius : 1);
+    fprintf(file, "level_editor_paint_mode=%d\n", proto ? proto->level_editor_paint_mode : 0);
+    fprintf(file, "option_input_assist=%d\n", proto ? proto->option_input_assist : 0);
+    fprintf(file, "option_compact_hud=%d\n", proto ? proto->option_compact_hud : 0);
+    fprintf(file, "active_world_variant=%d\n", proto ? proto->active_world_variant : 0);
+    fprintf(file, "render_debug_overlay=%d\n", proto ? proto->render_debug_overlay : 0);
+    fprintf(file, "physics_wireframe=%d\n", proto ? proto->physics_wireframe : 0);
+    fprintf(file, "world_seed_index=%d\n", proto ? proto->world_seed_index : 0);
+    fprintf(file, "frame_cap_index=%d\n", proto ? proto->frame_cap_index : 0);
+    fclose(file);
+}
+
 static HWND find_game_window(void)
 {
     return FindWindowA(BANANA_DX12_WINDOW_CLASS, NULL);
@@ -147,6 +388,18 @@ static void update_game_hud_title(HWND game_window,
         snprintf(title,
                  sizeof(title),
                  "Banana DX12 POC | Level Editor | E Apply Height");
+    }
+    else if (scene == BANANA_POC_SCENE_SCENE_BROWSER)
+    {
+        snprintf(title,
+                 sizeof(title),
+                 "Banana DX12 POC | Scene Browser | Up/Down select, Enter launch");
+    }
+    else if (scene == BANANA_POC_SCENE_CONFIG_LAB)
+    {
+        snprintf(title,
+                 sizeof(title),
+                 "Banana DX12 POC | Config Lab | Up/Down select, Left/Right toggle");
     }
     else if (objective_collected)
     {
@@ -310,316 +563,40 @@ static void render_ui_overlay(HWND game_window,
                               int elapsed_seconds,
                               int objective_timeout_seconds,
                               int objective_collected,
-                              int startup_smoke_mode)
+                              int startup_smoke_mode,
+                              const BananaPocProtoConfig *proto)
 {
-    char line_one[160];
-    char line_two[160];
-    char line_three[160];
-    char line_four[160];
-    char line_five[160];
-    int remaining_seconds = objective_timeout_seconds - elapsed_seconds;
-    float player_x = 0.0f;
-    float player_z = 0.0f;
-    float target_x = 0.0f;
-    float target_z = 0.0f;
-    float world_half_span = engine_get_terrain_half_span();
-    float minimap_x = 988.0f;
-    float minimap_y = 520.0f;
-    float minimap_w = 280.0f;
-    float minimap_h = 184.0f;
-    float marker_size = 5.0f;
-    int has_player = 0;
-    int has_target = 0;
-    float nav_dx = 0.0f;
-    float nav_dz = 0.0f;
-    const char *hint_x = "HOLD";
-    const char *hint_z = "HOLD";
-    const unsigned char *ui_framebuffer = NULL;
-    static const char *k_main_menu_items[] = {
-        "Enter World",
-        "Character Select",
-        "Level Editor",
-        "Options",
-        "Quit",
-    };
-    static const char *k_character_names[] = {
-        "DX12 Pilot",
-        "Vanguard One",
-        "Arcanist Flux",
-        "Ranger Echo",
-    };
-    static const char *k_class_names[] = {
-        "Vanguard",
-        "Arcanist",
-        "Ranger",
-    };
+    int using_dx12_runtime = (banana_render_backend_active() == BANANA_RENDER_BACKEND_DX12) ? 1 : 0;
 
-    if (!game_window)
+    if (!game_window && !using_dx12_runtime)
     {
         return;
     }
 
-    if (remaining_seconds < 0)
+    banana_poc_render_scene_overlay(scene,
+                                    main_menu_index,
+                                    character_index,
+                                    class_index,
+                                    option_index,
+                                    auto_target_enabled,
+                                    target_hotkey_enabled,
+                                    telemetry_enabled,
+                                    editor_height,
+                                    elapsed_seconds,
+                                    objective_timeout_seconds,
+                                    objective_collected,
+                                    startup_smoke_mode,
+                                    proto);
+
+    if (using_dx12_runtime)
     {
-        remaining_seconds = 0;
-    }
-
-    if (world_half_span < 1.0f)
-    {
-        world_half_span = 1.0f;
-    }
-
-    engine_ui_begin_frame();
-
-    if (scene == BANANA_POC_SCENE_MAIN_MENU ||
-        scene == BANANA_POC_SCENE_CHARACTER_SELECT ||
-        scene == BANANA_POC_SCENE_OPTIONS)
-    {
-        engine_ui_panel(170.0f, 90.0f, 940.0f, 530.0f, 0x101822E8u, 2.0f);
-
-        if (scene == BANANA_POC_SCENE_MAIN_MENU)
-        {
-            int i = 0;
-            engine_ui_text(220.0f, 140.0f, "BANANA DX12 POC");
-            engine_ui_text(220.0f, 172.0f, "Main Menu - Use Up/Down, Enter Select");
-            for (i = 0; i < (int)(sizeof(k_main_menu_items) / sizeof(k_main_menu_items[0])); i++)
-            {
-                char item_line[128];
-                snprintf(item_line,
-                         sizeof(item_line),
-                         "%s %s",
-                         (i == main_menu_index) ? ">" : " ",
-                         k_main_menu_items[i]);
-                engine_ui_text(240.0f, 230.0f + ((float)i * 36.0f), item_line);
-            }
-        }
-        else if (scene == BANANA_POC_SCENE_CHARACTER_SELECT)
-        {
-            char character_line[160];
-            char class_line[160];
-            engine_ui_text(220.0f, 140.0f, "Character Select");
-            engine_ui_text(220.0f, 172.0f, "Left/Right change values, Enter to start, Esc to menu");
-
-            snprintf(character_line,
-                     sizeof(character_line),
-                     "Character: %s",
-                     k_character_names[character_index]);
-            snprintf(class_line,
-                     sizeof(class_line),
-                     "Class: %s",
-                     k_class_names[class_index]);
-
-            engine_ui_text(240.0f, 246.0f, character_line);
-            engine_ui_text(240.0f, 286.0f, class_line);
-            engine_ui_text(240.0f, 340.0f, "Press Enter to Enter World");
-        }
-        else if (scene == BANANA_POC_SCENE_OPTIONS)
-        {
-            char option_line_a[160];
-            char option_line_b[160];
-            char option_line_c[160];
-            engine_ui_text(220.0f, 140.0f, "Options");
-            engine_ui_text(220.0f, 172.0f, "Up/Down select option, Left/Right toggle, Esc to menu");
-
-            snprintf(option_line_a,
-                     sizeof(option_line_a),
-                     "%s Auto Startup Target: %s",
-                     option_index == 0 ? ">" : " ",
-                     auto_target_enabled ? "On" : "Off");
-            snprintf(option_line_b,
-                     sizeof(option_line_b),
-                     "%s Target Hotkey (T): %s",
-                     option_index == 1 ? ">" : " ",
-                     target_hotkey_enabled ? "On" : "Off");
-            snprintf(option_line_c,
-                     sizeof(option_line_c),
-                     "%s Telemetry Prints: %s",
-                     option_index == 2 ? ">" : " ",
-                     telemetry_enabled ? "On" : "Off");
-
-            engine_ui_text(240.0f, 246.0f, option_line_a);
-            engine_ui_text(240.0f, 286.0f, option_line_b);
-            engine_ui_text(240.0f, 326.0f, option_line_c);
-        }
-
-        engine_ui_end_frame();
-        ui_framebuffer = engine_ui_get_framebuffer();
-        blit_ui_overlay(game_window, ui_framebuffer, BANANA_POC_WIDTH, BANANA_POC_HEIGHT);
+        banana_dx12_runtime_set_ui_overlay(engine_ui_get_framebuffer(),
+                                           BANANA_POC_WIDTH,
+                                           BANANA_POC_HEIGHT);
         return;
     }
 
-    has_player = engine_get_player_position(&player_x, &player_z);
-    has_target = engine_get_pbj_pickup_position(&target_x, &target_z);
-    if (has_player && has_target)
-    {
-        nav_dx = target_x - player_x;
-        nav_dz = target_z - player_z;
-        if (nav_dx > 0.20f)
-            hint_x = "D";
-        else if (nav_dx < -0.20f)
-            hint_x = "A";
-
-        if (nav_dz > 0.20f)
-            hint_z = "S";
-        else if (nav_dz < -0.20f)
-            hint_z = "W";
-    }
-
-    engine_ui_panel(12.0f, 12.0f, 760.0f, 94.0f, 0x0A1118C0u, 1.0f);
-    engine_ui_panel(12.0f, 112.0f, 420.0f, 92.0f, 0x121E28C0u, 1.0f);
-    engine_ui_panel(minimap_x, minimap_y, minimap_w, minimap_h, 0x1A2A22D0u, 1.0f);
-
-    snprintf(line_one,
-             sizeof(line_one),
-             scene == BANANA_POC_SCENE_LEVEL_EDITOR
-                 ? "BANANA DX12 POC  |  LEVEL EDITOR  |  WASD MOVE  |  E APPLY HEIGHT"
-                 : "BANANA DX12 POC  |  WASD MOVE  |  RIGHT-CLICK MOVE TARGET  |  ESC QUIT");
-
-    if (startup_smoke_mode)
-    {
-        snprintf(line_two,
-                 sizeof(line_two),
-                 "MODE: STARTUP SMOKE (CI)  |  ELAPSED: %ds",
-                 elapsed_seconds);
-    }
-    else if (objective_collected)
-    {
-        snprintf(line_two,
-                 sizeof(line_two),
-                 "OBJECTIVE COMPLETE: PBJ PICKUP COLLECTED");
-    }
-    else if (objective_timeout_seconds <= 0)
-    {
-        snprintf(line_two,
-                 sizeof(line_two),
-                 "OBJECTIVE: COLLECT PBJ PICKUP  |  TIME LEFT: UNLIMITED");
-    }
-    else
-    {
-        snprintf(line_two,
-                 sizeof(line_two),
-                 "OBJECTIVE: COLLECT PBJ PICKUP  |  TIME LEFT: %ds",
-                 remaining_seconds);
-    }
-
-    snprintf(line_three,
-             sizeof(line_three),
-             "ENTITIES: %d  |  CLICKS: %d  |  TARGETS REACHED: %d",
-             engine_get_entity_count(),
-             engine_get_click_count(),
-             engine_get_target_reached_count());
-
-    if (has_player && has_target)
-    {
-        snprintf(line_four,
-                 sizeof(line_four),
-                 "PLAYER XZ: (%.2f, %.2f)  TARGET XZ: (%.2f, %.2f)",
-                 player_x,
-                 player_z,
-                 target_x,
-                 target_z);
-
-        snprintf(line_five,
-                 sizeof(line_five),
-                 "NAV HINT: X -> %s  Z -> %s  DELTA=(%.2f, %.2f)",
-                 hint_x,
-                 hint_z,
-                 nav_dx,
-                 nav_dz);
-    }
-    else
-    {
-        snprintf(line_four,
-                 sizeof(line_four),
-                 "PLAYER/TARGET POSITION UNAVAILABLE");
-        snprintf(line_five,
-                 sizeof(line_five),
-                 "OBJECTIVE MAY ALREADY BE COLLECTED");
-    }
-
-    engine_ui_text(22.0f, 24.0f, line_one);
-    engine_ui_text(22.0f, 48.0f, line_two);
-    engine_ui_text(22.0f, 72.0f, line_three);
-    engine_ui_text(22.0f, 124.0f, line_four);
-    if (scene == BANANA_POC_SCENE_LEVEL_EDITOR)
-    {
-        char editor_line[160];
-        snprintf(editor_line,
-                 sizeof(editor_line),
-                 "EDITOR HEIGHT=%d  |  [ and ] adjust  |  E apply at player  |  M menu",
-                 editor_height);
-        engine_ui_text(22.0f, 148.0f, editor_line);
-    }
-    else
-    {
-        engine_ui_text(22.0f, 148.0f, line_five);
-    }
-    engine_ui_text(minimap_x + 10.0f, minimap_y + 10.0f, "MINIMAP (TERRAIN + ACTORS)");
-
-    engine_ui_panel(minimap_x + 10.0f,
-                    minimap_y + 34.0f,
-                    minimap_w - 20.0f,
-                    minimap_h - 44.0f,
-                    0x1E5A2FD8u,
-                    1.0f);
-
-    if (has_player)
-    {
-        float px = (player_x / world_half_span);
-        float pz = (player_z / world_half_span);
-        float panel_w = minimap_w - 20.0f;
-        float panel_h = minimap_h - 44.0f;
-        float screen_x = (minimap_x + 10.0f) + ((px + 1.0f) * 0.5f) * panel_w;
-        float screen_y = (minimap_y + 34.0f) + ((pz + 1.0f) * 0.5f) * panel_h;
-
-        if (screen_x < (minimap_x + 10.0f))
-            screen_x = minimap_x + 10.0f;
-        if (screen_x > (minimap_x + minimap_w - 10.0f - marker_size * 2.0f))
-            screen_x = minimap_x + minimap_w - 10.0f - marker_size * 2.0f;
-        if (screen_y < (minimap_y + 34.0f))
-            screen_y = minimap_y + 34.0f;
-        if (screen_y > (minimap_y + minimap_h - 10.0f - marker_size * 2.0f))
-            screen_y = minimap_y + minimap_h - 10.0f - marker_size * 2.0f;
-
-        engine_ui_panel(screen_x,
-                        screen_y,
-                        marker_size * 2.0f,
-                        marker_size * 2.0f,
-                        0x44D46CFFu,
-                        1.0f);
-    }
-
-    if (has_target)
-    {
-        float tx = (target_x / world_half_span);
-        float tz = (target_z / world_half_span);
-        float panel_w = minimap_w - 20.0f;
-        float panel_h = minimap_h - 44.0f;
-        float screen_x = (minimap_x + 10.0f) + ((tx + 1.0f) * 0.5f) * panel_w;
-        float screen_y = (minimap_y + 34.0f) + ((tz + 1.0f) * 0.5f) * panel_h;
-
-        if (screen_x < (minimap_x + 10.0f))
-            screen_x = minimap_x + 10.0f;
-        if (screen_x > (minimap_x + minimap_w - 10.0f - marker_size * 2.0f))
-            screen_x = minimap_x + minimap_w - 10.0f - marker_size * 2.0f;
-        if (screen_y < (minimap_y + 34.0f))
-            screen_y = minimap_y + 34.0f;
-        if (screen_y > (minimap_y + minimap_h - 10.0f - marker_size * 2.0f))
-            screen_y = minimap_y + minimap_h - 10.0f - marker_size * 2.0f;
-
-        engine_ui_panel(screen_x,
-                        screen_y,
-                        marker_size * 2.0f,
-                        marker_size * 2.0f,
-                        0x4A8CFAFFu,
-                        1.0f);
-    }
-
-    engine_ui_inventory_panel((float)BANANA_POC_WIDTH - 16.0f, 12.0f);
-
-    engine_ui_end_frame();
-    ui_framebuffer = engine_ui_get_framebuffer();
-    blit_ui_overlay(game_window, ui_framebuffer, BANANA_POC_WIDTH, BANANA_POC_HEIGHT);
+    blit_ui_overlay(game_window, engine_ui_get_framebuffer(), BANANA_POC_WIDTH, BANANA_POC_HEIGHT);
 }
 
 int main(void)
@@ -630,20 +607,24 @@ int main(void)
     ULONGLONG hud_updated_ms = 0;
     ULONGLONG session_started_ms = 0;
     HWND game_window = NULL;
-    int objective_timeout_seconds = 0;
+    BananaPocObjectivePolicy objective_policy;
     int startup_smoke_mode = 0;
     int startup_smoke_seconds = 0;
+    int telemetry_interval_ms = 1000;
     int auto_target_enabled = 1;
     int target_hotkey_enabled = 0;
-    int telemetry_enabled = 1;
+    int telemetry_enabled = 0;
     BananaPocScene scene = BANANA_POC_SCENE_MAIN_MENU;
     int menu_index = 0;
     int character_index = 0;
     int class_index = 0;
     int options_index = 0;
     int level_editor_height = 2;
+    BananaPocProtoConfig proto_config;
+    int world_variant = 0;
     int exit_code = 0;
     int last_rbutton_down = 0;
+    int last_lbutton_down = 0;
     int last_target_hotkey_down = 0;
     int last_up_down = 0;
     int last_down_down = 0;
@@ -651,11 +632,14 @@ int main(void)
     int last_right_down = 0;
     int last_enter_down = 0;
     int last_menu_hotkey_down = 0;
+    int last_menu_lbutton_down = 0;
+    int last_tab_down = 0;
     int last_apply_edit_down = 0;
     int last_raise_edit_down = 0;
     int last_lower_edit_down = 0;
     int last_escape_down = 0;
     int auto_target_injected = 0;
+    ULONGLONG frame_throttle_prev_ms = 0;
 
     if (!QueryPerformanceFrequency(&frequency) || !QueryPerformanceCounter(&previous_counter))
     {
@@ -665,6 +649,8 @@ int main(void)
 
     printf("[dx12-poc] launching Banana playable prototype\n");
     printf("[dx12-poc] controls: arrows navigate menus, Enter select, WASD in world, ESC back/quit\n");
+    memset(&proto_config, 0, sizeof(proto_config));
+    proto_config.level_editor_brush_radius = 1;
     printf("[dx12-poc] backend requested=%s active=%s status=%s\n",
            banana_render_backend_name(banana_render_backend_requested()),
            banana_render_backend_name(banana_render_backend_active()),
@@ -692,9 +678,75 @@ int main(void)
 
     startup_smoke_mode = parse_env_flag("BANANA_DX12_POC_AUTOTEST");
     startup_smoke_seconds = parse_env_int("BANANA_DX12_POC_AUTOTEST_SECONDS", 2, 1, 30);
-    objective_timeout_seconds = parse_env_int("BANANA_DX12_POC_OBJECTIVE_TIMEOUT_SECONDS", 0, 0, 3600);
+    banana_poc_objective_policy_init(&objective_policy,
+                                     parse_env_int("BANANA_DX12_POC_OBJECTIVE_TIMEOUT_SECONDS", 0, 0, 3600));
+    telemetry_interval_ms = parse_env_int("BANANA_DX12_POC_TELEMETRY_INTERVAL_MS", 5000, 250, 60000);
     auto_target_enabled = parse_env_int("BANANA_DX12_POC_AUTO_TARGET", 0, 0, 1);
     target_hotkey_enabled = parse_env_int("BANANA_DX12_POC_ENABLE_TARGET_HOTKEY", 0, 0, 1);
+    telemetry_enabled = parse_env_int("BANANA_DX12_POC_TELEMETRY", 0, 0, 1);
+    init_profile_path();
+    load_profile(&menu_index,
+                 &character_index,
+                 &class_index,
+                 &options_index,
+                 &auto_target_enabled,
+                 &target_hotkey_enabled,
+                 &telemetry_enabled,
+                 &level_editor_height,
+                 &proto_config);
+    if (menu_index < 0 || menu_index > 6)
+        menu_index = 0;
+    if (character_index < 0)
+        character_index = 0;
+    if (character_index > 3)
+        character_index = 3;
+    if (class_index < 0)
+        class_index = 0;
+    if (class_index > 2)
+        class_index = 2;
+    if (options_index < 0)
+        options_index = 0;
+    if (options_index > 4)
+        options_index = 4;
+    if (level_editor_height < 0)
+        level_editor_height = 0;
+    if (level_editor_height > 3)
+        level_editor_height = 3;
+    if (proto_config.scene_browser_index < 0)
+        proto_config.scene_browser_index = 0;
+    if (proto_config.scene_browser_index > 3)
+        proto_config.scene_browser_index = 3;
+    if (proto_config.config_lab_index < 0)
+        proto_config.config_lab_index = 0;
+    if (proto_config.config_lab_index > 3)
+        proto_config.config_lab_index = 3;
+    if (proto_config.character_loadout_index < 0)
+        proto_config.character_loadout_index = 0;
+    if (proto_config.character_loadout_index > 3)
+        proto_config.character_loadout_index = 3;
+    if (proto_config.level_editor_brush_radius < 1)
+        proto_config.level_editor_brush_radius = 1;
+    if (proto_config.level_editor_brush_radius > 4)
+        proto_config.level_editor_brush_radius = 4;
+    if (proto_config.level_editor_paint_mode < 0)
+        proto_config.level_editor_paint_mode = 0;
+    if (proto_config.level_editor_paint_mode > 2)
+        proto_config.level_editor_paint_mode = 2;
+    if (proto_config.world_seed_index < 0)
+        proto_config.world_seed_index = 0;
+    if (proto_config.world_seed_index > 3)
+        proto_config.world_seed_index = 3;
+    if (proto_config.frame_cap_index < 0)
+        proto_config.frame_cap_index = 0;
+    if (proto_config.frame_cap_index > 3)
+        proto_config.frame_cap_index = 3;
+    if (proto_config.active_world_variant < 0)
+        proto_config.active_world_variant = 0;
+    if (proto_config.active_world_variant > 3)
+        proto_config.active_world_variant = 3;
+
+    if (IsDebuggerPresent() && !parse_env_flag("BANANA_DX12_POC_ALLOW_DEBUG_TELEMETRY"))
+        telemetry_enabled = 0;
 
     telemetry_started_ms = GetTickCount64();
     hud_updated_ms = telemetry_started_ms;
@@ -704,170 +756,245 @@ int main(void)
         LARGE_INTEGER now_counter;
         float dt = 0.0f;
         ULONGLONG now_ms = GetTickCount64();
+        int frame_budget_ms = 0;
+        if (proto_config.frame_cap_index == 0)
+            frame_budget_ms = 33;
+        else if (proto_config.frame_cap_index == 1)
+            frame_budget_ms = 16;
+        else if (proto_config.frame_cap_index == 2)
+            frame_budget_ms = 8;
+        if (frame_budget_ms > 0 && frame_throttle_prev_ms != 0)
+        {
+            ULONGLONG frame_delta = now_ms - frame_throttle_prev_ms;
+            if (frame_delta < (ULONGLONG)frame_budget_ms)
+            {
+                Sleep((DWORD)((ULONGLONG)frame_budget_ms - frame_delta));
+                now_ms = GetTickCount64();
+            }
+        }
+        frame_throttle_prev_ms = now_ms;
         int elapsed_seconds = (int)((now_ms - session_started_ms) / 1000ULL);
         int objective_collected = 0;
         int tick_result = 0;
+        BananaPocScene previous_scene = scene;
+        BananaPocSceneFlowState flow_state;
+        BananaPocSceneFlowInput flow_input;
+        BananaPocSceneFlowResult flow_result;
+        static const char *k_character_names[] = {
+            "DX12 Pilot",
+            "Vanguard One",
+            "Arcanist Flux",
+            "Ranger Echo",
+        };
 
-        if (consume_key_press(VK_ESCAPE, &last_escape_down))
+        flow_state.scene = scene;
+        flow_state.menu_index = menu_index;
+        flow_state.character_index = character_index;
+        flow_state.class_index = class_index;
+        flow_state.options_index = options_index;
+        flow_state.level_editor_height = level_editor_height;
+        flow_state.proto_config = proto_config;
+
+        flow_input.escape_pressed = consume_key_press(VK_ESCAPE, &last_escape_down);
+        flow_input.menu_hotkey_pressed = consume_key_press('M', &last_menu_hotkey_down);
+        flow_input.tab_pressed = consume_key_press(VK_TAB, &last_tab_down);
+        flow_input.up_pressed = consume_key_press(VK_UP, &last_up_down);
+        flow_input.down_pressed = consume_key_press(VK_DOWN, &last_down_down);
+        flow_input.left_pressed = consume_key_press(VK_LEFT, &last_left_down);
+        flow_input.right_pressed = consume_key_press(VK_RIGHT, &last_right_down);
+        flow_input.enter_pressed = consume_key_press(VK_RETURN, &last_enter_down);
+        flow_input.lower_edit_pressed = consume_key_press(VK_OEM_4, &last_lower_edit_down);
+        flow_input.raise_edit_pressed = consume_key_press(VK_OEM_6, &last_raise_edit_down);
+        flow_input.apply_edit_pressed = consume_key_press('E', &last_apply_edit_down);
+
+        if (game_window)
         {
-            if (scene == BANANA_POC_SCENE_MAIN_MENU)
+            HCURSOR arrow = LoadCursor(NULL, IDC_ARROW);
+            if (arrow)
+                SetCursor(arrow);
+        }
+
+        if (game_window &&
+            (scene == BANANA_POC_SCENE_MAIN_MENU ||
+             scene == BANANA_POC_SCENE_CHARACTER_SELECT ||
+             scene == BANANA_POC_SCENE_OPTIONS ||
+             scene == BANANA_POC_SCENE_SCENE_BROWSER ||
+             scene == BANANA_POC_SCENE_CONFIG_LAB))
+        {
+            int menu_lbutton_down = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) ? 1 : 0;
+            int menu_click_edge = (menu_lbutton_down && !last_menu_lbutton_down) ? 1 : 0;
+            POINT cursor_screen;
+            POINT cursor_client;
+            if (GetCursorPos(&cursor_screen))
             {
-                break;
+                cursor_client = cursor_screen;
+                if (ScreenToClient(game_window, &cursor_client))
+                {
+                    apply_menu_mouse_input(scene,
+                                           cursor_client.x,
+                                           cursor_client.y,
+                                           menu_click_edge,
+                                           &flow_state,
+                                           &flow_input);
+                }
             }
-            scene = BANANA_POC_SCENE_MAIN_MENU;
-            engine_set_move_input(0.0f, 0.0f);
+            last_menu_lbutton_down = menu_lbutton_down;
+        }
+        else
+        {
+            last_menu_lbutton_down = 0;
         }
 
-        if (consume_key_press('M', &last_menu_hotkey_down) &&
-            (scene == BANANA_POC_SCENE_WORLD || scene == BANANA_POC_SCENE_LEVEL_EDITOR))
-        {
-            scene = BANANA_POC_SCENE_MAIN_MENU;
-            engine_set_move_input(0.0f, 0.0f);
-        }
+        banana_poc_scene_flow_step(&flow_state, &flow_input, &flow_result);
 
-        if (scene == BANANA_POC_SCENE_MAIN_MENU)
+        scene = flow_state.scene;
+        menu_index = flow_state.menu_index;
+        character_index = flow_state.character_index;
+        class_index = flow_state.class_index;
+        options_index = flow_state.options_index;
+        level_editor_height = flow_state.level_editor_height;
+        proto_config = flow_state.proto_config;
+
+        if (flow_result.entered_world)
         {
-            if (consume_key_press(VK_UP, &last_up_down) && menu_index > 0)
-                menu_index--;
-            if (consume_key_press(VK_DOWN, &last_down_down) && menu_index < 4)
-                menu_index++;
-            if (consume_key_press(VK_RETURN, &last_enter_down))
+            banana_poc_objective_policy_on_entered_world(&objective_policy,
+                                                         flow_result.entered_scene_browser_scene);
+            if (!flow_result.entered_scene_browser_scene)
             {
-                if (menu_index == 0)
-                {
-                    static const char *k_character_names[] = {
-                        "DX12 Pilot",
-                        "Vanguard One",
-                        "Arcanist Flux",
-                        "Ranger Echo",
-                    };
-                    if (engine_player_upsert("native-default-player",
-                                             k_character_names[character_index],
-                                             "human",
-                                             1) != 0)
-                    {
-                        (void)engine_player_build_set_class("native-default-player", class_index);
-                    }
-                    scene = BANANA_POC_SCENE_WORLD;
-                }
-                else if (menu_index == 1)
-                {
-                    scene = BANANA_POC_SCENE_CHARACTER_SELECT;
-                }
-                else if (menu_index == 2)
-                {
-                    scene = BANANA_POC_SCENE_LEVEL_EDITOR;
-                }
-                else if (menu_index == 3)
-                {
-                    scene = BANANA_POC_SCENE_OPTIONS;
-                }
-                else
-                {
-                    break;
-                }
+                world_variant = 0;
+                proto_config.active_world_variant = 0;
             }
-        }
-        else if (scene == BANANA_POC_SCENE_CHARACTER_SELECT)
-        {
-            if (consume_key_press(VK_LEFT, &last_left_down) && character_index > 0)
-                character_index--;
-            if (consume_key_press(VK_RIGHT, &last_right_down) && character_index < 3)
-                character_index++;
-            if (consume_key_press(VK_UP, &last_up_down) && class_index > 0)
-                class_index--;
-            if (consume_key_press(VK_DOWN, &last_down_down) && class_index < 2)
-                class_index++;
 
-            if (consume_key_press(VK_RETURN, &last_enter_down))
+            if (previous_scene == BANANA_POC_SCENE_CHARACTER_SELECT)
             {
-                static const char *k_character_names[] = {
-                    "DX12 Pilot",
-                    "Vanguard One",
-                    "Arcanist Flux",
-                    "Ranger Echo",
-                };
                 if (engine_player_upsert("native-default-player",
                                          k_character_names[character_index],
                                          "human",
                                          1) == 0)
                 {
                     fprintf(stderr, "[dx12-poc] character apply failed\n");
+                    scene = BANANA_POC_SCENE_CHARACTER_SELECT;
                 }
                 else
                 {
                     (void)engine_player_build_set_class("native-default-player", class_index);
-                    scene = BANANA_POC_SCENE_WORLD;
                 }
             }
-        }
-        else if (scene == BANANA_POC_SCENE_OPTIONS)
-        {
-            if (consume_key_press(VK_UP, &last_up_down) && options_index > 0)
-                options_index--;
-            if (consume_key_press(VK_DOWN, &last_down_down) && options_index < 2)
-                options_index++;
-
-            if (consume_key_press(VK_LEFT, &last_left_down) ||
-                consume_key_press(VK_RIGHT, &last_right_down) ||
-                consume_key_press(VK_RETURN, &last_enter_down))
+            else
             {
-                if (options_index == 0)
-                    auto_target_enabled = auto_target_enabled ? 0 : 1;
-                else if (options_index == 1)
-                    target_hotkey_enabled = target_hotkey_enabled ? 0 : 1;
-                else
-                    telemetry_enabled = telemetry_enabled ? 0 : 1;
-            }
-        }
-        else if (scene == BANANA_POC_SCENE_LEVEL_EDITOR)
-        {
-            if (consume_key_press(VK_OEM_4, &last_lower_edit_down) && level_editor_height > 0)
-                level_editor_height--;
-            if (consume_key_press(VK_OEM_6, &last_raise_edit_down) && level_editor_height < 3)
-                level_editor_height++;
-            if (consume_key_press('E', &last_apply_edit_down))
-            {
-                float px = 0.0f;
-                float pz = 0.0f;
-                if (engine_get_player_position(&px, &pz))
+                if (engine_player_upsert("native-default-player",
+                                         k_character_names[character_index],
+                                         "human",
+                                         1) != 0)
                 {
-                    float half_span = engine_get_terrain_half_span();
-                    int terrain_size = (int)(half_span * 2.0f + 1.0f);
-                    int ix = (int)roundf(px + half_span);
-                    int iz = (int)roundf(pz + half_span);
-
-                    if (ix < 0)
-                        ix = 0;
-                    if (iz < 0)
-                        iz = 0;
-                    if (ix >= terrain_size)
-                        ix = terrain_size - 1;
-                    if (iz >= terrain_size)
-                        iz = terrain_size - 1;
-
-                    if (engine_terrain_set_height(ix, iz, level_editor_height) != 0)
-                    {
-                        fprintf(stderr,
-                                "[dx12-poc] level-editor apply failed grid=(%d,%d) height=%d\n",
-                                ix,
-                                iz,
-                                level_editor_height);
-                    }
-                    else
-                    {
-                        printf("[dx12-poc] level-editor set grid=(%d,%d) height=%d\n",
-                               ix,
-                               iz,
-                               level_editor_height);
-                    }
+                    (void)engine_player_build_set_class("native-default-player", class_index);
                 }
             }
         }
+
+        if (flow_result.options_toggled)
+        {
+            if (options_index == 0)
+                auto_target_enabled = auto_target_enabled ? 0 : 1;
+            else if (options_index == 1)
+                target_hotkey_enabled = target_hotkey_enabled ? 0 : 1;
+            else
+                telemetry_enabled = telemetry_enabled ? 0 : 1;
+            if (options_index == 3)
+                proto_config.option_input_assist ^= 1;
+            else if (options_index == 4)
+                proto_config.option_compact_hud ^= 1;
+        }
+
+        if (flow_result.entered_scene_browser_scene)
+        {
+            world_variant = flow_result.scene_browser_variant;
+            proto_config.active_world_variant = world_variant;
+            auto_target_injected = 0;
+            banana_poc_objective_policy_apply_world_variant(&objective_policy, world_variant);
+            if (world_variant == 2 || world_variant == 3)
+                telemetry_enabled = 1;
+            printf("[dx12-poc] launching proto scene variant=%d\n", world_variant);
+        }
+
+        if (flow_result.config_lab_toggled)
+        {
+            printf("[dx12-poc] config-lab: dbg=%d phys-wire=%d seed=%d fcap=%d\n",
+                   proto_config.render_debug_overlay,
+                   proto_config.physics_wireframe,
+                   proto_config.world_seed_index,
+                   proto_config.frame_cap_index);
+        }
+
+        if (flow_result.editor_apply_requested)
+        {
+            float px = 0.0f;
+            float pz = 0.0f;
+            static const char *k_paint_mode_labels[] = { "Sculpt", "Flatten", "Smooth" };
+            if (engine_get_player_position(&px, &pz))
+            {
+                float half_span = engine_get_terrain_half_span();
+                int terrain_size = (int)(half_span * 2.0f + 1.0f);
+                int ix = (int)roundf(px + half_span);
+                int iz = (int)roundf(pz + half_span);
+
+                if (ix < 0)
+                    ix = 0;
+                if (iz < 0)
+                    iz = 0;
+                if (ix >= terrain_size)
+                    ix = terrain_size - 1;
+                if (iz >= terrain_size)
+                    iz = terrain_size - 1;
+
+                if (engine_terrain_set_height(ix, iz, level_editor_height) != 0)
+                {
+                    fprintf(stderr,
+                            "[dx12-poc] level-editor apply failed grid=(%d,%d) height=%d\n",
+                            ix,
+                            iz,
+                            level_editor_height);
+                }
+                else
+                {
+                    printf("[dx12-poc] level-editor set grid=(%d,%d) height=%d brush=%d mode=%s\n",
+                           ix,
+                           iz,
+                           level_editor_height,
+                           proto_config.level_editor_brush_radius,
+                           k_paint_mode_labels[proto_config.level_editor_paint_mode]);
+                    flow_result.profile_dirty = 1;
+                }
+            }
+        }
+
+        if (flow_result.profile_dirty)
+        {
+            save_profile(menu_index,
+                         character_index,
+                         class_index,
+                         options_index,
+                         auto_target_enabled,
+                         target_hotkey_enabled,
+                         telemetry_enabled,
+                         level_editor_height,
+                         &proto_config);
+        }
+
+        if (flow_result.quit_requested)
+            break;
+
+        if (scene == BANANA_POC_SCENE_MAIN_MENU && previous_scene != BANANA_POC_SCENE_MAIN_MENU)
+            engine_set_move_input(0.0f, 0.0f);
 
         if (!game_window)
         {
             game_window = find_game_window();
+            if (game_window)
+            {
+                SetForegroundWindow(game_window);
+                SetFocus(game_window);
+            }
         }
 
         if (game_window && (now_ms - hud_updated_ms) >= 200ULL)
@@ -877,14 +1004,16 @@ int main(void)
                                   scene,
                                   objective_collected,
                                   elapsed_seconds,
-                                  objective_timeout_seconds);
+                                  banana_poc_objective_policy_timeout_seconds(&objective_policy));
             hud_updated_ms = now_ms;
         }
 
         if (game_window && (scene == BANANA_POC_SCENE_WORLD || scene == BANANA_POC_SCENE_LEVEL_EDITOR))
         {
             int rbutton_down = (GetAsyncKeyState(VK_RBUTTON) & 0x8000) ? 1 : 0;
-            if (rbutton_down && !last_rbutton_down)
+            int lbutton_down = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) ? 1 : 0;
+            int click_edge = (rbutton_down && !last_rbutton_down) || (lbutton_down && !last_lbutton_down);
+            if (click_edge)
             {
                 POINT cursor_screen;
                 POINT cursor_client;
@@ -899,6 +1028,7 @@ int main(void)
                 }
             }
             last_rbutton_down = rbutton_down;
+            last_lbutton_down = lbutton_down;
 
             if (target_hotkey_enabled)
             {
@@ -923,6 +1053,7 @@ int main(void)
         else
         {
             last_rbutton_down = 0;
+            last_lbutton_down = 0;
             last_target_hotkey_down = 0;
         }
 
@@ -932,10 +1063,11 @@ int main(void)
             break;
         }
 
-        if (!startup_smoke_mode &&
-            scene == BANANA_POC_SCENE_WORLD &&
-            objective_timeout_seconds > 0 &&
-            elapsed_seconds >= objective_timeout_seconds)
+        if (banana_poc_objective_policy_should_fail_timeout(&objective_policy,
+                                                            startup_smoke_mode,
+                                                            scene,
+                                                            objective_collected,
+                                                            elapsed_seconds))
         {
             fprintf(stderr, "[dx12-poc] objective failed: PBJ pickup timeout\n");
             if (game_window)
@@ -991,11 +1123,14 @@ int main(void)
                           telemetry_enabled,
                           level_editor_height,
                           elapsed_seconds,
-                          objective_timeout_seconds,
+                          banana_poc_objective_policy_timeout_seconds(&objective_policy),
                           objective_collected,
-                          startup_smoke_mode);
+                          startup_smoke_mode,
+                          &proto_config);
 
-        if (scene == BANANA_POC_SCENE_WORLD && objective_collected)
+        if (banana_poc_objective_policy_on_objective_collected(&objective_policy,
+                                                                scene,
+                                                                objective_collected))
         {
             printf("[dx12-poc] objective complete: PBJ pickup collected\n");
             if (game_window)
@@ -1004,12 +1139,11 @@ int main(void)
                                       scene,
                                       1,
                                       elapsed_seconds,
-                                      objective_timeout_seconds);
+                                      banana_poc_objective_policy_timeout_seconds(&objective_policy));
             }
-            scene = BANANA_POC_SCENE_MAIN_MENU;
         }
 
-        if (telemetry_enabled && (now_ms - telemetry_started_ms) >= 1000ULL)
+        if (telemetry_enabled && (now_ms - telemetry_started_ms) >= (ULONGLONG)telemetry_interval_ms)
         {
             int entity_count = engine_get_entity_count();
             telemetry_started_ms = now_ms;
@@ -1025,6 +1159,15 @@ int main(void)
 
     engine_ui_shutdown();
     engine_shutdown();
+    save_profile(menu_index,
+                 character_index,
+                 class_index,
+                 options_index,
+                 auto_target_enabled,
+                 target_hotkey_enabled,
+                 telemetry_enabled,
+                 level_editor_height,
+                 &proto_config);
     free(s_ui_bgra_buffer);
     s_ui_bgra_buffer = NULL;
     s_ui_bgra_capacity = 0;

--- a/src/native/engine/win32_dx12_poc/main.c
+++ b/src/native/engine/win32_dx12_poc/main.c
@@ -17,6 +17,23 @@ static const int BANANA_POC_HEIGHT = 720;
 static unsigned char *s_ui_bgra_buffer = NULL;
 static size_t s_ui_bgra_capacity = 0;
 
+typedef enum BananaPocScene
+{
+    BANANA_POC_SCENE_MAIN_MENU = 0,
+    BANANA_POC_SCENE_CHARACTER_SELECT = 1,
+    BANANA_POC_SCENE_WORLD = 2,
+    BANANA_POC_SCENE_LEVEL_EDITOR = 3,
+    BANANA_POC_SCENE_OPTIONS = 4,
+} BananaPocScene;
+
+static int consume_key_press(int vk, int *last_down)
+{
+    int down = (GetAsyncKeyState(vk) & 0x8000) ? 1 : 0;
+    int pressed = down && (!(*last_down));
+    *last_down = down;
+    return pressed;
+}
+
 static float axis_value(int positive_key, int negative_key)
 {
     float axis = 0.0f;
@@ -95,6 +112,7 @@ static HWND find_game_window(void)
 }
 
 static void update_game_hud_title(HWND game_window,
+                                  BananaPocScene scene,
                                   int objective_collected,
                                   int elapsed_seconds,
                                   int objective_timeout_seconds)
@@ -106,7 +124,31 @@ static void update_game_hud_title(HWND game_window,
         remaining_seconds = 0;
     }
 
-    if (objective_collected)
+    if (scene == BANANA_POC_SCENE_MAIN_MENU)
+    {
+        snprintf(title,
+                 sizeof(title),
+                 "Banana DX12 POC | Main Menu | Enter Select");
+    }
+    else if (scene == BANANA_POC_SCENE_CHARACTER_SELECT)
+    {
+        snprintf(title,
+                 sizeof(title),
+                 "Banana DX12 POC | Character Select | Enter Confirm");
+    }
+    else if (scene == BANANA_POC_SCENE_OPTIONS)
+    {
+        snprintf(title,
+                 sizeof(title),
+                 "Banana DX12 POC | Options | Left/Right Toggle");
+    }
+    else if (scene == BANANA_POC_SCENE_LEVEL_EDITOR)
+    {
+        snprintf(title,
+                 sizeof(title),
+                 "Banana DX12 POC | Level Editor | E Apply Height");
+    }
+    else if (objective_collected)
     {
         snprintf(title,
                  sizeof(title),
@@ -256,6 +298,15 @@ static void blit_ui_overlay(HWND game_window,
 }
 
 static void render_ui_overlay(HWND game_window,
+                              BananaPocScene scene,
+                              int main_menu_index,
+                              int character_index,
+                              int class_index,
+                              int option_index,
+                              int auto_target_enabled,
+                              int target_hotkey_enabled,
+                              int telemetry_enabled,
+                              int editor_height,
                               int elapsed_seconds,
                               int objective_timeout_seconds,
                               int objective_collected,
@@ -284,6 +335,24 @@ static void render_ui_overlay(HWND game_window,
     const char *hint_x = "HOLD";
     const char *hint_z = "HOLD";
     const unsigned char *ui_framebuffer = NULL;
+    static const char *k_main_menu_items[] = {
+        "Enter World",
+        "Character Select",
+        "Level Editor",
+        "Options",
+        "Quit",
+    };
+    static const char *k_character_names[] = {
+        "DX12 Pilot",
+        "Vanguard One",
+        "Arcanist Flux",
+        "Ranger Echo",
+    };
+    static const char *k_class_names[] = {
+        "Vanguard",
+        "Arcanist",
+        "Ranger",
+    };
 
     if (!game_window)
     {
@@ -298,6 +367,85 @@ static void render_ui_overlay(HWND game_window,
     if (world_half_span < 1.0f)
     {
         world_half_span = 1.0f;
+    }
+
+    engine_ui_begin_frame();
+
+    if (scene == BANANA_POC_SCENE_MAIN_MENU ||
+        scene == BANANA_POC_SCENE_CHARACTER_SELECT ||
+        scene == BANANA_POC_SCENE_OPTIONS)
+    {
+        engine_ui_panel(170.0f, 90.0f, 940.0f, 530.0f, 0x101822E8u, 2.0f);
+
+        if (scene == BANANA_POC_SCENE_MAIN_MENU)
+        {
+            int i = 0;
+            engine_ui_text(220.0f, 140.0f, "BANANA DX12 POC");
+            engine_ui_text(220.0f, 172.0f, "Main Menu - Use Up/Down, Enter Select");
+            for (i = 0; i < (int)(sizeof(k_main_menu_items) / sizeof(k_main_menu_items[0])); i++)
+            {
+                char item_line[128];
+                snprintf(item_line,
+                         sizeof(item_line),
+                         "%s %s",
+                         (i == main_menu_index) ? ">" : " ",
+                         k_main_menu_items[i]);
+                engine_ui_text(240.0f, 230.0f + ((float)i * 36.0f), item_line);
+            }
+        }
+        else if (scene == BANANA_POC_SCENE_CHARACTER_SELECT)
+        {
+            char character_line[160];
+            char class_line[160];
+            engine_ui_text(220.0f, 140.0f, "Character Select");
+            engine_ui_text(220.0f, 172.0f, "Left/Right change values, Enter to start, Esc to menu");
+
+            snprintf(character_line,
+                     sizeof(character_line),
+                     "Character: %s",
+                     k_character_names[character_index]);
+            snprintf(class_line,
+                     sizeof(class_line),
+                     "Class: %s",
+                     k_class_names[class_index]);
+
+            engine_ui_text(240.0f, 246.0f, character_line);
+            engine_ui_text(240.0f, 286.0f, class_line);
+            engine_ui_text(240.0f, 340.0f, "Press Enter to Enter World");
+        }
+        else if (scene == BANANA_POC_SCENE_OPTIONS)
+        {
+            char option_line_a[160];
+            char option_line_b[160];
+            char option_line_c[160];
+            engine_ui_text(220.0f, 140.0f, "Options");
+            engine_ui_text(220.0f, 172.0f, "Up/Down select option, Left/Right toggle, Esc to menu");
+
+            snprintf(option_line_a,
+                     sizeof(option_line_a),
+                     "%s Auto Startup Target: %s",
+                     option_index == 0 ? ">" : " ",
+                     auto_target_enabled ? "On" : "Off");
+            snprintf(option_line_b,
+                     sizeof(option_line_b),
+                     "%s Target Hotkey (T): %s",
+                     option_index == 1 ? ">" : " ",
+                     target_hotkey_enabled ? "On" : "Off");
+            snprintf(option_line_c,
+                     sizeof(option_line_c),
+                     "%s Telemetry Prints: %s",
+                     option_index == 2 ? ">" : " ",
+                     telemetry_enabled ? "On" : "Off");
+
+            engine_ui_text(240.0f, 246.0f, option_line_a);
+            engine_ui_text(240.0f, 286.0f, option_line_b);
+            engine_ui_text(240.0f, 326.0f, option_line_c);
+        }
+
+        engine_ui_end_frame();
+        ui_framebuffer = engine_ui_get_framebuffer();
+        blit_ui_overlay(game_window, ui_framebuffer, BANANA_POC_WIDTH, BANANA_POC_HEIGHT);
+        return;
     }
 
     has_player = engine_get_player_position(&player_x, &player_z);
@@ -317,14 +465,15 @@ static void render_ui_overlay(HWND game_window,
             hint_z = "W";
     }
 
-    engine_ui_begin_frame();
     engine_ui_panel(12.0f, 12.0f, 760.0f, 94.0f, 0x0A1118C0u, 1.0f);
     engine_ui_panel(12.0f, 112.0f, 420.0f, 92.0f, 0x121E28C0u, 1.0f);
     engine_ui_panel(minimap_x, minimap_y, minimap_w, minimap_h, 0x1A2A22D0u, 1.0f);
 
     snprintf(line_one,
              sizeof(line_one),
-             "BANANA DX12 POC  |  WASD MOVE  |  RIGHT-CLICK MOVE TARGET  |  ESC QUIT");
+             scene == BANANA_POC_SCENE_LEVEL_EDITOR
+                 ? "BANANA DX12 POC  |  LEVEL EDITOR  |  WASD MOVE  |  E APPLY HEIGHT"
+                 : "BANANA DX12 POC  |  WASD MOVE  |  RIGHT-CLICK MOVE TARGET  |  ESC QUIT");
 
     if (startup_smoke_mode)
     {
@@ -392,7 +541,19 @@ static void render_ui_overlay(HWND game_window,
     engine_ui_text(22.0f, 48.0f, line_two);
     engine_ui_text(22.0f, 72.0f, line_three);
     engine_ui_text(22.0f, 124.0f, line_four);
-    engine_ui_text(22.0f, 148.0f, line_five);
+    if (scene == BANANA_POC_SCENE_LEVEL_EDITOR)
+    {
+        char editor_line[160];
+        snprintf(editor_line,
+                 sizeof(editor_line),
+                 "EDITOR HEIGHT=%d  |  [ and ] adjust  |  E apply at player  |  M menu",
+                 editor_height);
+        engine_ui_text(22.0f, 148.0f, editor_line);
+    }
+    else
+    {
+        engine_ui_text(22.0f, 148.0f, line_five);
+    }
     engine_ui_text(minimap_x + 10.0f, minimap_y + 10.0f, "MINIMAP (TERRAIN + ACTORS)");
 
     engine_ui_panel(minimap_x + 10.0f,
@@ -474,9 +635,26 @@ int main(void)
     int startup_smoke_seconds = 0;
     int auto_target_enabled = 1;
     int target_hotkey_enabled = 0;
+    int telemetry_enabled = 1;
+    BananaPocScene scene = BANANA_POC_SCENE_MAIN_MENU;
+    int menu_index = 0;
+    int character_index = 0;
+    int class_index = 0;
+    int options_index = 0;
+    int level_editor_height = 2;
     int exit_code = 0;
     int last_rbutton_down = 0;
     int last_target_hotkey_down = 0;
+    int last_up_down = 0;
+    int last_down_down = 0;
+    int last_left_down = 0;
+    int last_right_down = 0;
+    int last_enter_down = 0;
+    int last_menu_hotkey_down = 0;
+    int last_apply_edit_down = 0;
+    int last_raise_edit_down = 0;
+    int last_lower_edit_down = 0;
+    int last_escape_down = 0;
     int auto_target_injected = 0;
 
     if (!QueryPerformanceFrequency(&frequency) || !QueryPerformanceCounter(&previous_counter))
@@ -486,7 +664,7 @@ int main(void)
     }
 
     printf("[dx12-poc] launching Banana playable prototype\n");
-    printf("[dx12-poc] controls: WASD move, right-click move target, ESC quit\n");
+    printf("[dx12-poc] controls: arrows navigate menus, Enter select, WASD in world, ESC back/quit\n");
     printf("[dx12-poc] backend requested=%s active=%s status=%s\n",
            banana_render_backend_name(banana_render_backend_requested()),
            banana_render_backend_name(banana_render_backend_active()),
@@ -530,9 +708,161 @@ int main(void)
         int objective_collected = 0;
         int tick_result = 0;
 
-        if (GetAsyncKeyState(VK_ESCAPE) & 0x8000)
+        if (consume_key_press(VK_ESCAPE, &last_escape_down))
         {
-            break;
+            if (scene == BANANA_POC_SCENE_MAIN_MENU)
+            {
+                break;
+            }
+            scene = BANANA_POC_SCENE_MAIN_MENU;
+            engine_set_move_input(0.0f, 0.0f);
+        }
+
+        if (consume_key_press('M', &last_menu_hotkey_down) &&
+            (scene == BANANA_POC_SCENE_WORLD || scene == BANANA_POC_SCENE_LEVEL_EDITOR))
+        {
+            scene = BANANA_POC_SCENE_MAIN_MENU;
+            engine_set_move_input(0.0f, 0.0f);
+        }
+
+        if (scene == BANANA_POC_SCENE_MAIN_MENU)
+        {
+            if (consume_key_press(VK_UP, &last_up_down) && menu_index > 0)
+                menu_index--;
+            if (consume_key_press(VK_DOWN, &last_down_down) && menu_index < 4)
+                menu_index++;
+            if (consume_key_press(VK_RETURN, &last_enter_down))
+            {
+                if (menu_index == 0)
+                {
+                    static const char *k_character_names[] = {
+                        "DX12 Pilot",
+                        "Vanguard One",
+                        "Arcanist Flux",
+                        "Ranger Echo",
+                    };
+                    if (engine_player_upsert("native-default-player",
+                                             k_character_names[character_index],
+                                             "human",
+                                             1) != 0)
+                    {
+                        (void)engine_player_build_set_class("native-default-player", class_index);
+                    }
+                    scene = BANANA_POC_SCENE_WORLD;
+                }
+                else if (menu_index == 1)
+                {
+                    scene = BANANA_POC_SCENE_CHARACTER_SELECT;
+                }
+                else if (menu_index == 2)
+                {
+                    scene = BANANA_POC_SCENE_LEVEL_EDITOR;
+                }
+                else if (menu_index == 3)
+                {
+                    scene = BANANA_POC_SCENE_OPTIONS;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+        else if (scene == BANANA_POC_SCENE_CHARACTER_SELECT)
+        {
+            if (consume_key_press(VK_LEFT, &last_left_down) && character_index > 0)
+                character_index--;
+            if (consume_key_press(VK_RIGHT, &last_right_down) && character_index < 3)
+                character_index++;
+            if (consume_key_press(VK_UP, &last_up_down) && class_index > 0)
+                class_index--;
+            if (consume_key_press(VK_DOWN, &last_down_down) && class_index < 2)
+                class_index++;
+
+            if (consume_key_press(VK_RETURN, &last_enter_down))
+            {
+                static const char *k_character_names[] = {
+                    "DX12 Pilot",
+                    "Vanguard One",
+                    "Arcanist Flux",
+                    "Ranger Echo",
+                };
+                if (engine_player_upsert("native-default-player",
+                                         k_character_names[character_index],
+                                         "human",
+                                         1) == 0)
+                {
+                    fprintf(stderr, "[dx12-poc] character apply failed\n");
+                }
+                else
+                {
+                    (void)engine_player_build_set_class("native-default-player", class_index);
+                    scene = BANANA_POC_SCENE_WORLD;
+                }
+            }
+        }
+        else if (scene == BANANA_POC_SCENE_OPTIONS)
+        {
+            if (consume_key_press(VK_UP, &last_up_down) && options_index > 0)
+                options_index--;
+            if (consume_key_press(VK_DOWN, &last_down_down) && options_index < 2)
+                options_index++;
+
+            if (consume_key_press(VK_LEFT, &last_left_down) ||
+                consume_key_press(VK_RIGHT, &last_right_down) ||
+                consume_key_press(VK_RETURN, &last_enter_down))
+            {
+                if (options_index == 0)
+                    auto_target_enabled = auto_target_enabled ? 0 : 1;
+                else if (options_index == 1)
+                    target_hotkey_enabled = target_hotkey_enabled ? 0 : 1;
+                else
+                    telemetry_enabled = telemetry_enabled ? 0 : 1;
+            }
+        }
+        else if (scene == BANANA_POC_SCENE_LEVEL_EDITOR)
+        {
+            if (consume_key_press(VK_OEM_4, &last_lower_edit_down) && level_editor_height > 0)
+                level_editor_height--;
+            if (consume_key_press(VK_OEM_6, &last_raise_edit_down) && level_editor_height < 3)
+                level_editor_height++;
+            if (consume_key_press('E', &last_apply_edit_down))
+            {
+                float px = 0.0f;
+                float pz = 0.0f;
+                if (engine_get_player_position(&px, &pz))
+                {
+                    float half_span = engine_get_terrain_half_span();
+                    int terrain_size = (int)(half_span * 2.0f + 1.0f);
+                    int ix = (int)roundf(px + half_span);
+                    int iz = (int)roundf(pz + half_span);
+
+                    if (ix < 0)
+                        ix = 0;
+                    if (iz < 0)
+                        iz = 0;
+                    if (ix >= terrain_size)
+                        ix = terrain_size - 1;
+                    if (iz >= terrain_size)
+                        iz = terrain_size - 1;
+
+                    if (engine_terrain_set_height(ix, iz, level_editor_height) != 0)
+                    {
+                        fprintf(stderr,
+                                "[dx12-poc] level-editor apply failed grid=(%d,%d) height=%d\n",
+                                ix,
+                                iz,
+                                level_editor_height);
+                    }
+                    else
+                    {
+                        printf("[dx12-poc] level-editor set grid=(%d,%d) height=%d\n",
+                               ix,
+                               iz,
+                               level_editor_height);
+                    }
+                }
+            }
         }
 
         if (!game_window)
@@ -544,13 +874,14 @@ int main(void)
         {
             objective_collected = engine_get_pbj_pickup_collected();
             update_game_hud_title(game_window,
+                                  scene,
                                   objective_collected,
                                   elapsed_seconds,
                                   objective_timeout_seconds);
             hud_updated_ms = now_ms;
         }
 
-        if (game_window)
+        if (game_window && (scene == BANANA_POC_SCENE_WORLD || scene == BANANA_POC_SCENE_LEVEL_EDITOR))
         {
             int rbutton_down = (GetAsyncKeyState(VK_RBUTTON) & 0x8000) ? 1 : 0;
             if (rbutton_down && !last_rbutton_down)
@@ -589,6 +920,11 @@ int main(void)
                 printf("[dx12-poc] injected startup move target\n");
             }
         }
+        else
+        {
+            last_rbutton_down = 0;
+            last_target_hotkey_down = 0;
+        }
 
         if (startup_smoke_mode && elapsed_seconds >= startup_smoke_seconds)
         {
@@ -596,7 +932,10 @@ int main(void)
             break;
         }
 
-        if (!startup_smoke_mode && objective_timeout_seconds > 0 && elapsed_seconds >= objective_timeout_seconds)
+        if (!startup_smoke_mode &&
+            scene == BANANA_POC_SCENE_WORLD &&
+            objective_timeout_seconds > 0 &&
+            elapsed_seconds >= objective_timeout_seconds)
         {
             fprintf(stderr, "[dx12-poc] objective failed: PBJ pickup timeout\n");
             if (game_window)
@@ -625,7 +964,10 @@ int main(void)
             dt = 0.10f;
         }
 
-        update_keyboard_move_input();
+        if (scene == BANANA_POC_SCENE_WORLD || scene == BANANA_POC_SCENE_LEVEL_EDITOR)
+            update_keyboard_move_input();
+        else
+            engine_set_move_input(0.0f, 0.0f);
 
         tick_result = engine_tick(dt);
         if (tick_result != 0)
@@ -639,25 +981,35 @@ int main(void)
 
         objective_collected = engine_get_pbj_pickup_collected();
         render_ui_overlay(game_window,
+                          scene,
+                          menu_index,
+                          character_index,
+                          class_index,
+                          options_index,
+                          auto_target_enabled,
+                          target_hotkey_enabled,
+                          telemetry_enabled,
+                          level_editor_height,
                           elapsed_seconds,
                           objective_timeout_seconds,
                           objective_collected,
                           startup_smoke_mode);
 
-        if (objective_collected)
+        if (scene == BANANA_POC_SCENE_WORLD && objective_collected)
         {
             printf("[dx12-poc] objective complete: PBJ pickup collected\n");
             if (game_window)
             {
                 update_game_hud_title(game_window,
+                                      scene,
                                       1,
                                       elapsed_seconds,
                                       objective_timeout_seconds);
             }
-            break;
+            scene = BANANA_POC_SCENE_MAIN_MENU;
         }
 
-        if ((now_ms - telemetry_started_ms) >= 1000ULL)
+        if (telemetry_enabled && (now_ms - telemetry_started_ms) >= 1000ULL)
         {
             int entity_count = engine_get_entity_count();
             telemetry_started_ms = now_ms;

--- a/src/native/engine/win32_dx12_poc/main.c
+++ b/src/native/engine/win32_dx12_poc/main.c
@@ -271,7 +271,7 @@ static void render_ui_overlay(HWND game_window,
     float player_z = 0.0f;
     float target_x = 0.0f;
     float target_z = 0.0f;
-    float world_half_span = 24.0f;
+    float world_half_span = engine_get_terrain_half_span();
     float minimap_x = 988.0f;
     float minimap_y = 520.0f;
     float minimap_w = 280.0f;
@@ -293,6 +293,11 @@ static void render_ui_overlay(HWND game_window,
     if (remaining_seconds < 0)
     {
         remaining_seconds = 0;
+    }
+
+    if (world_half_span < 1.0f)
+    {
+        world_half_span = 1.0f;
     }
 
     has_player = engine_get_player_position(&player_x, &player_z);

--- a/src/native/engine/win32_dx12_poc/main.c
+++ b/src/native/engine/win32_dx12_poc/main.c
@@ -324,7 +324,7 @@ static void render_ui_overlay(HWND game_window,
 
     snprintf(line_one,
              sizeof(line_one),
-             "BANANA DX12 POC  |  WASD MOVE  |  RIGHT-CLICK/T MOVE TARGET  |  ESC QUIT");
+             "BANANA DX12 POC  |  WASD MOVE  |  RIGHT-CLICK MOVE TARGET  |  ESC QUIT");
 
     if (startup_smoke_mode)
     {
@@ -473,6 +473,7 @@ int main(void)
     int startup_smoke_mode = 0;
     int startup_smoke_seconds = 0;
     int auto_target_enabled = 1;
+    int target_hotkey_enabled = 0;
     int exit_code = 0;
     int last_rbutton_down = 0;
     int last_target_hotkey_down = 0;
@@ -485,7 +486,7 @@ int main(void)
     }
 
     printf("[dx12-poc] launching Banana playable prototype\n");
-    printf("[dx12-poc] controls: WASD move, right-click/T move target, ESC quit\n");
+    printf("[dx12-poc] controls: WASD move, right-click move target, ESC quit\n");
     printf("[dx12-poc] backend requested=%s active=%s status=%s\n",
            banana_render_backend_name(banana_render_backend_requested()),
            banana_render_backend_name(banana_render_backend_active()),
@@ -514,7 +515,8 @@ int main(void)
     startup_smoke_mode = parse_env_flag("BANANA_DX12_POC_AUTOTEST");
     startup_smoke_seconds = parse_env_int("BANANA_DX12_POC_AUTOTEST_SECONDS", 2, 1, 30);
     objective_timeout_seconds = parse_env_int("BANANA_DX12_POC_OBJECTIVE_TIMEOUT_SECONDS", 0, 0, 3600);
-    auto_target_enabled = parse_env_int("BANANA_DX12_POC_AUTO_TARGET", 1, 0, 1);
+    auto_target_enabled = parse_env_int("BANANA_DX12_POC_AUTO_TARGET", 0, 0, 1);
+    target_hotkey_enabled = parse_env_int("BANANA_DX12_POC_ENABLE_TARGET_HOTKEY", 0, 0, 1);
 
     telemetry_started_ms = GetTickCount64();
     hud_updated_ms = telemetry_started_ms;
@@ -567,6 +569,7 @@ int main(void)
             }
             last_rbutton_down = rbutton_down;
 
+            if (target_hotkey_enabled)
             {
                 int hotkey_down = (GetAsyncKeyState('T') & 0x8000) ? 1 : 0;
                 if (hotkey_down && !last_target_hotkey_down)

--- a/src/native/engine/win32_dx12_poc/objective_policy.c
+++ b/src/native/engine/win32_dx12_poc/objective_policy.c
@@ -1,0 +1,89 @@
+#include "objective_policy.h"
+
+void banana_poc_objective_policy_init(BananaPocObjectivePolicy *policy,
+                                      int base_timeout_seconds)
+{
+    if (!policy)
+        return;
+
+    if (base_timeout_seconds < 0)
+        base_timeout_seconds = 0;
+
+    policy->base_timeout_seconds = base_timeout_seconds;
+    policy->active_timeout_seconds = base_timeout_seconds;
+    policy->completion_announced = 0;
+}
+
+void banana_poc_objective_policy_on_entered_world(BananaPocObjectivePolicy *policy,
+                                                   int entered_scene_browser_scene)
+{
+    if (!policy)
+        return;
+
+    policy->completion_announced = 0;
+
+    if (!entered_scene_browser_scene)
+        policy->active_timeout_seconds = policy->base_timeout_seconds;
+}
+
+void banana_poc_objective_policy_apply_world_variant(BananaPocObjectivePolicy *policy,
+                                                     int world_variant)
+{
+    if (!policy)
+        return;
+
+    if (world_variant == 0)
+        policy->active_timeout_seconds = policy->base_timeout_seconds;
+    else if (world_variant == 2)
+        policy->active_timeout_seconds = policy->base_timeout_seconds;
+    else
+        policy->active_timeout_seconds = 0;
+}
+
+int banana_poc_objective_policy_should_fail_timeout(const BananaPocObjectivePolicy *policy,
+                                                    int startup_smoke_mode,
+                                                    BananaPocScene scene,
+                                                    int objective_collected,
+                                                    int elapsed_seconds)
+{
+    int timeout_seconds = 0;
+
+    if (!policy)
+        return 0;
+
+    timeout_seconds = policy->active_timeout_seconds;
+
+    return (!startup_smoke_mode &&
+            scene == BANANA_POC_SCENE_WORLD &&
+            !objective_collected &&
+            timeout_seconds > 0 &&
+            elapsed_seconds >= timeout_seconds)
+               ? 1
+               : 0;
+}
+
+int banana_poc_objective_policy_on_objective_collected(BananaPocObjectivePolicy *policy,
+                                                        BananaPocScene scene,
+                                                        int objective_collected)
+{
+    int announce = 0;
+
+    if (!policy)
+        return 0;
+
+    if (scene != BANANA_POC_SCENE_WORLD || !objective_collected)
+        return 0;
+
+    announce = policy->completion_announced ? 0 : 1;
+    policy->completion_announced = 1;
+    policy->active_timeout_seconds = 0;
+    return announce;
+}
+
+int banana_poc_objective_policy_timeout_seconds(const BananaPocObjectivePolicy *policy)
+{
+    if (!policy)
+        return 0;
+
+    return policy->active_timeout_seconds;
+}

--- a/src/native/engine/win32_dx12_poc/objective_policy.h
+++ b/src/native/engine/win32_dx12_poc/objective_policy.h
@@ -1,0 +1,43 @@
+#ifndef BANANA_ENGINE_WIN32_DX12_POC_OBJECTIVE_POLICY_H
+#define BANANA_ENGINE_WIN32_DX12_POC_OBJECTIVE_POLICY_H
+
+#include "scene_overlay.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct BananaPocObjectivePolicy
+    {
+        int base_timeout_seconds;
+        int active_timeout_seconds;
+        int completion_announced;
+    } BananaPocObjectivePolicy;
+
+    void banana_poc_objective_policy_init(BananaPocObjectivePolicy *policy,
+                                          int base_timeout_seconds);
+
+    void banana_poc_objective_policy_on_entered_world(BananaPocObjectivePolicy *policy,
+                                                       int entered_scene_browser_scene);
+
+    void banana_poc_objective_policy_apply_world_variant(BananaPocObjectivePolicy *policy,
+                                                         int world_variant);
+
+    int banana_poc_objective_policy_should_fail_timeout(const BananaPocObjectivePolicy *policy,
+                                                        int startup_smoke_mode,
+                                                        BananaPocScene scene,
+                                                        int objective_collected,
+                                                        int elapsed_seconds);
+
+    int banana_poc_objective_policy_on_objective_collected(BananaPocObjectivePolicy *policy,
+                                                            BananaPocScene scene,
+                                                            int objective_collected);
+
+    int banana_poc_objective_policy_timeout_seconds(const BananaPocObjectivePolicy *policy);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/native/engine/win32_dx12_poc/scene_flow.c
+++ b/src/native/engine/win32_dx12_poc/scene_flow.c
@@ -1,0 +1,317 @@
+#include "scene_flow.h"
+
+static void clear_result(BananaPocSceneFlowResult *result)
+{
+    if (!result)
+        return;
+
+    result->quit_requested = 0;
+    result->profile_dirty = 0;
+    result->entered_world = 0;
+    result->character_selection_confirmed = 0;
+    result->options_toggled = 0;
+    result->editor_height_changed = 0;
+    result->editor_apply_requested = 0;
+    result->entered_scene_browser_scene = 0;
+    result->scene_browser_variant = 0;
+    result->config_lab_toggled = 0;
+}
+
+void banana_poc_scene_flow_step(BananaPocSceneFlowState *state,
+                                const BananaPocSceneFlowInput *input,
+                                BananaPocSceneFlowResult *result)
+{
+    if (!state || !input)
+        return;
+
+    clear_result(result);
+
+    if (input->escape_pressed)
+    {
+        if (state->scene == BANANA_POC_SCENE_MAIN_MENU)
+        {
+            if (result)
+                result->quit_requested = 1;
+            return;
+        }
+
+        state->scene = BANANA_POC_SCENE_MAIN_MENU;
+        return;
+    }
+
+    if (input->menu_hotkey_pressed &&
+        (state->scene == BANANA_POC_SCENE_WORLD || state->scene == BANANA_POC_SCENE_LEVEL_EDITOR))
+    {
+        state->scene = BANANA_POC_SCENE_MAIN_MENU;
+        return;
+    }
+
+    if (state->scene == BANANA_POC_SCENE_MAIN_MENU)
+    {
+        if (input->up_pressed && state->menu_index > 0)
+        {
+            state->menu_index--;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->down_pressed && state->menu_index < 6)
+        {
+            state->menu_index++;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->enter_pressed)
+        {
+            if (state->menu_index == 0)
+            {
+                state->scene = BANANA_POC_SCENE_WORLD;
+                if (result)
+                {
+                    result->entered_world = 1;
+                    result->profile_dirty = 1;
+                }
+            }
+            else if (state->menu_index == 1)
+            {
+                state->scene = BANANA_POC_SCENE_CHARACTER_SELECT;
+            }
+            else if (state->menu_index == 2)
+            {
+                state->scene = BANANA_POC_SCENE_SCENE_BROWSER;
+            }
+            else if (state->menu_index == 3)
+            {
+                state->scene = BANANA_POC_SCENE_LEVEL_EDITOR;
+            }
+            else if (state->menu_index == 4)
+            {
+                state->scene = BANANA_POC_SCENE_CONFIG_LAB;
+            }
+            else if (state->menu_index == 5)
+            {
+                state->scene = BANANA_POC_SCENE_OPTIONS;
+            }
+            else if (result)
+            {
+                result->quit_requested = 1;
+                result->profile_dirty = 1;
+            }
+        }
+
+        return;
+    }
+
+    if (state->scene == BANANA_POC_SCENE_CHARACTER_SELECT)
+    {
+        if (input->tab_pressed)
+        {
+            state->proto_config.character_loadout_index =
+                (state->proto_config.character_loadout_index + 1) % 4;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->left_pressed && state->character_index > 0)
+        {
+            state->character_index--;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->right_pressed && state->character_index < 3)
+        {
+            state->character_index++;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->up_pressed && state->class_index > 0)
+        {
+            state->class_index--;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->down_pressed && state->class_index < 2)
+        {
+            state->class_index++;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->enter_pressed)
+        {
+            state->scene = BANANA_POC_SCENE_WORLD;
+            if (result)
+            {
+                result->entered_world = 1;
+                result->character_selection_confirmed = 1;
+                result->profile_dirty = 1;
+            }
+        }
+
+        return;
+    }
+
+    if (state->scene == BANANA_POC_SCENE_OPTIONS)
+    {
+        if (input->up_pressed && state->options_index > 0)
+        {
+            state->options_index--;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->down_pressed && state->options_index < 4)
+        {
+            state->options_index++;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->left_pressed || input->right_pressed || input->enter_pressed)
+        {
+            if (result)
+            {
+                result->options_toggled = 1;
+                result->profile_dirty = 1;
+            }
+        }
+
+        return;
+    }
+
+    if (state->scene == BANANA_POC_SCENE_LEVEL_EDITOR)
+    {
+        if (input->up_pressed && state->proto_config.level_editor_brush_radius < 4)
+        {
+            state->proto_config.level_editor_brush_radius++;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->down_pressed && state->proto_config.level_editor_brush_radius > 1)
+        {
+            state->proto_config.level_editor_brush_radius--;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->left_pressed)
+        {
+            state->proto_config.level_editor_paint_mode--;
+            if (state->proto_config.level_editor_paint_mode < 0)
+                state->proto_config.level_editor_paint_mode = 2;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->right_pressed)
+        {
+            state->proto_config.level_editor_paint_mode =
+                (state->proto_config.level_editor_paint_mode + 1) % 3;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->lower_edit_pressed && state->level_editor_height > 0)
+        {
+            state->level_editor_height--;
+            if (result)
+            {
+                result->editor_height_changed = 1;
+                result->profile_dirty = 1;
+            }
+        }
+
+        if (input->raise_edit_pressed && state->level_editor_height < 3)
+        {
+            state->level_editor_height++;
+            if (result)
+            {
+                result->editor_height_changed = 1;
+                result->profile_dirty = 1;
+            }
+        }
+
+        if (input->apply_edit_pressed && result)
+            result->editor_apply_requested = 1;
+        return;
+    }
+
+    if (state->scene == BANANA_POC_SCENE_SCENE_BROWSER)
+    {
+        /* Navigate the four prototype scenes. */
+        if (input->up_pressed && state->proto_config.scene_browser_index > 0)
+        {
+            state->proto_config.scene_browser_index--;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->down_pressed && state->proto_config.scene_browser_index < 3)
+        {
+            state->proto_config.scene_browser_index++;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->enter_pressed)
+        {
+            /* All prototype scenes reuse the WORLD runtime for now.
+               scene_browser_variant tells main.c which flavour to prep. */
+            state->scene = BANANA_POC_SCENE_WORLD;
+            state->proto_config.active_world_variant = state->proto_config.scene_browser_index;
+            if (result)
+            {
+                result->entered_world = 1;
+                result->entered_scene_browser_scene = 1;
+                result->scene_browser_variant = state->proto_config.scene_browser_index;
+                result->profile_dirty = 1;
+            }
+        }
+
+        return;
+    }
+
+    if (state->scene == BANANA_POC_SCENE_CONFIG_LAB)
+    {
+        /* Navigate the four config rows. */
+        if (input->up_pressed && state->proto_config.config_lab_index > 0)
+        {
+            state->proto_config.config_lab_index--;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->down_pressed && state->proto_config.config_lab_index < 3)
+        {
+            state->proto_config.config_lab_index++;
+            if (result)
+                result->profile_dirty = 1;
+        }
+
+        if (input->left_pressed || input->right_pressed || input->enter_pressed)
+        {
+            int idx = state->proto_config.config_lab_index;
+            if (idx == 0)
+                state->proto_config.render_debug_overlay ^= 1;
+            else if (idx == 1)
+                state->proto_config.physics_wireframe ^= 1;
+            else if (idx == 2)
+                state->proto_config.world_seed_index =
+                    (state->proto_config.world_seed_index + 1) % 4;
+            else
+                state->proto_config.frame_cap_index =
+                    (state->proto_config.frame_cap_index + 1) % 4;
+
+            if (result)
+            {
+                result->config_lab_toggled = 1;
+                result->profile_dirty = 1;
+            }
+        }
+    }
+}

--- a/src/native/engine/win32_dx12_poc/scene_flow.h
+++ b/src/native/engine/win32_dx12_poc/scene_flow.h
@@ -1,0 +1,59 @@
+#ifndef BANANA_ENGINE_WIN32_DX12_POC_SCENE_FLOW_H
+#define BANANA_ENGINE_WIN32_DX12_POC_SCENE_FLOW_H
+
+#include "scene_overlay.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct BananaPocSceneFlowInput
+{
+    int escape_pressed;
+    int menu_hotkey_pressed;
+    int tab_pressed;
+    int up_pressed;
+    int down_pressed;
+    int left_pressed;
+    int right_pressed;
+    int enter_pressed;
+    int lower_edit_pressed;
+    int raise_edit_pressed;
+    int apply_edit_pressed;
+} BananaPocSceneFlowInput;
+
+typedef struct BananaPocSceneFlowState
+{
+    BananaPocScene scene;
+    int menu_index;
+    int character_index;
+    int class_index;
+    int options_index;
+    int level_editor_height;
+    BananaPocProtoConfig proto_config; /* scene browser + config lab state */
+} BananaPocSceneFlowState;
+
+typedef struct BananaPocSceneFlowResult
+{
+    int quit_requested;
+    int profile_dirty;
+    int entered_world;
+    int character_selection_confirmed;
+    int options_toggled;
+    int editor_height_changed;
+    int editor_apply_requested;
+    int entered_scene_browser_scene; /* fired when user picks a proto scene     */
+    int scene_browser_variant;       /* which proto scene was chosen (0-3)      */
+    int config_lab_toggled;          /* fired when a config-lab value is changed */
+} BananaPocSceneFlowResult;
+
+void banana_poc_scene_flow_step(BananaPocSceneFlowState *state,
+                                const BananaPocSceneFlowInput *input,
+                                BananaPocSceneFlowResult *result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/native/engine/win32_dx12_poc/scene_overlay.c
+++ b/src/native/engine/win32_dx12_poc/scene_overlay.c
@@ -1,0 +1,459 @@
+#include "scene_overlay.h"
+
+#include "../engine.h"
+
+#include <stdio.h>
+#include <string.h>
+
+void banana_poc_render_scene_overlay(BananaPocScene scene,
+                                     int main_menu_index,
+                                     int character_index,
+                                     int class_index,
+                                     int option_index,
+                                     int auto_target_enabled,
+                                     int target_hotkey_enabled,
+                                     int telemetry_enabled,
+                                     int editor_height,
+                                     int elapsed_seconds,
+                                     int objective_timeout_seconds,
+                                     int objective_collected,
+                                     int startup_smoke_mode,
+                                     const BananaPocProtoConfig *proto)
+{
+    char line_one[160];
+    char line_two[160];
+    char line_three[160];
+    char line_four[160];
+    char line_five[160];
+    int remaining_seconds = objective_timeout_seconds - elapsed_seconds;
+    float player_x = 0.0f;
+    float player_z = 0.0f;
+    float target_x = 0.0f;
+    float target_z = 0.0f;
+    float world_half_span = engine_get_terrain_half_span();
+    float minimap_x = 988.0f;
+    float minimap_y = 520.0f;
+    float minimap_w = 280.0f;
+    float minimap_h = 184.0f;
+    float marker_size = 5.0f;
+    int has_player = 0;
+    int has_target = 0;
+    float nav_dx = 0.0f;
+    float nav_dz = 0.0f;
+    const char *hint_x = "HOLD";
+    const char *hint_z = "HOLD";
+    static const char *k_main_menu_items[] = {
+        "Enter World",
+        "Character Select",
+        "Scene Browser",
+        "Level Editor",
+        "Config Lab",
+        "Options",
+        "Quit",
+    };
+    static const char *k_character_names[] = {
+        "DX12 Pilot",
+        "Vanguard One",
+        "Arcanist Flux",
+        "Ranger Echo",
+    };
+    static const char *k_class_names[] = {
+        "Vanguard",
+        "Arcanist",
+        "Ranger",
+    };
+    static const char *k_loadout_names[] = {
+        "Balanced",
+        "Tank",
+        "Burst",
+        "Support",
+    };
+    static const char *k_variant_names[] = {
+        "Open World",
+        "Physics Sandbox",
+        "AI Encounter",
+        "Render Benchmark",
+    };
+
+    if (remaining_seconds < 0)
+    {
+        remaining_seconds = 0;
+    }
+
+    if (world_half_span < 1.0f)
+    {
+        world_half_span = 1.0f;
+    }
+
+    engine_ui_begin_frame();
+
+    if (scene == BANANA_POC_SCENE_MAIN_MENU ||
+        scene == BANANA_POC_SCENE_CHARACTER_SELECT ||
+        scene == BANANA_POC_SCENE_OPTIONS ||
+        scene == BANANA_POC_SCENE_SCENE_BROWSER ||
+        scene == BANANA_POC_SCENE_CONFIG_LAB)
+    {
+        engine_ui_panel(0.0f,
+                        0.0f,
+                        (float)BANANA_POC_WIDTH,
+                        (float)BANANA_POC_HEIGHT,
+                        0x081423FFu,
+                        0.0f);
+        engine_ui_panel(170.0f, 90.0f, 940.0f, 530.0f, 0x101822E8u, 2.0f);
+
+        if (scene == BANANA_POC_SCENE_MAIN_MENU)
+        {
+            int i = 0;
+            engine_ui_text(220.0f, 140.0f, "BANANA DX12 POC");
+            engine_ui_text(220.0f, 172.0f, "Main Menu - Use Up/Down, Enter Select");
+            for (i = 0; i < (int)(sizeof(k_main_menu_items) / sizeof(k_main_menu_items[0])); i++)
+            {
+                char item_line[128];
+                snprintf(item_line,
+                         sizeof(item_line),
+                         "%s %s",
+                         (i == main_menu_index) ? ">" : " ",
+                         k_main_menu_items[i]);
+                engine_ui_text(240.0f, 230.0f + ((float)i * 36.0f), item_line);
+            }
+            engine_ui_text(240.0f, 502.0f, "Scaffolded menus: Character, Scene Browser, Editor, Config Lab, Options");
+        }
+        else if (scene == BANANA_POC_SCENE_CHARACTER_SELECT)
+        {
+            char character_line[160];
+            char class_line[160];
+            char loadout_line[160];
+            int loadout_index = proto ? proto->character_loadout_index : 0;
+            engine_ui_text(220.0f, 140.0f, "Character Select");
+            engine_ui_text(220.0f, 172.0f, "Left/Right character, Up/Down class, TAB loadout, Enter start");
+
+            snprintf(character_line,
+                     sizeof(character_line),
+                     "Character: %s",
+                     k_character_names[character_index]);
+            snprintf(class_line,
+                     sizeof(class_line),
+                     "Class: %s",
+                     k_class_names[class_index]);
+            snprintf(loadout_line,
+                     sizeof(loadout_line),
+                     "Loadout Preset (TAB): %s",
+                     k_loadout_names[loadout_index]);
+
+            engine_ui_text(240.0f, 246.0f, character_line);
+            engine_ui_text(240.0f, 286.0f, class_line);
+            engine_ui_text(240.0f, 326.0f, loadout_line);
+            engine_ui_text(240.0f, 374.0f, "Press Enter to Enter World");
+        }
+        else if (scene == BANANA_POC_SCENE_OPTIONS)
+        {
+            char option_line_a[160];
+            char option_line_b[160];
+            char option_line_c[160];
+            char option_line_d[160];
+            char option_line_e[160];
+            engine_ui_text(220.0f, 140.0f, "Options");
+            engine_ui_text(220.0f, 172.0f, "Up/Down select option, Left/Right toggle, Esc to menu");
+
+            snprintf(option_line_a,
+                     sizeof(option_line_a),
+                     "%s Auto Startup Target: %s",
+                     option_index == 0 ? ">" : " ",
+                     auto_target_enabled ? "On" : "Off");
+            snprintf(option_line_b,
+                     sizeof(option_line_b),
+                     "%s Target Hotkey (T): %s",
+                     option_index == 1 ? ">" : " ",
+                     target_hotkey_enabled ? "On" : "Off");
+            snprintf(option_line_c,
+                     sizeof(option_line_c),
+                     "%s Telemetry Prints: %s",
+                     option_index == 2 ? ">" : " ",
+                     telemetry_enabled ? "On" : "Off");
+            snprintf(option_line_d,
+                     sizeof(option_line_d),
+                     "%s Input Assist Hints: %s",
+                     option_index == 3 ? ">" : " ",
+                     (proto && proto->option_input_assist) ? "On" : "Off");
+            snprintf(option_line_e,
+                     sizeof(option_line_e),
+                     "%s Compact HUD: %s",
+                     option_index == 4 ? ">" : " ",
+                     (proto && proto->option_compact_hud) ? "On" : "Off");
+
+            engine_ui_text(240.0f, 246.0f, option_line_a);
+            engine_ui_text(240.0f, 286.0f, option_line_b);
+            engine_ui_text(240.0f, 326.0f, option_line_c);
+            engine_ui_text(240.0f, 366.0f, option_line_d);
+            engine_ui_text(240.0f, 406.0f, option_line_e);
+        }
+        else if (scene == BANANA_POC_SCENE_SCENE_BROWSER)
+        {
+            static const char *k_proto_scenes[] = {
+                "Open World         (terrain + physics + player)",
+                "Physics Sandbox    (flat arena, spawn test)",
+                "AI Encounter       (pre-spawned AI actors)",
+                "Render Benchmark   (geometry stress test)",
+            };
+            int i = 0;
+            int browser_index = proto ? proto->scene_browser_index : 0;
+            engine_ui_text(220.0f, 140.0f, "Scene Browser");
+            engine_ui_text(220.0f, 172.0f, "Up/Down select, Enter launch, Esc back");
+            for (i = 0; i < 4; i++)
+            {
+                char row[160];
+                snprintf(row, sizeof(row), "%s %s",
+                         (i == browser_index) ? ">" : " ",
+                         k_proto_scenes[i]);
+                engine_ui_text(240.0f, 230.0f + ((float)i * 40.0f), row);
+            }
+        }
+        else if (scene == BANANA_POC_SCENE_CONFIG_LAB)
+        {
+            static const char *k_seed_labels[]  = { "Default", "42", "1337", "99" };
+            static const char *k_fcap_labels[]  = { "30 FPS", "60 FPS", "120 FPS", "Uncapped" };
+            char lab_line_a[160];
+            char lab_line_b[160];
+            char lab_line_c[160];
+            char lab_line_d[160];
+            int lab_index    = proto ? proto->config_lab_index     : 0;
+            int dbg_overlay  = proto ? proto->render_debug_overlay : 0;
+            int phys_wire    = proto ? proto->physics_wireframe    : 0;
+            int seed_idx     = proto ? proto->world_seed_index     : 0;
+            int fcap_idx     = proto ? proto->frame_cap_index      : 0;
+            engine_ui_text(220.0f, 140.0f, "Config Lab");
+            engine_ui_text(220.0f, 172.0f, "Up/Down select, Left/Right/Enter toggle, Esc back");
+            snprintf(lab_line_a, sizeof(lab_line_a),
+                     "%s Render Debug Overlay: %s",
+                     lab_index == 0 ? ">" : " ", dbg_overlay ? "On" : "Off");
+            snprintf(lab_line_b, sizeof(lab_line_b),
+                     "%s Physics Wireframe:    %s",
+                     lab_index == 1 ? ">" : " ", phys_wire ? "On" : "Off");
+            snprintf(lab_line_c, sizeof(lab_line_c),
+                     "%s World Seed:           %s",
+                     lab_index == 2 ? ">" : " ", k_seed_labels[seed_idx]);
+            snprintf(lab_line_d, sizeof(lab_line_d),
+                     "%s Frame Cap:            %s",
+                     lab_index == 3 ? ">" : " ", k_fcap_labels[fcap_idx]);
+            engine_ui_text(240.0f, 230.0f, lab_line_a);
+            engine_ui_text(240.0f, 270.0f, lab_line_b);
+            engine_ui_text(240.0f, 310.0f, lab_line_c);
+            engine_ui_text(240.0f, 350.0f, lab_line_d);
+        }
+
+        engine_ui_end_frame();
+        return;
+    }
+
+    has_player = engine_get_player_position(&player_x, &player_z);
+    has_target = engine_get_pbj_pickup_position(&target_x, &target_z);
+    if (has_player && has_target)
+    {
+        nav_dx = target_x - player_x;
+        nav_dz = target_z - player_z;
+        if (nav_dx > 0.20f)
+            hint_x = "D";
+        else if (nav_dx < -0.20f)
+            hint_x = "A";
+
+        if (nav_dz > 0.20f)
+            hint_z = "S";
+        else if (nav_dz < -0.20f)
+            hint_z = "W";
+    }
+
+    engine_ui_panel(12.0f, 12.0f, 760.0f, 94.0f, 0x0A1118C0u, 1.0f);
+    engine_ui_panel(12.0f, 112.0f, 420.0f, 92.0f, 0x121E28C0u, 1.0f);
+    engine_ui_panel(minimap_x, minimap_y, minimap_w, minimap_h, 0x1A2A22D0u, 1.0f);
+
+    snprintf(line_one,
+             sizeof(line_one),
+             scene == BANANA_POC_SCENE_LEVEL_EDITOR
+                 ? "BANANA DX12 POC | LEVEL EDITOR | WASD MOVE | E APPLY HEIGHT"
+                 : "BANANA DX12 POC | WASD MOVE | RIGHT-CLICK MOVE TARGET | ESC QUIT");
+
+    if (proto)
+    {
+        size_t used = strlen(line_one);
+        if (used < sizeof(line_one) - 1)
+        {
+            snprintf(line_one + used,
+                     sizeof(line_one) - used,
+                     " | VARIANT: %s",
+                     k_variant_names[proto->active_world_variant]);
+        }
+    }
+
+    if (startup_smoke_mode)
+    {
+        snprintf(line_two,
+                 sizeof(line_two),
+                 "MODE: STARTUP SMOKE (CI)  |  ELAPSED: %ds",
+                 elapsed_seconds);
+    }
+    else if (objective_collected)
+    {
+        snprintf(line_two,
+                 sizeof(line_two),
+                 "OBJECTIVE COMPLETE: PBJ PICKUP COLLECTED");
+    }
+    else if (objective_timeout_seconds <= 0)
+    {
+        snprintf(line_two,
+                 sizeof(line_two),
+                 "OBJECTIVE: COLLECT PBJ PICKUP  |  TIME LEFT: UNLIMITED");
+    }
+    else
+    {
+        snprintf(line_two,
+                 sizeof(line_two),
+                 "OBJECTIVE: COLLECT PBJ PICKUP  |  TIME LEFT: %ds",
+                 remaining_seconds);
+    }
+
+    snprintf(line_three,
+             sizeof(line_three),
+             "ENTITIES: %d  |  CLICKS: %d  |  TARGETS REACHED: %d",
+             engine_get_entity_count(),
+             engine_get_click_count(),
+             engine_get_target_reached_count());
+
+    if (has_player && has_target)
+    {
+        snprintf(line_four,
+                 sizeof(line_four),
+                 "PLAYER XZ: (%.2f, %.2f)  TARGET XZ: (%.2f, %.2f)",
+                 player_x,
+                 player_z,
+                 target_x,
+                 target_z);
+
+        if (proto && !proto->option_input_assist)
+        {
+            snprintf(line_five,
+                     sizeof(line_five),
+                     "INPUT ASSIST HINTS OFF  |  DELTA=(%.2f, %.2f)",
+                     nav_dx,
+                     nav_dz);
+        }
+        else
+        {
+            snprintf(line_five,
+                     sizeof(line_five),
+                     "NAV HINT: X -> %s  Z -> %s  DELTA=(%.2f, %.2f)",
+                     hint_x,
+                     hint_z,
+                     nav_dx,
+                     nav_dz);
+        }
+    }
+    else
+    {
+        snprintf(line_four,
+                 sizeof(line_four),
+                 "PLAYER/TARGET POSITION UNAVAILABLE");
+        snprintf(line_five,
+                 sizeof(line_five),
+                 "OBJECTIVE MAY ALREADY BE COLLECTED");
+    }
+
+    engine_ui_text(22.0f, 24.0f, line_one);
+    engine_ui_text(22.0f, 48.0f, line_two);
+    engine_ui_text(22.0f, 72.0f, line_three);
+    engine_ui_text(22.0f, 124.0f, line_four);
+    if (scene == BANANA_POC_SCENE_LEVEL_EDITOR)
+    {
+        char editor_line[160];
+        static const char *k_paint_mode_names[] = { "Sculpt", "Flatten", "Smooth" };
+        int brush = proto ? proto->level_editor_brush_radius : 1;
+        int mode = proto ? proto->level_editor_paint_mode : 0;
+        snprintf(editor_line,
+                 sizeof(editor_line),
+                 "EDITOR HEIGHT=%d | BRUSH=%d | MODE=%s | [ ] height | arrows brush/mode | E apply",
+                 editor_height,
+                 brush,
+                 k_paint_mode_names[mode]);
+        engine_ui_text(22.0f, 148.0f, editor_line);
+    }
+    else if (!(proto && proto->option_compact_hud))
+    {
+        engine_ui_text(22.0f, 148.0f, line_five);
+    }
+
+    if (proto && proto->render_debug_overlay)
+    {
+        char debug_line[160];
+        snprintf(debug_line,
+                 sizeof(debug_line),
+                 "DEBUG OVERLAY ON | seed=%d frame-cap=%d wire=%d input-assist=%d",
+                 proto->world_seed_index,
+                 proto->frame_cap_index,
+                 proto->physics_wireframe,
+                 proto->option_input_assist);
+        engine_ui_text(22.0f, 176.0f, debug_line);
+    }
+    engine_ui_text(minimap_x + 10.0f, minimap_y + 10.0f, "MINIMAP (TERRAIN + ACTORS)");
+
+    engine_ui_panel(minimap_x + 10.0f,
+                    minimap_y + 34.0f,
+                    minimap_w - 20.0f,
+                    minimap_h - 44.0f,
+                    0x1E5A2FD8u,
+                    1.0f);
+
+    if (has_player)
+    {
+        float px = (player_x / world_half_span);
+        float pz = (player_z / world_half_span);
+        float panel_w = minimap_w - 20.0f;
+        float panel_h = minimap_h - 44.0f;
+        float screen_x = (minimap_x + 10.0f) + ((px + 1.0f) * 0.5f) * panel_w;
+        float screen_y = (minimap_y + 34.0f) + ((pz + 1.0f) * 0.5f) * panel_h;
+
+        if (screen_x < (minimap_x + 10.0f))
+            screen_x = minimap_x + 10.0f;
+        if (screen_x > (minimap_x + minimap_w - 10.0f - marker_size * 2.0f))
+            screen_x = minimap_x + minimap_w - 10.0f - marker_size * 2.0f;
+        if (screen_y < (minimap_y + 34.0f))
+            screen_y = minimap_y + 34.0f;
+        if (screen_y > (minimap_y + minimap_h - 10.0f - marker_size * 2.0f))
+            screen_y = minimap_y + minimap_h - 10.0f - marker_size * 2.0f;
+
+        engine_ui_panel(screen_x,
+                        screen_y,
+                        marker_size * 2.0f,
+                        marker_size * 2.0f,
+                        0x44D46CFFu,
+                        1.0f);
+    }
+
+    if (has_target)
+    {
+        float tx = (target_x / world_half_span);
+        float tz = (target_z / world_half_span);
+        float panel_w = minimap_w - 20.0f;
+        float panel_h = minimap_h - 44.0f;
+        float screen_x = (minimap_x + 10.0f) + ((tx + 1.0f) * 0.5f) * panel_w;
+        float screen_y = (minimap_y + 34.0f) + ((tz + 1.0f) * 0.5f) * panel_h;
+
+        if (screen_x < (minimap_x + 10.0f))
+            screen_x = minimap_x + 10.0f;
+        if (screen_x > (minimap_x + minimap_w - 10.0f - marker_size * 2.0f))
+            screen_x = minimap_x + minimap_w - 10.0f - marker_size * 2.0f;
+        if (screen_y < (minimap_y + 34.0f))
+            screen_y = minimap_y + 34.0f;
+        if (screen_y > (minimap_y + minimap_h - 10.0f - marker_size * 2.0f))
+            screen_y = minimap_y + minimap_h - 10.0f - marker_size * 2.0f;
+
+        engine_ui_panel(screen_x,
+                        screen_y,
+                        marker_size * 2.0f,
+                        marker_size * 2.0f,
+                        0x4A8CFAFFu,
+                        1.0f);
+    }
+
+    engine_ui_inventory_panel((float)BANANA_POC_WIDTH - 16.0f, 12.0f);
+
+    engine_ui_end_frame();
+}

--- a/src/native/engine/win32_dx12_poc/scene_overlay.h
+++ b/src/native/engine/win32_dx12_poc/scene_overlay.h
@@ -1,0 +1,60 @@
+#ifndef BANANA_ENGINE_WIN32_DX12_POC_SCENE_OVERLAY_H
+#define BANANA_ENGINE_WIN32_DX12_POC_SCENE_OVERLAY_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define BANANA_POC_WIDTH 1280
+#define BANANA_POC_HEIGHT 720
+
+typedef enum BananaPocScene
+{
+    BANANA_POC_SCENE_MAIN_MENU      = 0,
+    BANANA_POC_SCENE_CHARACTER_SELECT = 1,
+    BANANA_POC_SCENE_WORLD          = 2,
+    BANANA_POC_SCENE_LEVEL_EDITOR   = 3,
+    BANANA_POC_SCENE_OPTIONS        = 4,
+    BANANA_POC_SCENE_SCENE_BROWSER  = 5,
+    BANANA_POC_SCENE_CONFIG_LAB     = 6,
+} BananaPocScene;
+
+/* Prototype/dev configuration state passed into the overlay renderer.
+   All fields default to 0 (safe/off) when zero-initialised. */
+typedef struct BananaPocProtoConfig
+{
+    int scene_browser_index;  /* cursor row in Scene Browser (0-3)  */
+    int config_lab_index;     /* cursor row in Config Lab   (0-3)   */
+    int character_loadout_index; /* 0=Balanced 1=Tank 2=Burst 3=Support */
+    int level_editor_brush_radius; /* 1..4 */
+    int level_editor_paint_mode;   /* 0=Sculpt 1=Flatten 2=Smooth */
+    int option_input_assist; /* option menu toggle */
+    int option_compact_hud;  /* option menu toggle */
+    int active_world_variant; /* current launched scene browser variant */
+    int render_debug_overlay; /* 0=off  1=on                        */
+    int physics_wireframe;    /* 0=off  1=on                        */
+    int world_seed_index;     /* 0=Default 1=42 2=1337 3=99         */
+    int frame_cap_index;      /* 0=30fps 1=60fps 2=120fps 3=Uncapped */
+} BananaPocProtoConfig;
+
+void banana_poc_render_scene_overlay(BananaPocScene scene,
+                                     int main_menu_index,
+                                     int character_index,
+                                     int class_index,
+                                     int option_index,
+                                     int auto_target_enabled,
+                                     int target_hotkey_enabled,
+                                     int telemetry_enabled,
+                                     int editor_height,
+                                     int elapsed_seconds,
+                                     int objective_timeout_seconds,
+                                     int objective_collected,
+                                     int startup_smoke_mode,
+                                     const BananaPocProtoConfig *proto);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/native/dx12_gameplay_click_lane_test.c
+++ b/tests/native/dx12_gameplay_click_lane_test.c
@@ -1,0 +1,144 @@
+#include "../../../src/native/engine/engine.h"
+#include "../../../src/native/engine/win32_dx12_poc/scene_flow.h"
+
+#include <math.h>
+#include <stdio.h>
+
+static int expect_int(const char *label, int actual, int expected)
+{
+    if (actual == expected)
+        return 1;
+
+    fprintf(stderr, "%s expected=%d actual=%d\n", label, expected, actual);
+    return 0;
+}
+
+int main(void)
+{
+    BananaPocSceneFlowState flow_state;
+    BananaPocSceneFlowInput flow_input;
+    BananaPocSceneFlowResult flow_result;
+    static const char *k_character_names[] = {
+        "DX12 Pilot",
+        "Vanguard One",
+        "Arcanist Flux",
+        "Ranger Echo",
+    };
+    float pickup_x = 0.0f;
+    float pickup_z = 0.0f;
+    float player_x = 0.0f;
+    float player_z = 0.0f;
+    int baseline_reached = 0;
+    int reached = 0;
+    int tick = 0;
+
+    if (!expect_int("engine init", engine_init(BANANA_POC_WIDTH, BANANA_POC_HEIGHT), 0))
+        return 1;
+
+    flow_state.scene = BANANA_POC_SCENE_MAIN_MENU;
+    flow_state.menu_index = 0;
+    flow_state.character_index = 0;
+    flow_state.class_index = 0;
+    flow_state.options_index = 0;
+    flow_state.level_editor_height = 2;
+
+    flow_input.escape_pressed = 0;
+    flow_input.menu_hotkey_pressed = 0;
+    flow_input.tab_pressed = 0;
+    flow_input.up_pressed = 0;
+    flow_input.down_pressed = 0;
+    flow_input.left_pressed = 0;
+    flow_input.right_pressed = 0;
+    flow_input.enter_pressed = 1;
+    flow_input.lower_edit_pressed = 0;
+    flow_input.raise_edit_pressed = 0;
+    flow_input.apply_edit_pressed = 0;
+
+    banana_poc_scene_flow_step(&flow_state, &flow_input, &flow_result);
+    if (!expect_int("entered world requested", flow_result.entered_world, 1))
+        return 1;
+
+    if (!expect_int("player upsert", engine_player_upsert("native-default-player",
+                                                           k_character_names[flow_state.character_index],
+                                                           "human",
+                                                           1) != 0 ? 1 : 0,
+                    1))
+        return 1;
+
+    (void)engine_player_build_set_class("native-default-player", flow_state.class_index);
+
+    if (!expect_int("initial tick", engine_tick(1.0f / 60.0f), 0))
+        return 1;
+
+    if (!expect_int("pickup exists", engine_get_pbj_pickup_position(&pickup_x, &pickup_z), 1))
+        return 1;
+    if (!expect_int("objective starts incomplete", engine_get_pbj_pickup_collected(), 0))
+        return 1;
+
+    baseline_reached = engine_get_target_reached_count();
+    if (!expect_int("center click accepted", engine_handle_right_click_normalized(0.0f, 0.0f), 1))
+        return 1;
+    if (!expect_int("target active", engine_get_has_move_target(), 1))
+        return 1;
+
+    for (tick = 0; tick < 900; tick++)
+    {
+        if (!expect_int("click lane tick", engine_tick(1.0f / 60.0f), 0))
+            return 1;
+
+        if (engine_get_pbj_pickup_collected())
+            break;
+
+        reached = engine_get_target_reached_count();
+        if (reached > baseline_reached)
+            break;
+    }
+
+    reached = engine_get_target_reached_count();
+    if (!expect_int("target reached incremented", reached > baseline_reached ? 1 : 0, 1))
+        return 1;
+
+    /* Continue movement using public input path until the pickup is collected. */
+    for (tick = 0; tick < 2400 && !engine_get_pbj_pickup_collected(); tick++)
+    {
+        float dx = 0.0f;
+        float dz = 0.0f;
+        float len = 0.0f;
+
+        if (!engine_get_player_position(&player_x, &player_z))
+            return 1;
+
+        dx = pickup_x - player_x;
+        dz = pickup_z - player_z;
+        len = sqrtf((dx * dx) + (dz * dz));
+
+        if (len > 0.001f)
+        {
+            engine_set_move_input(dx / len, dz / len);
+        }
+        else
+        {
+            engine_set_move_input(0.0f, 0.0f);
+        }
+
+        if (!expect_int("objective lane tick", engine_tick(1.0f / 60.0f), 0))
+            return 1;
+    }
+
+    engine_set_move_input(0.0f, 0.0f);
+
+    if (!expect_int("objective collected", engine_get_pbj_pickup_collected(), 1))
+    {
+        (void)engine_get_player_position(&player_x, &player_z);
+        fprintf(stderr,
+                "objective diagnostics: player=(%.2f,%.2f) pickup=(%.2f,%.2f)\n",
+                player_x,
+                player_z,
+                pickup_x,
+                pickup_z);
+        return 1;
+    }
+
+    engine_shutdown();
+    return 0;
+}

--- a/tests/native/dx12_gameplay_lane_test.c
+++ b/tests/native/dx12_gameplay_lane_test.c
@@ -1,0 +1,95 @@
+#include "../../../src/native/engine/engine.h"
+#include "../../../src/native/engine/win32_dx12_poc/scene_flow.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static int expect_int(const char *label, int actual, int expected)
+{
+    if (actual == expected)
+        return 1;
+
+    fprintf(stderr, "%s expected=%d actual=%d\n", label, expected, actual);
+    return 0;
+}
+
+int main(void)
+{
+    BananaPocSceneFlowState flow_state;
+    BananaPocSceneFlowInput flow_input;
+    BananaPocSceneFlowResult flow_result;
+    static const char *k_character_names[] = {
+        "DX12 Pilot",
+        "Vanguard One",
+        "Arcanist Flux",
+        "Ranger Echo",
+    };
+    float pickup_x = 0.0f;
+    float pickup_z = 0.0f;
+    int collected = 0;
+    int tick = 0;
+
+    if (!expect_int("engine init", engine_init(BANANA_POC_WIDTH, BANANA_POC_HEIGHT), 0))
+        return 1;
+
+    flow_state.scene = BANANA_POC_SCENE_MAIN_MENU;
+    flow_state.menu_index = 0;
+    flow_state.character_index = 0;
+    flow_state.class_index = 0;
+    flow_state.options_index = 0;
+    flow_state.level_editor_height = 2;
+
+    flow_input.escape_pressed = 0;
+    flow_input.menu_hotkey_pressed = 0;
+    flow_input.tab_pressed = 0;
+    flow_input.up_pressed = 0;
+    flow_input.down_pressed = 0;
+    flow_input.left_pressed = 0;
+    flow_input.right_pressed = 0;
+    flow_input.enter_pressed = 1;
+    flow_input.lower_edit_pressed = 0;
+    flow_input.raise_edit_pressed = 0;
+    flow_input.apply_edit_pressed = 0;
+
+    banana_poc_scene_flow_step(&flow_state, &flow_input, &flow_result);
+
+    if (!expect_int("entered world requested", flow_result.entered_world, 1))
+        return 1;
+    if (!expect_int("scene switched to world", flow_state.scene, BANANA_POC_SCENE_WORLD))
+        return 1;
+
+    if (!expect_int("player upsert", engine_player_upsert("native-default-player",
+                                                           k_character_names[flow_state.character_index],
+                                                           "human",
+                                                           1) != 0 ? 1 : 0,
+                    1))
+        return 1;
+
+    (void)engine_player_build_set_class("native-default-player", flow_state.class_index);
+
+    if (!expect_int("initial tick", engine_tick(1.0f / 60.0f), 0))
+        return 1;
+
+    if (!expect_int("pickup exists", engine_get_pbj_pickup_position(&pickup_x, &pickup_z), 1))
+        return 1;
+    if (!expect_int("objective starts incomplete", engine_get_pbj_pickup_collected(), 0))
+        return 1;
+
+    engine_player_set_transform("native-default-player", pickup_x, 1.55f, pickup_z, 1);
+
+    for (tick = 0; tick < 120; tick++)
+    {
+        if (!expect_int("tick after teleport", engine_tick(1.0f / 60.0f), 0))
+            return 1;
+
+        collected = engine_get_pbj_pickup_collected();
+        if (collected)
+            break;
+    }
+
+    if (!expect_int("objective collected", collected, 1))
+        return 1;
+
+    engine_shutdown();
+    return 0;
+}

--- a/tests/native/dx12_objective_policy_test.c
+++ b/tests/native/dx12_objective_policy_test.c
@@ -1,0 +1,85 @@
+#include "../../../src/native/engine/win32_dx12_poc/objective_policy.h"
+
+#include <stdio.h>
+
+static int expect_int(const char *label, int actual, int expected)
+{
+    if (actual == expected)
+        return 1;
+
+    fprintf(stderr, "%s expected=%d actual=%d\n", label, expected, actual);
+    return 0;
+}
+
+int main(void)
+{
+    BananaPocObjectivePolicy policy = {0};
+
+    banana_poc_objective_policy_init(&policy, 30);
+    if (!expect_int("init base timeout", policy.base_timeout_seconds, 30))
+        return 1;
+    if (!expect_int("init active timeout", policy.active_timeout_seconds, 30))
+        return 1;
+
+    banana_poc_objective_policy_apply_world_variant(&policy, 1);
+    if (!expect_int("variant 1 has no timeout", policy.active_timeout_seconds, 0))
+        return 1;
+
+    banana_poc_objective_policy_apply_world_variant(&policy, 2);
+    if (!expect_int("variant 2 restores base timeout", policy.active_timeout_seconds, 30))
+        return 1;
+
+    if (!expect_int("no timeout fail in startup smoke",
+                    banana_poc_objective_policy_should_fail_timeout(&policy,
+                                                                    1,
+                                                                    BANANA_POC_SCENE_WORLD,
+                                                                    0,
+                                                                    31),
+                    0))
+        return 1;
+
+    if (!expect_int("timeout triggers in world",
+                    banana_poc_objective_policy_should_fail_timeout(&policy,
+                                                                    0,
+                                                                    BANANA_POC_SCENE_WORLD,
+                                                                    0,
+                                                                    31),
+                    1))
+        return 1;
+
+    if (!expect_int("timeout ignored after objective",
+                    banana_poc_objective_policy_should_fail_timeout(&policy,
+                                                                    0,
+                                                                    BANANA_POC_SCENE_WORLD,
+                                                                    1,
+                                                                    31),
+                    0))
+        return 1;
+
+    if (!expect_int("first completion announces",
+                    banana_poc_objective_policy_on_objective_collected(&policy,
+                                                                        BANANA_POC_SCENE_WORLD,
+                                                                        1),
+                    1))
+        return 1;
+
+    if (!expect_int("completion clears timeout",
+                    policy.active_timeout_seconds,
+                    0))
+        return 1;
+
+    if (!expect_int("second completion does not announce",
+                    banana_poc_objective_policy_on_objective_collected(&policy,
+                                                                        BANANA_POC_SCENE_WORLD,
+                                                                        1),
+                    0))
+        return 1;
+
+    banana_poc_objective_policy_on_entered_world(&policy, 0);
+    if (!expect_int("enter world resets timeout from base",
+                    policy.active_timeout_seconds,
+                    30))
+        return 1;
+
+    return 0;
+}

--- a/tests/native/dx12_projection_policy_test.c
+++ b/tests/native/dx12_projection_policy_test.c
@@ -1,0 +1,129 @@
+#include "render/backend_dx12_projection_policy.h"
+
+#include <math.h>
+#include <stdio.h>
+
+static int expect_int(const char *label, int actual, int expected)
+{
+    if (actual == expected)
+        return 1;
+
+    fprintf(stderr, "%s expected=%d actual=%d\n", label, expected, actual);
+    return 0;
+}
+
+static int expect_float_in_range(const char *label, float value, float min_value, float max_value)
+{
+    if (value >= min_value && value <= max_value)
+        return 1;
+
+    fprintf(stderr,
+            "%s expected range=[%.4f, %.4f] actual=%.4f\n",
+            label,
+            min_value,
+            max_value,
+            value);
+    return 0;
+}
+
+static int expect_float_close(const char *label, float actual, float expected, float tolerance)
+{
+    float delta = fabsf(actual - expected);
+    if (delta <= tolerance)
+        return 1;
+
+    fprintf(stderr,
+            "%s expected=%.5f actual=%.5f delta=%.5f tolerance=%.5f\n",
+            label,
+            expected,
+            actual,
+            delta,
+            tolerance);
+    return 0;
+}
+
+int main(void)
+{
+    BananaDx12ProjectionCamera camera = {0};
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+    float depth = 0.0f;
+    float centered_x = 0.0f;
+
+    banana_dx12_projection_world_to_clip(NULL,
+                                         0.0f,
+                                         0.0f,
+                                         0.0f,
+                                         &x,
+                                         &y,
+                                         &z,
+                                         &depth);
+
+    if (!expect_float_in_range("default clip x", x, -1.25f, 1.25f))
+        return 1;
+    if (!expect_float_in_range("default clip y", y, -1.25f, 1.25f))
+        return 1;
+    if (!expect_float_in_range("default clip z", z, 0.02f, 0.98f))
+        return 1;
+    if (!expect_float_in_range("default depth", depth, 0.01f, 10000.0f))
+        return 1;
+
+    camera.eye[0] = 0.0f;
+    camera.eye[1] = 14.0f;
+    camera.eye[2] = -16.0f;
+    camera.target[0] = 0.0f;
+    camera.target[1] = 0.0f;
+    camera.target[2] = 0.0f;
+    camera.up[0] = 0.0f;
+    camera.up[1] = 1.0f;
+    camera.up[2] = 0.0f;
+    camera.fov_degrees = 52.0f;
+    camera.aspect = 1280.0f / 720.0f;
+    camera.valid = 1;
+
+    banana_dx12_projection_world_to_clip(&camera,
+                                         0.0f,
+                                         0.0f,
+                                         0.0f,
+                                         &x,
+                                         &y,
+                                         &z,
+                                         &depth);
+
+    if (!expect_float_close("origin center x", x, 0.0f, 0.10f))
+        return 1;
+    if (!expect_float_in_range("origin center y", y, -0.20f, 0.20f))
+        return 1;
+
+    camera.eye[0] = 10.0f;
+    camera.target[0] = 10.0f;
+
+    banana_dx12_projection_world_to_clip(&camera,
+                                         10.0f,
+                                         0.0f,
+                                         0.0f,
+                                         &centered_x,
+                                         &y,
+                                         &z,
+                                         &depth);
+
+    if (!expect_float_close("translated camera center x", centered_x, 0.0f, 0.10f))
+        return 1;
+
+    banana_dx12_projection_world_to_clip(&camera,
+                                         0.0f,
+                                         0.0f,
+                                         0.0f,
+                                         &x,
+                                         &y,
+                                         &z,
+                                         &depth);
+
+    if (!expect_int("off-center point should not remain centered",
+                    fabsf(x) > 0.10f ? 1 : 0,
+                    1))
+        return 1;
+
+    return 0;
+}

--- a/tests/native/dx12_scene_flow_test.c
+++ b/tests/native/dx12_scene_flow_test.c
@@ -1,0 +1,146 @@
+#include "../../../src/native/engine/win32_dx12_poc/scene_flow.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static void fail_test(const char *label, const char *message)
+{
+    fprintf(stderr, "FAIL %s: %s\n", label, message);
+    exit(1);
+}
+
+static void expect_int(const char *label, int actual, int expected)
+{
+    if (actual != expected)
+        fail_test(label, "unexpected value");
+}
+
+static BananaPocSceneFlowInput input_zero(void)
+{
+    BananaPocSceneFlowInput input;
+
+    input.escape_pressed = 0;
+    input.menu_hotkey_pressed = 0;
+    input.tab_pressed = 0;
+    input.up_pressed = 0;
+    input.down_pressed = 0;
+    input.left_pressed = 0;
+    input.right_pressed = 0;
+    input.enter_pressed = 0;
+    input.lower_edit_pressed = 0;
+    input.raise_edit_pressed = 0;
+    input.apply_edit_pressed = 0;
+
+    return input;
+}
+
+int main(void)
+{
+    BananaPocSceneFlowState state;
+    BananaPocSceneFlowResult result;
+    BananaPocSceneFlowInput input;
+
+    state.scene = BANANA_POC_SCENE_MAIN_MENU;
+    state.menu_index = 0;
+    state.character_index = 1;
+    state.class_index = 2;
+    state.options_index = 0;
+    state.level_editor_height = 2;
+    state.proto_config.scene_browser_index = 0;
+    state.proto_config.config_lab_index = 0;
+    state.proto_config.character_loadout_index = 0;
+    state.proto_config.level_editor_brush_radius = 1;
+    state.proto_config.level_editor_paint_mode = 0;
+    state.proto_config.option_input_assist = 0;
+    state.proto_config.option_compact_hud = 0;
+    state.proto_config.active_world_variant = 0;
+    state.proto_config.render_debug_overlay = 0;
+    state.proto_config.physics_wireframe = 0;
+    state.proto_config.world_seed_index = 0;
+    state.proto_config.frame_cap_index = 0;
+
+    input = input_zero();
+    input.down_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("main menu down", state.menu_index, 1);
+    expect_int("main menu profile dirty", result.profile_dirty, 1);
+
+    input = input_zero();
+    input.enter_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("main menu to character select", state.scene, BANANA_POC_SCENE_CHARACTER_SELECT);
+    expect_int("main menu enter world", result.entered_world, 0);
+
+    input = input_zero();
+    input.right_pressed = 1;
+    input.down_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("character select character", state.character_index, 2);
+    expect_int("character select class", state.class_index, 2);
+    expect_int("character select dirty", result.profile_dirty, 1);
+
+    input = input_zero();
+    input.tab_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("character select loadout", state.proto_config.character_loadout_index, 1);
+
+    input = input_zero();
+    input.enter_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("character select to world", state.scene, BANANA_POC_SCENE_WORLD);
+    expect_int("character select confirmed", result.character_selection_confirmed, 1);
+    expect_int("character select entered world", result.entered_world, 1);
+
+    input = input_zero();
+    input.menu_hotkey_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("world menu hotkey", state.scene, BANANA_POC_SCENE_MAIN_MENU);
+
+    state.scene = BANANA_POC_SCENE_OPTIONS;
+    state.options_index = 1;
+    input = input_zero();
+    input.left_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("options toggle flag", result.options_toggled, 1);
+    expect_int("options dirty", result.profile_dirty, 1);
+
+    state.options_index = 4;
+    input = input_zero();
+    input.up_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("options navigation expanded", state.options_index, 3);
+
+    state.scene = BANANA_POC_SCENE_LEVEL_EDITOR;
+    state.level_editor_height = 2;
+    input = input_zero();
+    input.up_pressed = 1;
+    input.right_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("editor brush radius", state.proto_config.level_editor_brush_radius, 2);
+    expect_int("editor paint mode", state.proto_config.level_editor_paint_mode, 1);
+
+    input = input_zero();
+    input.raise_edit_pressed = 1;
+    input.apply_edit_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("editor height", state.level_editor_height, 3);
+    expect_int("editor height dirty", result.editor_height_changed, 1);
+    expect_int("editor apply", result.editor_apply_requested, 1);
+
+    state.scene = BANANA_POC_SCENE_SCENE_BROWSER;
+    state.proto_config.scene_browser_index = 2;
+    input = input_zero();
+    input.enter_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("scene browser to world", state.scene, BANANA_POC_SCENE_WORLD);
+    expect_int("scene browser result flag", result.entered_scene_browser_scene, 1);
+    expect_int("scene browser variant", result.scene_browser_variant, 2);
+
+    input = input_zero();
+    input.escape_pressed = 1;
+    banana_poc_scene_flow_step(&state, &input, &result);
+    expect_int("escape back to menu", state.scene, BANANA_POC_SCENE_MAIN_MENU);
+
+    puts("scene flow ok");
+    return 0;
+}

--- a/tests/native/dx12_scene_overlay_frame_test.c
+++ b/tests/native/dx12_scene_overlay_frame_test.c
@@ -1,0 +1,191 @@
+#include "../../../src/native/engine/engine.h"
+#include "../../../src/native/engine/win32_dx12_poc/scene_overlay.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define BANANA_POC_TEST_WIDTH 1280
+#define BANANA_POC_TEST_HEIGHT 720
+
+static void fail_test(const char *label, const char *message)
+{
+    fprintf(stderr, "FAIL %s: %s\n", label, message);
+    exit(1);
+}
+
+static void expect_nonzero_u64(const char *label, uint64_t value)
+{
+    if (value == 0)
+        fail_test(label, "expected non-zero hash");
+}
+
+static void expect_distinct_u64(const char *label, uint64_t left, uint64_t right)
+{
+    if (left == right)
+        fail_test(label, "expected distinct frame hash");
+}
+
+static uint64_t fnv1a64(const unsigned char *bytes, size_t size)
+{
+    uint64_t hash = 1469598103934665603ULL;
+    size_t i = 0;
+
+    for (i = 0; i < size; i++)
+    {
+        hash ^= (uint64_t)bytes[i];
+        hash *= 1099511628211ULL;
+    }
+
+    return hash;
+}
+
+static uint64_t render_scene_hash(BananaPocScene scene,
+                                  int main_menu_index,
+                                  int character_index,
+                                  int class_index,
+                                  int option_index,
+                                  int auto_target_enabled,
+                                  int target_hotkey_enabled,
+                                  int telemetry_enabled,
+                                  int editor_height,
+                                  int elapsed_seconds,
+                                  int objective_timeout_seconds,
+                                  int objective_collected,
+                                  int startup_smoke_mode)
+{
+    const unsigned char *frame = NULL;
+
+    banana_poc_render_scene_overlay(scene,
+                                    main_menu_index,
+                                    character_index,
+                                    class_index,
+                                    option_index,
+                                    auto_target_enabled,
+                                    target_hotkey_enabled,
+                                    telemetry_enabled,
+                                    editor_height,
+                                    elapsed_seconds,
+                                    objective_timeout_seconds,
+                                    objective_collected,
+                                    startup_smoke_mode,
+                                    NULL);
+
+    frame = engine_ui_get_framebuffer();
+    if (!frame)
+        fail_test("framebuffer", "engine_ui_get_framebuffer returned NULL");
+
+    return fnv1a64(frame, (size_t)BANANA_POC_TEST_WIDTH * (size_t)BANANA_POC_TEST_HEIGHT * 4u);
+}
+
+int main(void)
+{
+    uint64_t main_menu_hash = 0;
+    uint64_t character_hash = 0;
+    uint64_t options_hash = 0;
+    uint64_t world_hash = 0;
+    uint64_t editor_hash = 0;
+
+    if (engine_init(BANANA_POC_TEST_WIDTH, BANANA_POC_TEST_HEIGHT) != 0)
+        fail_test("engine_init", "failed to initialize runtime");
+    if (engine_ui_init(BANANA_POC_TEST_WIDTH, BANANA_POC_TEST_HEIGHT) != 0)
+        fail_test("engine_ui_init", "failed to initialize UI");
+
+    main_menu_hash = render_scene_hash(BANANA_POC_SCENE_MAIN_MENU,
+                                       0,
+                                       0,
+                                       0,
+                                       0,
+                                       0,
+                                       0,
+                                       0,
+                                       2,
+                                       0,
+                                       0,
+                                       0,
+                                       0);
+    character_hash = render_scene_hash(BANANA_POC_SCENE_CHARACTER_SELECT,
+                                       0,
+                                       2,
+                                       1,
+                                       0,
+                                       0,
+                                       0,
+                                       0,
+                                       2,
+                                       0,
+                                       0,
+                                       0,
+                                       0);
+    options_hash = render_scene_hash(BANANA_POC_SCENE_OPTIONS,
+                                     0,
+                                     0,
+                                     0,
+                                     2,
+                                     1,
+                                     1,
+                                     0,
+                                     2,
+                                     0,
+                                     0,
+                                     0,
+                                     0);
+
+    if (engine_tick(0.016f) != 0)
+        fail_test("engine_tick", "runtime frame update failed");
+
+    world_hash = render_scene_hash(BANANA_POC_SCENE_WORLD,
+                                   0,
+                                   0,
+                                   0,
+                                   0,
+                                   1,
+                                   0,
+                                   1,
+                                   2,
+                                   1,
+                                   0,
+                                   0,
+                                   0);
+    editor_hash = render_scene_hash(BANANA_POC_SCENE_LEVEL_EDITOR,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    1,
+                                    3,
+                                    1,
+                                    0,
+                                    0,
+                                    0);
+
+    expect_nonzero_u64("main_menu_hash", main_menu_hash);
+    expect_nonzero_u64("character_hash", character_hash);
+    expect_nonzero_u64("options_hash", options_hash);
+    expect_nonzero_u64("world_hash", world_hash);
+    expect_nonzero_u64("editor_hash", editor_hash);
+
+    expect_distinct_u64("main_menu_vs_character", main_menu_hash, character_hash);
+    expect_distinct_u64("main_menu_vs_options", main_menu_hash, options_hash);
+    expect_distinct_u64("main_menu_vs_world", main_menu_hash, world_hash);
+    expect_distinct_u64("main_menu_vs_editor", main_menu_hash, editor_hash);
+    expect_distinct_u64("character_vs_options", character_hash, options_hash);
+    expect_distinct_u64("character_vs_world", character_hash, world_hash);
+    expect_distinct_u64("character_vs_editor", character_hash, editor_hash);
+    expect_distinct_u64("options_vs_world", options_hash, world_hash);
+    expect_distinct_u64("options_vs_editor", options_hash, editor_hash);
+    expect_distinct_u64("world_vs_editor", world_hash, editor_hash);
+
+    printf("scene hashes: main=%llu character=%llu options=%llu world=%llu editor=%llu\n",
+           (unsigned long long)main_menu_hash,
+           (unsigned long long)character_hash,
+           (unsigned long long)options_hash,
+           (unsigned long long)world_hash,
+           (unsigned long long)editor_hash);
+
+    engine_ui_shutdown();
+    engine_shutdown();
+    return 0;
+}

--- a/tests/native/runtime_camera_follow_policy_test.c
+++ b/tests/native/runtime_camera_follow_policy_test.c
@@ -1,0 +1,80 @@
+#include "runtime/camera_follow_policy.h"
+
+#include <math.h>
+#include <stdio.h>
+
+static int expect_int(const char *label, int actual, int expected)
+{
+    if (actual == expected)
+        return 1;
+
+    fprintf(stderr, "%s expected=%d actual=%d\n", label, expected, actual);
+    return 0;
+}
+
+static int expect_float(const char *label, float actual, float expected, float tolerance)
+{
+    float delta = fabsf(actual - expected);
+    if (delta <= tolerance)
+        return 1;
+
+    fprintf(stderr,
+            "%s expected=%.5f actual=%.5f delta=%.5f tolerance=%.5f\n",
+            label,
+            expected,
+            actual,
+            delta,
+            tolerance);
+    return 0;
+}
+
+int main(void)
+{
+    RuntimeCameraFollowPose pose = {0};
+    float player[3] = {2.5f, 0.7f, -4.0f};
+
+    if (!expect_int("null player rejected",
+                    runtime_camera_follow_policy_compute(NULL, 1280, 720, &pose),
+                    0))
+        return 1;
+
+    if (!expect_int("zero width rejected",
+                    runtime_camera_follow_policy_compute(player, 0, 720, &pose),
+                    0))
+        return 1;
+
+    if (!expect_int("null pose rejected",
+                    runtime_camera_follow_policy_compute(player, 1280, 720, NULL),
+                    0))
+        return 1;
+
+    if (!expect_int("valid pose accepted",
+                    runtime_camera_follow_policy_compute(player, 1280, 720, &pose),
+                    1))
+        return 1;
+
+    if (!expect_float("eye x", pose.eye[0], -7.5f, 0.001f))
+        return 1;
+    if (!expect_float("eye y", pose.eye[1], 14.2f, 0.001f))
+        return 1;
+    if (!expect_float("eye z", pose.eye[2], -14.0f, 0.001f))
+        return 1;
+
+    if (!expect_float("target x", pose.target[0], 2.5f, 0.001f))
+        return 1;
+    if (!expect_float("target y", pose.target[1], 2.05f, 0.001f))
+        return 1;
+    if (!expect_float("target z", pose.target[2], -4.0f, 0.001f))
+        return 1;
+
+    if (!expect_float("fov", pose.fov_degrees, 52.0f, 0.001f))
+        return 1;
+    if (!expect_float("near", pose.near_plane, 0.1f, 0.0001f))
+        return 1;
+    if (!expect_float("far", pose.far_plane, 1000.0f, 0.001f))
+        return 1;
+    if (!expect_float("aspect", pose.aspect, 1280.0f / 720.0f, 0.0001f))
+        return 1;
+
+    return 0;
+}

--- a/tests/native/runtime_engine_lifecycle_test.c
+++ b/tests/native/runtime_engine_lifecycle_test.c
@@ -1,5 +1,6 @@
 #include "runtime/engine_lifecycle.h"
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -87,6 +88,26 @@ int main(void)
         return 1;
     if (!expect_true("entity count after actors", world->entity_count == 10))
         return 1;
+
+    {
+        int saw_wide_spawn = 0;
+        for (int i = 1; i < world->entity_count; i++)
+        {
+            Entity *entity = world->entities[i];
+            if (!entity)
+                continue;
+            float radial = sqrtf((entity->position[0] * entity->position[0]) +
+                                 (entity->position[2] * entity->position[2]));
+            if (radial > 10.0f)
+            {
+                saw_wide_spawn = 1;
+                break;
+            }
+        }
+
+        if (!expect_true("actors distributed beyond starter zone", saw_wide_spawn == 1))
+            return 1;
+    }
 
     controllers[0] = (ControllerInstance *)calloc(1, sizeof(ControllerInstance));
     controllers[1] = (ControllerInstance *)calloc(1, sizeof(ControllerInstance));

--- a/tests/native/runtime_engine_tick_test.c
+++ b/tests/native/runtime_engine_tick_test.c
@@ -7,36 +7,42 @@ static int s_follow_calls = 0;
 static int s_gameplay_calls = 0;
 static int s_render_calls = 0;
 
-static int rebuild_ok(int max_chunks)
+static int rebuild_ok(void *context, int max_chunks)
 {
+    (void)context;
     (void)max_chunks;
     return 1;
 }
 
-static int rebuild_fail(int max_chunks)
+static int rebuild_fail(void *context, int max_chunks)
 {
+    (void)context;
     (void)max_chunks;
     return 0;
 }
 
-static void update_cb(float dt)
+static void update_cb(void *context, float dt)
 {
+    (void)context;
     (void)dt;
     s_update_calls += 1;
 }
 
-static void follow_cb(void)
+static void follow_cb(void *context)
 {
+    (void)context;
     s_follow_calls += 1;
 }
 
-static void gameplay_cb(void)
+static void gameplay_cb(void *context)
 {
+    (void)context;
     s_gameplay_calls += 1;
 }
 
-static void render_cb(void)
+static void render_cb(void *context)
 {
+    (void)context;
     s_render_calls += 1;
 }
 
@@ -78,6 +84,7 @@ int main(void)
                                                 NULL,
                                                 0,
                                                 1.0f / 60.0f,
+                                                NULL,
                                                 update_cb,
                                                 follow_cb,
                                                 NULL,
@@ -97,6 +104,7 @@ int main(void)
                                                 NULL,
                                                 0,
                                                 1.0f / 60.0f,
+                                                NULL,
                                                 update_cb,
                                                 follow_cb,
                                                 NULL,
@@ -116,6 +124,7 @@ int main(void)
                                                 NULL,
                                                 0,
                                                 1.0f / 60.0f,
+                                                NULL,
                                                 update_cb,
                                                 follow_cb,
                                                 NULL,

--- a/tests/native/terrain_chunks_test.c
+++ b/tests/native/terrain_chunks_test.c
@@ -137,6 +137,64 @@ void test_player_update(void)
     terrain_chunks_cleanup();
 }
 
+void test_origin_chunk_has_playable_land(void)
+{
+    terrain_chunks_init(12345, 64);
+
+    const TerrainChunk *chunk = terrain_chunks_get(0, 0);
+    ASSERT_NOT_NULL(chunk, "Origin chunk should exist");
+
+    if (chunk)
+    {
+        int land_tiles = 0;
+        int total_tiles = TERRAIN_CHUNK_SIZE * TERRAIN_CHUNK_SIZE;
+        for (int z = 0; z < TERRAIN_CHUNK_SIZE; z++)
+        {
+            for (int x = 0; x < TERRAIN_CHUNK_SIZE; x++)
+            {
+                if (chunk->biomes[z][x] != BIOME_WATER)
+                    land_tiles++;
+            }
+        }
+
+        ASSERT_EQ(land_tiles > (total_tiles / 2), 1,
+                  "Origin chunk should have majority non-water tiles");
+    }
+
+    terrain_chunks_cleanup();
+}
+
+void test_biome_variety_in_origin_neighborhood(void)
+{
+    terrain_chunks_init(12345, 64);
+
+    const TerrainChunk *chunk = terrain_chunks_get(0, 0);
+    ASSERT_NOT_NULL(chunk, "Origin chunk should exist for biome variety");
+
+    if (chunk)
+    {
+        int seen[BIOME_COUNT] = {0};
+        int unique = 0;
+
+        for (int z = 0; z < TERRAIN_CHUNK_SIZE; z++)
+        {
+            for (int x = 0; x < TERRAIN_CHUNK_SIZE; x++)
+            {
+                int biome = (int)chunk->biomes[z][x];
+                if (biome >= 0 && biome < BIOME_COUNT && !seen[biome])
+                {
+                    seen[biome] = 1;
+                    unique++;
+                }
+            }
+        }
+
+        ASSERT_EQ(unique >= 2, 1, "Origin chunk should contain multiple biome types");
+    }
+
+    terrain_chunks_cleanup();
+}
+
 int main(void)
 {
     printf("=== Terrain Chunks Tests ===\n\n");
@@ -148,6 +206,8 @@ int main(void)
     test_world_to_chunk_conversion();
     test_chunk_to_world_conversion();
     test_player_update();
+    test_origin_chunk_has_playable_land();
+    test_biome_variety_in_origin_neighborhood();
 
     printf("\n=== Results ===\n");
     printf("Passed: %d / %d\n", tests_passed, tests_run);


### PR DESCRIPTION
## Summary\n- extract runtime orchestration slices into bounded modules for player, terrain, and render tick responsibilities\n- split camera and dx12 projection behavior into dedicated policy modules\n- move win32 dx12 POC objective timeout/completion logic behind objective policy service\n- keep gameplay and scene behavior stable while reducing monolithic loop responsibilities\n\n## Validation\n- cmake --build out/v3-native --config Debug\n- ctest --test-dir out/v3-native -C Debug -R "banana_dx12_objective_policy_test|banana_dx12_projection_policy_test|banana_runtime_camera_follow_policy_test|banana_runtime_engine_tick_test|banana_engine_win32_dx12_poc_startup_smoke|banana_dx12_gameplay_lane_test|banana_dx12_gameplay_click_lane_test" --output-on-failure\n\n## Notes\n- continues Phase 13 work in docs/native-ddd-solid-refactor-plan.md with objective policy extraction now complete