### PR TITLE
feat(ui): scaffold session-room character menu and onboarding

### DIFF
--- a/src/typescript/react/src/lib/router.tsx
+++ b/src/typescript/react/src/lib/router.tsx
@@ -1,8 +1,10 @@
 import { createBrowserRouter, Navigate } from "react-router-dom";
 import { hasStoredAuthSession } from "@banana/ui";
+import { GameEnginePage } from "../pages/GameEnginePage";
 import { LoginPage } from "../pages/LoginPage";
 import { MarketingPage } from "../pages/MarketingPage";
 import { PlayerPortalPage } from "../pages/PlayerPortalPage";
+import { SessionRoomPage } from "../pages/SessionRoomPage";
 
 export const router = createBrowserRouter([
   {
@@ -14,11 +16,11 @@ export const router = createBrowserRouter([
   { path: "/login", element: <LoginPage /> },
   {
     path: "/session-room",
-    element: <Navigate to={hasStoredAuthSession() ? "/download" : "/login"} replace />,
+    element: hasStoredAuthSession() ? <SessionRoomPage /> : <Navigate to="/login" replace />,
   },
   {
     path: "/game-engine",
-    element: <Navigate to="/download" replace />,
+    element: hasStoredAuthSession() ? <GameEnginePage /> : <Navigate to="/login" replace />,
   },
   { path: "*", element: <Navigate to="/" replace /> },
 ]);

--- a/src/typescript/react/src/pages/SessionRoomPage.tsx
+++ b/src/typescript/react/src/pages/SessionRoomPage.tsx
@@ -1,0 +1,8 @@
+import { SessionRoomPage as SharedSessionRoomPage } from "@banana/ui";
+
+/**
+ * Compatibility wrapper for the shared local-client session room menu.
+ */
+export function SessionRoomPage() {
+  return <SharedSessionRoomPage />;
+}

--- a/src/typescript/shared/ui/src/auth/LoginPage.tsx
+++ b/src/typescript/shared/ui/src/auth/LoginPage.tsx
@@ -43,7 +43,7 @@ export function LoginPage() {
             window.history.replaceState({}, document.title, `${window.location.pathname}${window.location.search}`);
             setSessionReady(true);
             setStatus("authenticated");
-            window.location.replace("/download");
+            window.location.replace("/session-room");
             return;
         }
 
@@ -72,6 +72,13 @@ export function LoginPage() {
         clearStoredAuthSession();
         setSessionReady(false);
         setStatus("idle");
+    };
+
+    const handleOpenSessionRoom = () => {
+        if (typeof window === "undefined") {
+            return;
+        }
+        window.location.assign("/session-room");
     };
 
     return (
@@ -369,6 +376,26 @@ export function LoginPage() {
                         )}
 
                         <div style={{ display: "grid", gap: 12 }}>
+                            {sessionReady ? (
+                                <button
+                                    type="button"
+                                    onClick={handleOpenSessionRoom}
+                                    style={{
+                                        border: "none",
+                                        borderRadius: 18,
+                                        padding: "16px 18px",
+                                        background: "linear-gradient(135deg, #2563eb, #0f766e)",
+                                        color: "#ffffff",
+                                        fontSize: tokens.font.size.md,
+                                        fontWeight: tokens.font.weight.semibold,
+                                        cursor: "pointer",
+                                        boxShadow: "0 16px 30px rgba(37, 99, 235, 0.28)",
+                                    }}
+                                >
+                                    Open session room
+                                </button>
+                            ) : null}
+
                             <button
                                 type="button"
                                 onClick={handleSteamSignIn}

--- a/src/typescript/shared/ui/src/auth/SessionRoomPage.tsx
+++ b/src/typescript/shared/ui/src/auth/SessionRoomPage.tsx
@@ -1,0 +1,380 @@
+import {useEffect, useMemo, useState, type CSSProperties} from 'react';
+
+import {ErrorText} from '../components/ErrorText';
+import {tokens} from '../tokens';
+import {fetchGameAccountOverview, fetchPlayerAccount, fetchPlayerInsights, resolveApiBaseResolutionError, resolveApiBaseUrl, updatePlayerAccountProfile, type GameAccountOverviewResponse, type PlayerAccountResponse, type PlayerInsightsResponse,} from '../game-engine/api';
+import {ensureGameSessionBootstrap} from '../game-engine/sessionBootstrap';
+import {clearStoredAuthSession, readStoredAuthSession} from './session';
+
+type LoadState = 'idle' | 'loading' | 'ready' | 'error';
+
+function readProfileDisplayName(profile: Record<string, unknown>): string {
+  const raw = profile['displayName'];
+  if (typeof raw !== 'string') {
+    return '';
+  }
+  return raw.trim();
+}
+
+export function SessionRoomPage() {
+  const session = useMemo(() => readStoredAuthSession(), []);
+  const apiBaseError = resolveApiBaseResolutionError();
+  const apiBaseUrl = resolveApiBaseUrl();
+
+  const [loadState, setLoadState] = useState<LoadState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [launching, setLaunching] = useState(false);
+  const [onboardingSaving, setOnboardingSaving] = useState(false);
+
+  const [account, setAccount] = useState<PlayerAccountResponse | null>(null);
+  const [insights, setInsights] = useState<PlayerInsightsResponse | null>(null);
+  const [overview, setOverview] = useState<GameAccountOverviewResponse | null>(null);
+  const [displayNameInput, setDisplayNameInput] = useState('');
+
+  const needsOnboarding =
+      account ? readProfileDisplayName(account.profile).length === 0 : false;
+
+  useEffect(() => {
+    if (!session?.token) {
+      return;
+    }
+
+    if (apiBaseError) {
+      setLoadState('error');
+      setError(apiBaseError);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadState('loading');
+    setError(null);
+
+    Promise.all([
+      fetchPlayerAccount(apiBaseUrl, session.token),
+      fetchPlayerInsights(apiBaseUrl, session.token),
+      fetchGameAccountOverview(apiBaseUrl, session.token),
+    ])
+        .then(([accountPayload, insightsPayload, overviewPayload]) => {
+          if (cancelled) {
+            return;
+          }
+
+          setAccount(accountPayload);
+          setInsights(insightsPayload);
+          setOverview(overviewPayload);
+          setDisplayNameInput(readProfileDisplayName(accountPayload.profile));
+          setLoadState('ready');
+        })
+        .catch((cause: unknown) => {
+          if (cancelled) {
+            return;
+          }
+
+          setLoadState('error');
+          setError(cause instanceof Error ? cause.message : String(cause));
+        });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseError, apiBaseUrl, session?.token]);
+
+  const handleSignOut = () => {
+    clearStoredAuthSession();
+    sessionStorage.removeItem('banana-game-session');
+    window.location.assign('/login');
+  };
+
+  const handleLaunchGame = async () => {
+    if (!session?.token) {
+      setError('Steam login required before launching the game client.');
+      return;
+    }
+
+    setLaunching(true);
+    setError(null);
+
+    try {
+      const playerName =
+          displayNameInput.trim() ||
+          readProfileDisplayName(account?.profile ?? {}) ||
+          `steam-${(session.steamId || '').slice(-4) || 'player'}`;
+      const bootstrapped = await ensureGameSessionBootstrap({playerName});
+      if (bootstrapped.error) {
+        throw new Error(bootstrapped.error);
+      }
+
+      window.location.assign('/game-engine');
+    } catch (cause: unknown) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLaunching(false);
+    }
+  };
+
+  const handleOnboardingSubmit = async () => {
+    if (!session?.token || !account) {
+      return;
+    }
+
+    const displayName = displayNameInput.trim();
+    if (!displayName) {
+      setError('Enter a character name to finish onboarding.');
+      return;
+    }
+
+    setOnboardingSaving(true);
+    setError(null);
+
+    try {
+      const updated = await updatePlayerAccountProfile(
+          apiBaseUrl,
+          session.token,
+          account.version,
+          {
+            ...account.profile,
+            displayName,
+            onboardingCompletedAt: new Date().toISOString(),
+          },
+      );
+      setAccount(updated);
+      sessionStorage.removeItem('banana-game-session');
+    } catch (cause: unknown) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setOnboardingSaving(false);
+    }
+  };
+
+  if (!session?.token) {
+    return (
+      <main style={shellStyle}>
+        <section style={panelStyle}>
+          <h1 style={titleStyle}>Steam login required</h1>
+          <p style={bodyStyle}>
+            Sign in with Steam to load your production-backed character and world state.
+          </p>
+          <a href="/login" style={actionStyle}>Go to login</a>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main style={shellStyle}>
+      <section style={panelStyle}>
+        <div style={headerRowStyle}>
+          <div>
+            <p style={eyebrowStyle}>Local game client session room</p>
+            <h1 style={titleStyle}>Character menu and onboarding</h1>
+            <p style={bodyStyle}>
+              Steam-authenticated production data powers this local game-client menu.
+              Admin and operator controls stay out of this user-facing flow.
+            </p>
+          </div>
+          <div style={{display: 'grid', gap: 10}}>
+            <button type="button" onClick={handleLaunchGame} style={buttonPrimaryStyle} disabled={launching || loadState === 'loading'}>
+              {launching ? 'Launching game client...' : 'Launch game client'}
+            </button>
+            <button type="button" onClick={handleSignOut} style={buttonSecondaryStyle}>
+              Sign out
+            </button>
+          </div>
+        </div>
+
+        {loadState === 'loading' ? <p style={bodyStyle}>Loading character and world data...</p> : null}
+        {error ? <ErrorText>{error}</ErrorText> : null}
+
+        {loadState === 'ready' && account && insights && overview ? (
+          <div style={gridStyle}>
+            <article style={cardStyle}>
+              <h2 style={cardTitleStyle}>Character identity</h2>
+              <dl style={dlStyle}>
+                <div style={rowStyle}><dt style={dtStyle}>Steam ID</dt><dd style={ddStyle}>{overview.steamId}</dd></div>
+                <div style={rowStyle}><dt style={dtStyle}>Player GUID</dt><dd style={ddStyle}>{overview.playerGuid}</dd></div>
+                <div style={rowStyle}><dt style={dtStyle}>Display name</dt><dd style={ddStyle}>{readProfileDisplayName(account.profile) || 'Unassigned'}</dd></div>
+                <div style={rowStyle}><dt style={dtStyle}>Account status</dt><dd style={ddStyle}>{account.accountStatus}</dd></div>
+              </dl>
+            </article>
+
+            <article style={cardStyle}>
+              <h2 style={cardTitleStyle}>World state</h2>
+              <dl style={dlStyle}>
+                <div style={rowStyle}><dt style={dtStyle}>Mode</dt><dd style={ddStyle}>{overview.mode}</dd></div>
+                <div style={rowStyle}><dt style={dtStyle}>Entities</dt><dd style={ddStyle}>{overview.world.entityCount}</dd></div>
+                <div style={rowStyle}><dt style={dtStyle}>Last snapshot tick</dt><dd style={ddStyle}>{overview.world.lastSnapshotTick}</dd></div>
+                <div style={rowStyle}><dt style={dtStyle}>Session ID</dt><dd style={ddStyle}>{overview.sessionId}</dd></div>
+              </dl>
+            </article>
+
+            <article style={cardStyle}>
+              <h2 style={cardTitleStyle}>Progression snapshot</h2>
+              <dl style={dlStyle}>
+                <div style={rowStyle}><dt style={dtStyle}>Level</dt><dd style={ddStyle}>{insights.progressionSummary.level}</dd></div>
+                <div style={rowStyle}><dt style={dtStyle}>XP</dt><dd style={ddStyle}>{insights.progressionSummary.xp}</dd></div>
+                <div style={rowStyle}><dt style={dtStyle}>Distinct items</dt><dd style={ddStyle}>{insights.inventoryTrendSummary.distinctItems}</dd></div>
+                <div style={rowStyle}><dt style={dtStyle}>Build attack</dt><dd style={ddStyle}>{overview.buildStats.attack}</dd></div>
+              </dl>
+            </article>
+
+            <article style={cardStyle}>
+              <h2 style={cardTitleStyle}>New player onboarding</h2>
+              {needsOnboarding ? (
+                <>
+                  <p style={bodyStyle}>First login detected. Choose a character name to finish onboarding.</p>
+                  <input
+                    value={displayNameInput}
+                    onChange={(event) => setDisplayNameInput(event.target.value)}
+                    placeholder="Enter character name"
+                    style={inputStyle}
+                  />
+                  <button type="button" onClick={handleOnboardingSubmit} style={buttonPrimaryStyle} disabled={onboardingSaving}>
+                    {onboardingSaving ? 'Saving...' : 'Save character profile'}
+                  </button>
+                </>
+              ) : (
+                <p style={bodyStyle}>
+                  Onboarding complete. Your character profile is ready for launch.
+                </p>
+              )}
+            </article>
+          </div>
+        ) : null}
+      </section>
+    </main>
+  );
+}
+
+const shellStyle: CSSProperties = {
+  minHeight: '100dvh',
+  padding: '36px 20px',
+  display: 'grid',
+  placeItems: 'center',
+  background:
+      'radial-gradient(circle at 10% 12%, rgba(56, 189, 248, 0.16), transparent 32%), radial-gradient(circle at 86% 18%, rgba(250, 204, 21, 0.18), transparent 36%), linear-gradient(160deg, #050816 0%, #0b1327 54%, #111f3f 100%)',
+  color: '#f8fafc',
+};
+
+const panelStyle: CSSProperties = {
+  width: 'min(100%, 1160px)',
+  borderRadius: 24,
+  border: '1px solid rgba(148, 163, 184, 0.24)',
+  padding: 28,
+  background: 'rgba(8, 12, 27, 0.76)',
+  boxShadow: '0 24px 90px rgba(2, 6, 23, 0.52)',
+};
+
+const headerRowStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: 18,
+  flexWrap: 'wrap',
+};
+
+const eyebrowStyle: CSSProperties = {
+  margin: 0,
+  textTransform: 'uppercase',
+  letterSpacing: '0.13em',
+  color: '#7dd3fc',
+  fontWeight: tokens.font.weight.semibold,
+  fontSize: tokens.font.size.xs,
+};
+
+const titleStyle: CSSProperties = {
+  margin: '12px 0 8px',
+  fontSize: 'clamp(2rem, 4vw, 3rem)',
+  lineHeight: 1,
+};
+
+const bodyStyle: CSSProperties = {
+  margin: 0,
+  color: '#cbd5e1',
+  lineHeight: 1.6,
+};
+
+const actionStyle: CSSProperties = {
+  marginTop: 18,
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '12px 16px',
+  borderRadius: 12,
+  textDecoration: 'none',
+  color: '#fff',
+  fontWeight: 700,
+  background: 'linear-gradient(135deg, #2563eb, #0891b2)',
+};
+
+const buttonPrimaryStyle: CSSProperties = {
+  border: '1px solid rgba(59, 130, 246, 0.34)',
+  borderRadius: 12,
+  padding: '10px 14px',
+  background: 'linear-gradient(135deg, #2563eb, #0f766e)',
+  color: '#eff6ff',
+  fontWeight: 700,
+  cursor: 'pointer',
+};
+
+const buttonSecondaryStyle: CSSProperties = {
+  border: '1px solid rgba(148, 163, 184, 0.34)',
+  borderRadius: 12,
+  padding: '10px 14px',
+  background: 'rgba(15, 23, 42, 0.82)',
+  color: '#e2e8f0',
+  fontWeight: 600,
+  cursor: 'pointer',
+};
+
+const gridStyle: CSSProperties = {
+  marginTop: 24,
+  display: 'grid',
+  gap: 14,
+  gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
+};
+
+const cardStyle: CSSProperties = {
+  borderRadius: 16,
+  border: '1px solid rgba(148, 163, 184, 0.22)',
+  background: 'rgba(15, 23, 42, 0.58)',
+  padding: 16,
+  display: 'grid',
+  gap: 10,
+};
+
+const cardTitleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: 18,
+};
+
+const dlStyle: CSSProperties = {
+  margin: 0,
+  display: 'grid',
+  gap: 10,
+};
+
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: 10,
+};
+
+const dtStyle: CSSProperties = {
+  color: '#94a3b8',
+};
+
+const ddStyle: CSSProperties = {
+  margin: 0,
+  color: '#f8fafc',
+  fontWeight: 600,
+  maxWidth: '65%',
+  textAlign: 'right',
+  wordBreak: 'break-word',
+};
+
+const inputStyle: CSSProperties = {
+  borderRadius: 12,
+  border: '1px solid rgba(148, 163, 184, 0.35)',
+  background: 'rgba(2, 6, 23, 0.72)',
+  color: '#f8fafc',
+  padding: '10px 12px',
+  fontSize: tokens.font.size.md,
+};

