### PR TITLE
Epic: add truce telemetry and threshold playloop checks

### DIFF
--- a/src/native/engine/runtime/engine/engine_state.h
+++ b/src/native/engine/runtime/engine/engine_state.h
@@ -123,6 +123,13 @@ typedef struct EngineRuntimeState
     RuntimeWarSentienceBehaviorMode war_sentience_behavior_bean;
     int war_sentience_spawn_mode_hits_banana[BANANA_ENGINE_WAR_SENTIENCE_MODE_COUNT];
     int war_sentience_spawn_mode_hits_bean[BANANA_ENGINE_WAR_SENTIENCE_MODE_COUNT];
+    int war_sentience_truce_variant_hits_total;
+    int war_sentience_truce_variant_hits_banana;
+    int war_sentience_truce_variant_hits_bean;
+    int war_sentience_truce_variant_hits_stage[BANANA_ENGINE_WAR_INTELLIGENCE_STAGE_BUCKETS];
+    int war_sentience_truce_variant_hits_base;
+    int war_sentience_truce_variant_hits_apex;
+    int war_sentience_truce_variant_hits_mythic;
     int war_sentience_negotiate_streak_ticks;
     int war_sentience_negotiate_deescalation_trim_last_tick;
     int war_sentience_comeback_bonus_last_tick;

