### PR TITLE
Expand war reinforcement art suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Thumbs.db
 *.swp
 .idea/
 /artifacts/steam-build/dev-candidate/http-upload
+/artifacts/native/human-feedback/

--- a/src/native/engine/runtime/engine/gameplay_model_profile.c
+++ b/src/native/engine/runtime/engine/gameplay_model_profile.c
@@ -35,6 +35,24 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
             *out_tip_taper += 0.02f;
         }
 
+        if (strstr(model_id, "flank") != NULL)
+        {
+            *out_length_scale += 0.10f;
+            *out_curve_scale += 0.16f;
+        }
+        else if (strstr(model_id, "regroup") != NULL)
+        {
+            *out_radius_scale += 0.14f;
+            *out_curve_scale -= 0.18f;
+            *out_tip_taper += 0.03f;
+        }
+        else if (strstr(model_id, "envoy") != NULL)
+        {
+            *out_length_scale += 0.04f;
+            *out_curve_scale -= 0.26f;
+            *out_tip_taper += 0.06f;
+        }
+
         return 1;
     }
 
@@ -55,6 +73,24 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
         {
             *out_curve_scale -= 0.07f;
             *out_tip_taper += 0.03f;
+        }
+
+        if (strstr(model_id, "flank") != NULL)
+        {
+            *out_length_scale += 0.08f;
+            *out_curve_scale += 0.14f;
+        }
+        else if (strstr(model_id, "regroup") != NULL)
+        {
+            *out_radius_scale += 0.12f;
+            *out_curve_scale -= 0.16f;
+            *out_tip_taper += 0.02f;
+        }
+        else if (strstr(model_id, "envoy") != NULL)
+        {
+            *out_length_scale += 0.03f;
+            *out_curve_scale -= 0.20f;
+            *out_tip_taper += 0.05f;
         }
 
         return 1;

--- a/src/native/engine/runtime/engine/gameplay_service.c
+++ b/src/native/engine/runtime/engine/gameplay_service.c
@@ -87,11 +87,53 @@ static const char *k_banana_apex_models[] = {
     "gameplay/war/banana-phalanx-volcanic-v1",
 };
 