--- a/src/typescript/shared/ui/src/game-engine/api.ts
+++ b/src/typescript/shared/ui/src/game-engine/api.ts
@@ -44,6 +44,35 @@ export type GameSessionSnapshotEnvelope = {
   server?: GameSessionServerMetrics;
 };
 
+export type PlayerAccountResponse = {
+  playerId: string;
+  accountStatus: string;
+  profile: Record<string, unknown>;
+  version: number;
+  updatedAt: string;
+};
+
+export type PlayerInsightsResponse = {
+  playerId: string;
+  sessionSummary: {changeEvents: number; latestAction: string | null;};
+  progressionSummary: {xp: number; level: number;};
+  inventoryTrendSummary: {distinctItems: number; totalQuantity: number;};
+  noData: boolean;
+  freshnessTimestamp: string;
+};
+
+export type GameAccountOverviewResponse = {
+  steamId: string;
+  playerGuid: string;
+  sessionId: string;
+  buildStats: {health: number; attack: number; defense: number; utility: number;};
+  replayCursor: {lastTick: number; lastSequence: number;};
+  antiCheat: {score: number; flagged: boolean; integrityHash: number;};
+  world: {entityCount: number; lastSnapshotTick: number;};
+  workflows: {totalEvents: number; recent: Array<Record<string, unknown>>;};
+  mode: string;
+};
+
 type ElectronBridge = {
   apiBaseUrl: string;
 };