--- a/src/native/engine/runtime/engine/gameplay_service.c
+++ b/src/native/engine/runtime/engine/gameplay_service.c
@@ -759,10 +759,13 @@ static void runtime_gameplay_record_war_reinforcement_spawn(EngineRuntimeState *
                                                             RuntimeWarReinforcementFamily family,
                                                             RuntimeWarSentienceBehaviorMode behavior_mode,
                                                             int war_intelligence_stage,
+                                                            int use_truce_variant,
                                                             int biome_index)
 {
     int stage_bucket = 0;
     int mode_index = 0;
+    RuntimeWarReinforcementVisualTier visual_tier =
+        runtime_gameplay_reinforcement_visual_tier_for_family(family, war_intelligence_stage);
 
     if (!runtime_state)
         return;
@@ -779,6 +782,24 @@ static void runtime_gameplay_record_war_reinforcement_spawn(EngineRuntimeState *
         runtime_state->war_sentience_spawn_mode_hits_banana[mode_index] += 1;
     else if (team == CONTROLLER_TEAM_BEAN)
         runtime_state->war_sentience_spawn_mode_hits_bean[mode_index] += 1;
+
+    if (use_truce_variant)
+    {
+        runtime_state->war_sentience_truce_variant_hits_total += 1;
+        runtime_state->war_sentience_truce_variant_hits_stage[stage_bucket] += 1;
+
+        if (team == CONTROLLER_TEAM_BANANA)
+            runtime_state->war_sentience_truce_variant_hits_banana += 1;
+        else if (team == CONTROLLER_TEAM_BEAN)
+            runtime_state->war_sentience_truce_variant_hits_bean += 1;
+
+        if (visual_tier == RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_MYTHIC)
+            runtime_state->war_sentience_truce_variant_hits_mythic += 1;
+        else if (visual_tier == RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_APEX)
+            runtime_state->war_sentience_truce_variant_hits_apex += 1;
+        else
+            runtime_state->war_sentience_truce_variant_hits_base += 1;
+    }
 
     switch (family)
     {
@@ -1148,6 +1169,7 @@ static int runtime_gameplay_spawn_war_reinforcement(World *world,
     EntityId entity_id = 0;
     Entity *entity = NULL;
     uint32_t controller_id = 0;
+    int use_truce_variant = 0;
 
     if (!world || !controllers || !inout_controller_count || max_controllers <= 0)
         return 0;
@@ -1173,10 +1195,9 @@ static int runtime_gameplay_spawn_war_reinforcement(World *world,
     }
     else
     {
-        const int use_truce_variant =
-            runtime_gameplay_should_use_truce_variant(runtime_state,
-                                                      behavior_mode,
-                                                      war_intelligence_stage);
+        use_truce_variant = runtime_gameplay_should_use_truce_variant(runtime_state,
+                                                                      behavior_mode,
+                                                                      war_intelligence_stage);
         gameplay_model_id = runtime_gameplay_reinforcement_model_id_for_family(family,
                                                                                 behavior_mode,
                                                                                 war_intelligence_stage,
@@ -1219,6 +1240,7 @@ static int runtime_gameplay_spawn_war_reinforcement(World *world,
                                                     family,
                                                     behavior_mode,
                                                     war_intelligence_stage,
+                                                    use_truce_variant,
                                                     biome_index);
     return 1;
 }

--- a/tests/native/feedback/native_feedback_loop_factory.c
+++ b/tests/native/feedback/native_feedback_loop_factory.c
@@ -982,7 +982,8 @@ static void emit_snapshot(FILE *stream,
             "tick=%d scenario=%s label=%s entities=%d controllers=%d banana=%d bean=%d "
             "bananaMode=%s beanMode=%s negotiateStreak=%d trim=%d comebackBonus=%d "
             "bananaHits={hold:%d flank:%d regroup:%d negotiate:%d} "
-            "beanHits={hold:%d flank:%d regroup:%d negotiate:%d}\n",
+            "beanHits={hold:%d flank:%d regroup:%d negotiate:%d} "
+            "truceHits={total:%d banana:%d bean:%d base:%d apex:%d mythic:%d}\n",
             tick,
             scenario_name,
             label ? label : "-",
@@ -1002,7 +1003,13 @@ static void emit_snapshot(FILE *stream,
             context->telemetry.war_sentience_spawn_mode_hits_bean[RUNTIME_WAR_SENTIENCE_BEHAVIOR_HOLD_LINE],
             context->telemetry.war_sentience_spawn_mode_hits_bean[RUNTIME_WAR_SENTIENCE_BEHAVIOR_FLANK],
             context->telemetry.war_sentience_spawn_mode_hits_bean[RUNTIME_WAR_SENTIENCE_BEHAVIOR_REGROUP],
-            context->telemetry.war_sentience_spawn_mode_hits_bean[RUNTIME_WAR_SENTIENCE_BEHAVIOR_NEGOTIATE]);
+            context->telemetry.war_sentience_spawn_mode_hits_bean[RUNTIME_WAR_SENTIENCE_BEHAVIOR_NEGOTIATE],
+            context->telemetry.war_sentience_truce_variant_hits_total,
+            context->telemetry.war_sentience_truce_variant_hits_banana,
+            context->telemetry.war_sentience_truce_variant_hits_bean,
+            context->telemetry.war_sentience_truce_variant_hits_base,
+            context->telemetry.war_sentience_truce_variant_hits_apex,
+            context->telemetry.war_sentience_truce_variant_hits_mythic);
 }
 
 static void emit_snapshot_dual(Dx12PlayloopRunner *runner, const char *label)
@@ -1280,6 +1287,42 @@ static int read_metric_value(const Dx12PlayloopRunner *runner, const char *metri
     if (strcmp(metric_name, "bean-negotiate-hits") == 0)
     {
         *out_value = runner->context.telemetry.war_sentience_spawn_mode_hits_bean[RUNTIME_WAR_SENTIENCE_BEHAVIOR_NEGOTIATE];
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-hits-total") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_variant_hits_total;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-hits-banana") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_variant_hits_banana;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-hits-bean") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_variant_hits_bean;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-hits-base") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_variant_hits_base;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-hits-apex") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_variant_hits_apex;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-hits-mythic") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_variant_hits_mythic;
         return 1;
     }
 

--- a/tests/native/feedback/scripts/negotiate.dx12play
+++ b/tests/native/feedback/scripts/negotiate.dx12play
@@ -1,11 +1,12 @@
 # DX12 playloop script: negotiate validation
 page.goto negotiate
-state.sentience 14 9 9
+state.sentience 14 9 6
 engine.config snapshot-interval 2
 page.tick 2
 expect.mode banana negotiate
 expect.mode bean negotiate
 expect.metric negotiate-streak gte 1
 expect.metric trim gte 1
+expect.metric truce-hits-total eq 0
 snapshot negotiate-baseline
 note negotiate_baseline_validated

--- a/tests/native/feedback/scripts/truce.dx12play
+++ b/tests/native/feedback/scripts/truce.dx12play
@@ -8,5 +8,7 @@ expect.mode banana negotiate
 expect.mode bean negotiate
 expect.metric negotiate-streak gte 1
 expect.team-count neutral gte 1
+expect.metric truce-hits-total gte 1
+expect.metric truce-hits-apex gte 1
 snapshot truce-baseline
 note truce_baseline_validated


### PR DESCRIPTION
## Epic Step 2: Truce Telemetry + Threshold Checks

## What this adds
- Truce-variant telemetry counters on runtime state:
  - total, per-team, per-stage, and per-tier (base/apex/mythic)
- Truce telemetry accounting in reinforcement spawn recording when truce variant routing is active
- Feedback harness metric exposure for script assertions:
  - truce-hits-total, truce-hits-banana, truce-hits-bean, truce-hits-base, truce-hits-apex, truce-hits-mythic
- Threshold-focused script assertions:
  - negotiate baseline lowers empathy so negotiate remains active but truce does not trigger
  - truce scenario asserts truce telemetry uptake and apex-tier truce hits

## Validation
- Static diagnostics: no errors in edited files
- Local build/test limitation in this worktree:
  - `cmake --build out/v3-native --target banana_native_feedback_loop_factory` fails because `src/native/engine/runtime/engine/demo_frame_export.c` is missing in this environment
  - existing stale binary still runs, but cannot validate new truce metrics until rebuild is possible

## Files
- src/native/engine/runtime/engine/engine_state.h
- src/native/engine/runtime/engine/gameplay_service.c
- tests/native/feedback/native_feedback_loop_factory.c
- tests/native/feedback/scripts/negotiate.dx12play
- tests/native/feedback/scripts/truce.dx12play
