### PR TITLE
Tune elite biome art profiles

### DIFF
--- a/src/native/engine/runtime/engine/gameplay_model_profile.c
+++ b/src/native/engine/runtime/engine/gameplay_model_profile.c
@@ -63,6 +63,17 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
             *out_tip_taper += 0.06f;
         }
 
+        if (strstr(model_id, "banana-") != NULL)
+        {
+            *out_length_scale += 0.05f;
+            *out_curve_scale += 0.03f;
+        }
+        else if (strstr(model_id, "bean-") != NULL)
+        {
+            *out_radius_scale += 0.05f;
+            *out_tip_taper += 0.02f;
+        }
+
         return 1;
     }
 
@@ -113,6 +124,17 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
             *out_tip_taper += 0.05f;
         }
 
+        if (strstr(model_id, "banana-") != NULL)
+        {
+            *out_length_scale += 0.04f;
+            *out_curve_scale += 0.02f;
+        }
+        else if (strstr(model_id, "bean-") != NULL)
+        {
+            *out_radius_scale += 0.04f;
+            *out_tip_taper += 0.02f;
+        }
+
         return 1;
     }
 
@@ -145,6 +167,35 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
         {
             *out_curve_scale += 0.06f;
             *out_tip_taper += 0.02f;
+        }
+
+        if (strstr(model_id, "banana-") != NULL)
+        {
+            *out_length_scale += 0.04f;
+            *out_curve_scale += 0.02f;
+        }
+        else if (strstr(model_id, "bean-") != NULL)
+        {
+            *out_radius_scale += 0.06f;
+            *out_tip_taper += 0.02f;
+        }
+
+        if (strstr(model_id, "flank") != NULL)
+        {
+            *out_length_scale += 0.08f;
+            *out_curve_scale += 0.13f;
+        }
+        else if (strstr(model_id, "regroup") != NULL)
+        {
+            *out_radius_scale += 0.12f;
+            *out_curve_scale -= 0.14f;
+            *out_tip_taper += 0.02f;
+        }
+        else if (strstr(model_id, "envoy") != NULL)
+        {
+            *out_length_scale += 0.03f;
+            *out_curve_scale -= 0.19f;
+            *out_tip_taper += 0.04f;
         }
 
         return 1;

--- a/src/native/engine/runtime/engine/gameplay_model_profile.c
+++ b/src/native/engine/runtime/engine/gameplay_model_profile.c
@@ -34,6 +34,16 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
             *out_curve_scale -= 0.06f;
             *out_tip_taper += 0.02f;
         }
+        else if (strstr(model_id, "urban") != NULL)
+        {
+            *out_length_scale += 0.06f;
+            *out_curve_scale -= 0.04f;
+        }
+        else if (strstr(model_id, "tropical") != NULL)
+        {
+            *out_curve_scale += 0.08f;
+            *out_tip_taper += 0.02f;
+        }
 
         if (strstr(model_id, "flank") != NULL)
         {
@@ -73,6 +83,16 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
         {
             *out_curve_scale -= 0.07f;
             *out_tip_taper += 0.03f;
+        }
+        else if (strstr(model_id, "urban") != NULL)
+        {
+            *out_length_scale += 0.05f;
+            *out_curve_scale -= 0.03f;
+        }
+        else if (strstr(model_id, "tropical") != NULL)
+        {
+            *out_curve_scale += 0.07f;
+            *out_tip_taper += 0.02f;
         }
 
         if (strstr(model_id, "flank") != NULL)
@@ -115,6 +135,16 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
         {
             *out_curve_scale -= 0.08f;
             *out_tip_taper += 0.03f;
+        }
+        else if (strstr(model_id, "urban") != NULL)
+        {
+            *out_length_scale += 0.04f;
+            *out_curve_scale -= 0.02f;
+        }
+        else if (strstr(model_id, "tropical") != NULL)
+        {
+            *out_curve_scale += 0.06f;
+            *out_tip_taper += 0.02f;
         }
 
         return 1;


### PR DESCRIPTION
Next batch of native war art enhancements focused on elite profile differentiation by biome.\n\nChanges:\n- Add urban/tropical tuning for archon/leviathan profiles.\n- Add urban/tropical tuning for phalanx/colossus profiles.\n- Add urban/tropical tuning for siege/warbrute/commander profiles.