@@ -246,24 +275,39 @@ async function requestJson<T>(
   return (await response.json()) as T;
 }
 
+function withBearerAuth(token: string): Record<string, string> {
+  return {authorization: `Bearer ${token}`};
+}
+
 export async function startGameSession(
     baseUrl: string, playerName: string,
-    playerGuid: string): Promise<GameSessionBootstrap> {
+    playerGuid: string, token?: string): Promise<GameSessionBootstrap> {
+  const headers: Record<string, string> = {'content-type': 'application/json'};
+  if (token?.trim()) {
+    headers.authorization = `Bearer ${token.trim()}`;
+  }
+
   return requestJson<GameSessionBootstrap>(
       resolveGameplayApiBaseUrl(baseUrl), '/api/game/session/start', {
         method: 'POST',
-        headers: {'content-type': 'application/json'},
+        headers,
         body: JSON.stringify({playerName, playerGuid}),
       });
 }
 
 export async function rejoinGameSession(
-    baseUrl: string, playerGuid: string): Promise<GameSessionBootstrap> {
+    baseUrl: string, playerGuid: string,
+    token?: string): Promise<GameSessionBootstrap> {
+  const headers: Record<string, string> = {'content-type': 'application/json'};
+  if (token?.trim()) {
+    headers.authorization = `Bearer ${token.trim()}`;
+  }
+
   const response =
       await requestJson<GameSessionBootstrap&{playerName?: string}>(
           resolveGameplayApiBaseUrl(baseUrl), '/api/game/session/rejoin', {
             method: 'POST',
-            headers: {'content-type': 'application/json'},
+            headers,
             body: JSON.stringify({playerGuid}),
           });
 
@@ -273,4 +317,42 @@ export async function rejoinGameSession(
     playerName: response.playerName ?? 'player',
     playerGuid,
   };
+}
+
+export async function fetchPlayerAccount(
+    baseUrl: string, token: string): Promise<PlayerAccountResponse> {
+  return requestJson<PlayerAccountResponse>(baseUrl, '/v1/player/account', {
+    method: 'GET',
+    headers: withBearerAuth(token),
+  });
+}
+
+export async function updatePlayerAccountProfile(
+    baseUrl: string, token: string, expectedVersion: number,
+    profilePatch: Record<string, unknown>): Promise<PlayerAccountResponse> {
+  return requestJson<PlayerAccountResponse>(baseUrl, '/v1/player/account', {
+    method: 'PATCH',
+    headers: {
+      'content-type': 'application/json',
+      ...withBearerAuth(token),
+    },
+    body: JSON.stringify({expectedVersion, profilePatch}),
+  });
+}
+
+export async function fetchPlayerInsights(
+    baseUrl: string, token: string): Promise<PlayerInsightsResponse> {
+  return requestJson<PlayerInsightsResponse>(baseUrl, '/v1/player/insights', {
+    method: 'GET',
+    headers: withBearerAuth(token),
+  });
+}
+
+export async function fetchGameAccountOverview(
+    baseUrl: string, token: string): Promise<GameAccountOverviewResponse> {
+  return requestJson<GameAccountOverviewResponse>(
+      resolveGameplayApiBaseUrl(baseUrl), '/api/game/account/overview', {
+        method: 'GET',
+        headers: withBearerAuth(token),
+      });
 }

