### PR TITLE
Increase faction contrast in scout and bean silhouettes

### DIFF
--- a/src/native/engine/runtime/engine/gameplay_model_profile.c
+++ b/src/native/engine/runtime/engine/gameplay_model_profile.c
@@ -244,15 +244,38 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
             *out_tip_taper += 0.02f;
         }
 
+        if (has_banana_tag)
+        {
+            *out_length_scale += 0.08f;
+            *out_curve_scale += 0.06f;
+            *out_tip_taper -= 0.02f;
+        }
+        else if (has_bean_tag)
+        {
+            *out_radius_scale += 0.09f;
+            *out_curve_scale -= 0.08f;
+            *out_tip_taper += 0.04f;
+        }
+
         return 1;
     }
 
-    if (strstr(model_id, "banana-bean-green") != NULL || strstr(model_id, "bean") != NULL)
+    if (strstr(model_id, "banana-bean-green") != NULL)
     {
-        *out_radius_scale = 1.32f;
-        *out_length_scale = 0.72f;
-        *out_curve_scale = 0.62f;
-        *out_tip_taper = 0.22f;
+        *out_radius_scale = 1.26f;
+        *out_length_scale = 0.84f;
+        *out_curve_scale = 0.70f;
+        *out_tip_taper = 0.18f;
+        *out_quality = 3;
+        return 1;
+    }
+
+    if (strstr(model_id, "bean") != NULL)
+    {
+        *out_radius_scale = 1.38f;
+        *out_length_scale = 0.68f;
+        *out_curve_scale = 0.54f;
+        *out_tip_taper = 0.26f;
         *out_quality = 3;
         return 1;
     }


### PR DESCRIPTION
## Summary
- increase faction-specific silhouette contrast for scout and raider profiles
- make banana scout silhouettes longer and more curved, with slightly cleaner tips
- make bean scout silhouettes broader with flatter curves and heavier taper
- split baseline bean versus banana-bean-green profile tuning for clearer neutral asset differentiation

## Validation
- ctest -C Debug --test-dir out/v3-native -R banana_native_feedback_loop_factory_negotiate_smoke --output-on-failure (pass)
- note: full cmake regenerate in this worktree remains blocked by missing runtime/engine/demo_frame_export.c in src/native/engine/CMakeLists.txt