+static const char *k_banana_apex_flank_models[] = {
+    "gameplay/war/banana-phalanx-flank-tropical-v1",
+    "gameplay/war/banana-phalanx-flank-glacier-v1",
+    "gameplay/war/banana-phalanx-flank-urban-v1",
+    "gameplay/war/banana-phalanx-flank-volcanic-v1",
+};
+
+static const char *k_banana_apex_regroup_models[] = {
+    "gameplay/war/banana-phalanx-regroup-tropical-v1",
+    "gameplay/war/banana-phalanx-regroup-glacier-v1",
+    "gameplay/war/banana-phalanx-regroup-urban-v1",
+    "gameplay/war/banana-phalanx-regroup-volcanic-v1",
+};
+
+static const char *k_banana_apex_negotiate_models[] = {
+    "gameplay/war/banana-phalanx-envoy-tropical-v1",
+    "gameplay/war/banana-phalanx-envoy-glacier-v1",
+    "gameplay/war/banana-phalanx-envoy-urban-v1",
+    "gameplay/war/banana-phalanx-envoy-volcanic-v1",
+};
+
 static const char *k_bean_apex_models[] = {
     "gameplay/war/bean-colossus-tropical-v1",
     "gameplay/war/bean-colossus-glacier-v1",
     "gameplay/war/bean-colossus-urban-v1",
     "gameplay/war/bean-colossus-volcanic-v1",
+};
+
+static const char *k_bean_apex_flank_models[] = {
+    "gameplay/war/bean-colossus-flank-tropical-v1",
+    "gameplay/war/bean-colossus-flank-glacier-v1",
+    "gameplay/war/bean-colossus-flank-urban-v1",
+    "gameplay/war/bean-colossus-flank-volcanic-v1",
+};
+
+static const char *k_bean_apex_regroup_models[] = {
+    "gameplay/war/bean-colossus-regroup-tropical-v1",
+    "gameplay/war/bean-colossus-regroup-glacier-v1",
+    "gameplay/war/bean-colossus-regroup-urban-v1",
+    "gameplay/war/bean-colossus-regroup-volcanic-v1",
+};
+
+static const char *k_bean_apex_negotiate_models[] = {
+    "gameplay/war/bean-colossus-envoy-tropical-v1",
+    "gameplay/war/bean-colossus-envoy-glacier-v1",
+    "gameplay/war/bean-colossus-envoy-urban-v1",
+    "gameplay/war/bean-colossus-envoy-volcanic-v1",
 };
 
 static const char *k_banana_mythic_models[] = {
@@ -101,11 +143,53 @@ static const char *k_banana_mythic_models[] = {
     "gameplay/war/banana-archon-volcanic-v1",
 };
 
+static const char *k_banana_mythic_flank_models[] = {
+    "gameplay/war/banana-archon-flank-tropical-v1",
+    "gameplay/war/banana-archon-flank-glacier-v1",
+    "gameplay/war/banana-archon-flank-urban-v1",
+    "gameplay/war/banana-archon-flank-volcanic-v1",
+};
+
+static const char *k_banana_mythic_regroup_models[] = {
+    "gameplay/war/banana-archon-regroup-tropical-v1",
+    "gameplay/war/banana-archon-regroup-glacier-v1",
+    "gameplay/war/banana-archon-regroup-urban-v1",
+    "gameplay/war/banana-archon-regroup-volcanic-v1",
+};
+
+static const char *k_banana_mythic_negotiate_models[] = {
+    "gameplay/war/banana-archon-envoy-tropical-v1",
+    "gameplay/war/banana-archon-envoy-glacier-v1",
+    "gameplay/war/banana-archon-envoy-urban-v1",
+    "gameplay/war/banana-archon-envoy-volcanic-v1",
+};
+
 static const char *k_bean_mythic_models[] = {
     "gameplay/war/bean-leviathan-tropical-v1",
     "gameplay/war/bean-leviathan-glacier-v1",
     "gameplay/war/bean-leviathan-urban-v1",
     "gameplay/war/bean-leviathan-volcanic-v1",
+};
+
+static const char *k_bean_mythic_flank_models[] = {
+    "gameplay/war/bean-leviathan-flank-tropical-v1",
+    "gameplay/war/bean-leviathan-flank-glacier-v1",
+    "gameplay/war/bean-leviathan-flank-urban-v1",
+    "gameplay/war/bean-leviathan-flank-volcanic-v1",
+};
+
+static const char *k_bean_mythic_regroup_models[] = {
+    "gameplay/war/bean-leviathan-regroup-tropical-v1",
+    "gameplay/war/bean-leviathan-regroup-glacier-v1",
+    "gameplay/war/bean-leviathan-regroup-urban-v1",
+    "gameplay/war/bean-leviathan-regroup-volcanic-v1",
+};
+
+static const char *k_bean_mythic_negotiate_models[] = {
+    "gameplay/war/bean-leviathan-envoy-tropical-v1",
+    "gameplay/war/bean-leviathan-envoy-glacier-v1",
+    "gameplay/war/bean-leviathan-envoy-urban-v1",
+    "gameplay/war/bean-leviathan-envoy-volcanic-v1",
 };
 
 typedef enum RuntimeWarReinforcementFamily
@@ -410,6 +494,92 @@ static RuntimeWarReinforcementVisualTier runtime_gameplay_reinforcement_visual_t
     return RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_BASE;
 }
 