--- a/src/typescript/shared/ui/src/game-engine/sessionBootstrap.ts
+++ b/src/typescript/shared/ui/src/game-engine/sessionBootstrap.ts
@@ -1,12 +1,19 @@
 import {GAME_SESSION_STORAGE_KEY, type GameSessionBootstrap, rejoinGameSession, resolveApiBaseResolutionError, resolveApiBaseUrl, resolveRuntimePlayerGuid, startGameSession,} from './api';
+import {readStoredAuthSession} from '../auth/session';
 
 export type SessionBootstrapResult = {
   bootstrap: GameSessionBootstrap|null; error: string | null;
 };
 
-export async function ensureGameSessionBootstrap():
+export type SessionBootstrapOptions = {
+  playerName?: string;
+};
+
+export async function ensureGameSessionBootstrap(
+    options: SessionBootstrapOptions = {}):
     Promise<SessionBootstrapResult> {
   const runtimePlayerGuid = resolveRuntimePlayerGuid();
+  const authSession = readStoredAuthSession();
 
   try {
     const stored = sessionStorage.getItem(GAME_SESSION_STORAGE_KEY);
@@ -34,13 +41,26 @@ export async function ensureGameSessionBootstrap():
   }
 
   const apiBaseUrl = resolveApiBaseUrl();
+  if (!authSession?.token) {
+    return {
+      bootstrap: null,
+      error: 'Steam login required. Sign in before launching the game client.',
+    };
+  }
+
+  const requestedPlayerName = (options.playerName ?? '').trim();
+  const fallbackPlayerName = requestedPlayerName ||
+      (authSession.steamId?.trim() ?
+           `steam-${authSession.steamId.trim().slice(-4)}` :
+           'player');
 
   try {
-    const rejoined = await rejoinGameSession(apiBaseUrl, runtimePlayerGuid);
+    const rejoined = await rejoinGameSession(
+        apiBaseUrl, runtimePlayerGuid, authSession.token);
     const normalized = {
       ...rejoined,
       playerGuid: runtimePlayerGuid,
-      playerName: rejoined.playerName || 'player',
+      playerName: rejoined.playerName || fallbackPlayerName,
     };
     sessionStorage.setItem(
         GAME_SESSION_STORAGE_KEY, JSON.stringify(normalized));
@@ -51,11 +71,13 @@ export async function ensureGameSessionBootstrap():
 
   try {
     const created =
-        await startGameSession(apiBaseUrl, 'player', runtimePlayerGuid);
+        await startGameSession(
+            apiBaseUrl, fallbackPlayerName, runtimePlayerGuid,
+            authSession.token);
     const normalized = {
       ...created,
       playerGuid: runtimePlayerGuid,
-      playerName: created.playerName || 'player',
+      playerName: created.playerName || fallbackPlayerName,
     };
     sessionStorage.setItem(
         GAME_SESSION_STORAGE_KEY, JSON.stringify(normalized));

--- a/src/typescript/shared/ui/src/index.ts
+++ b/src/typescript/shared/ui/src/index.ts
@@ -24,6 +24,7 @@ export * from './domains/PredictionDomain';
 export * from './domains/ReplicationDomain';
 export * from './domains/ViewportDomain';
 export {LoginPage} from './auth/LoginPage';
+export {SessionRoomPage} from './auth/SessionRoomPage';
 export {BANANA_AUTH_STEAM_ID_STORAGE_KEY, BANANA_AUTH_TOKEN_STORAGE_KEY, buildSteamAuthStartUrl, clearStoredAuthSession, hasStoredAuthSession, parseAuthCallbackHash, readStoredAuthSession, resolveLoginReturnToUrl, storeAuthSession,} from './auth/session';
 export {logoutAuthSession, validateAuthSession} from './auth/session';
 export {GameEnginePage} from './game-engine/GameEnginePage';


### PR DESCRIPTION
## Summary
- add a shared session-room menu page for local game client entry
- load production-backed Steam character/account/progression/world overview in the menu
- scaffold first-time player onboarding with display name capture and profile patch
- route authenticated users from login callback into /session-room
- gate /game-engine and /session-room routes on cached Steam auth
- make game session bootstrap auth-aware using stored Steam token

## Validation
- bun test src/auth/LoginPage.test.tsx src/auth/session.test.ts src/tokens.test.ts (shared/ui)
- bun test src/lib/router.test.tsx (react)
- bunx tsc -b (react)
- VS Code task: UI: smoke (v3)

## Notes
- this scaffolds menu and onboarding UX using production APIs while keeping admin/operator controls out of user-facing pages.