+<<<<<<< HEAD
+=======
+static const char *runtime_gameplay_behavioral_elite_model_id_for_family(
+    RuntimeWarReinforcementFamily family,
+    RuntimeWarSentienceBehaviorMode behavior_mode,
+    RuntimeWarReinforcementVisualTier visual_tier,
+    int biome_index)
+{
+    if (visual_tier == RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_APEX)
+    {
+        if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SCOUT ||
+            family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SIEGE)
+        {
+            switch (behavior_mode)
+            {
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_FLANK:
+                    return k_banana_apex_flank_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_REGROUP:
+                    return k_banana_apex_regroup_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_NEGOTIATE:
+                    return k_banana_apex_negotiate_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_HOLD_LINE:
+                default:
+                    return k_banana_apex_models[biome_index];
+            }
+        }
+
+        if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_RAIDER ||
+            family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_WARBRUTE)
+        {
+            switch (behavior_mode)
+            {
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_FLANK:
+                    return k_bean_apex_flank_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_REGROUP:
+                    return k_bean_apex_regroup_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_NEGOTIATE:
+                    return k_bean_apex_negotiate_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_HOLD_LINE:
+                default:
+                    return k_bean_apex_models[biome_index];
+            }
+        }
+    }
+
+    if (visual_tier == RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_MYTHIC)
+    {
+        if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SCOUT ||
+            family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SIEGE)
+        {
+            switch (behavior_mode)
+            {
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_FLANK:
+                    return k_banana_mythic_flank_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_REGROUP:
+                    return k_banana_mythic_regroup_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_NEGOTIATE:
+                    return k_banana_mythic_negotiate_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_HOLD_LINE:
+                default:
+                    return k_banana_mythic_models[biome_index];
+            }
+        }
+
+        if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_RAIDER ||
+            family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_WARBRUTE)
+        {
+            switch (behavior_mode)
+            {
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_FLANK:
+                    return k_bean_mythic_flank_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_REGROUP:
+                    return k_bean_mythic_regroup_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_NEGOTIATE:
+                    return k_bean_mythic_negotiate_models[biome_index];
+                case RUNTIME_WAR_SENTIENCE_BEHAVIOR_HOLD_LINE:
+                default:
+                    return k_bean_mythic_models[biome_index];
+            }
+        }
+    }
+
+    return NULL;
+}
+
+>>>>>>> 2f31c9f (Expand war reinforcement art suite)
 static const char *runtime_gameplay_behavioral_skirmish_model_id_for_family(
     RuntimeWarReinforcementFamily family,
     RuntimeWarSentienceBehaviorMode behavior_mode,
@@ -460,6 +630,7 @@ static const char *runtime_gameplay_reinforcement_model_id_for_family(RuntimeWar
 {
     RuntimeWarReinforcementVisualTier visual_tier =
         runtime_gameplay_reinforcement_visual_tier_for_family(family, war_intelligence_stage);
+<<<<<<< HEAD
     if (visual_tier == RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_MYTHIC)
     {
         if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SIEGE ||
@@ -479,6 +650,26 @@ static const char *runtime_gameplay_reinforcement_model_id_for_family(RuntimeWar
             family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_RAIDER)
             return k_bean_apex_models[biome_index];
     }
+=======
+    const char *behavioral_model_id = NULL;
+
+    if (visual_tier == RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_BASE)
+    {
+        behavioral_model_id = runtime_gameplay_behavioral_skirmish_model_id_for_family(family,
+                                                                                        behavior_mode,
+                                                                                        biome_index);
+    }
+    else
+    {
+        behavioral_model_id = runtime_gameplay_behavioral_elite_model_id_for_family(family,
+                                                                                     behavior_mode,
+                                                                                     visual_tier,
+                                                                                     biome_index);
+    }
+
+    if (behavioral_model_id)
+        return behavioral_model_id;
+>>>>>>> 2f31c9f (Expand war reinforcement art suite)
 
     if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SCOUT ||
         family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_RAIDER)

--- a/src/native/engine/runtime/engine/gameplay_service.c
+++ b/src/native/engine/runtime/engine/gameplay_service.c
@@ -494,8 +494,6 @@ static RuntimeWarReinforcementVisualTier runtime_gameplay_reinforcement_visual_t
     return RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_BASE;
 }
 
-<<<<<<< HEAD
-=======
 static const char *runtime_gameplay_behavioral_elite_model_id_for_family(
     RuntimeWarReinforcementFamily family,
     RuntimeWarSentienceBehaviorMode behavior_mode,
@@ -579,7 +577,6 @@ static const char *runtime_gameplay_behavioral_elite_model_id_for_family(
     return NULL;
 }
 
->>>>>>> 2f31c9f (Expand war reinforcement art suite)
 static const char *runtime_gameplay_behavioral_skirmish_model_id_for_family(
     RuntimeWarReinforcementFamily family,
     RuntimeWarSentienceBehaviorMode behavior_mode,
@@ -630,27 +627,6 @@ static const char *runtime_gameplay_reinforcement_model_id_for_family(RuntimeWar
 {
     RuntimeWarReinforcementVisualTier visual_tier =
         runtime_gameplay_reinforcement_visual_tier_for_family(family, war_intelligence_stage);
-<<<<<<< HEAD
-    if (visual_tier == RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_MYTHIC)
-    {
-        if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SIEGE ||
-            family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SCOUT)
-            return k_banana_mythic_models[biome_index];
-        if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_WARBRUTE ||
-            family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_RAIDER)
-            return k_bean_mythic_models[biome_index];
-    }
-
-    if (visual_tier == RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_APEX)
-    {
-        if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SIEGE ||
-            family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SCOUT)
-            return k_banana_apex_models[biome_index];
-        if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_WARBRUTE ||
-            family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_RAIDER)
-            return k_bean_apex_models[biome_index];
-    }
-=======
     const char *behavioral_model_id = NULL;
 
     if (visual_tier == RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_BASE)
@@ -669,7 +645,6 @@ static const char *runtime_gameplay_reinforcement_model_id_for_family(RuntimeWar
 
     if (behavioral_model_id)
         return behavioral_model_id;
->>>>>>> 2f31c9f (Expand war reinforcement art suite)
 
     if (family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BANANA_SCOUT ||
         family == RUNTIME_WAR_REINFORCEMENT_FAMILY_BEAN_RAIDER)


### PR DESCRIPTION
Broadens war reinforcement art coverage by adding behavior-specific apex and mythic model IDs for banana and bean war units, and updates elite model profiling so flank, regroup, and envoy variants render with distinct silhouettes instead of falling back to generic high-tier art.

Validation:
- cmake -S src/native -B out/v3-native && cmake --build out/v3-native -- -m:1
- bash scripts/run-war-test-suites.sh --suite gameplay --intelligence-stage 5 --non-interactive
