### PR TITLE
Epic: surface truce telemetry in the engine HUD

### DIFF
--- a/src/native/engine/engine.c
+++ b/src/native/engine/engine.c
@@ -750,6 +750,36 @@ int engine_get_controller_war_sentience_comeback_bonus_last_tick(void)
     return s_engine_state.war_sentience_comeback_bonus_last_tick;
 }
 
+int engine_get_controller_war_sentience_truce_variant_hits_total(void)
+{
+    return s_engine_state.war_sentience_truce_variant_hits_total;
+}
+
+int engine_get_controller_war_sentience_truce_variant_hits_banana(void)
+{
+    return s_engine_state.war_sentience_truce_variant_hits_banana;
+}
+
+int engine_get_controller_war_sentience_truce_variant_hits_bean(void)
+{
+    return s_engine_state.war_sentience_truce_variant_hits_bean;
+}
+
+int engine_get_controller_war_sentience_truce_variant_hits_base(void)
+{
+    return s_engine_state.war_sentience_truce_variant_hits_base;
+}
+
+int engine_get_controller_war_sentience_truce_variant_hits_apex(void)
+{
+    return s_engine_state.war_sentience_truce_variant_hits_apex;
+}
+
+int engine_get_controller_war_sentience_truce_variant_hits_mythic(void)
+{
+    return s_engine_state.war_sentience_truce_variant_hits_mythic;
+}
+
 static int runtime_engine_sum_war_reinforcement_hits(const int *hits)
 {
     int total = 0;

--- a/src/native/engine/engine.h
+++ b/src/native/engine/engine.h
@@ -200,6 +200,12 @@ extern "C"
     int engine_get_controller_war_sentience_negotiate_streak_ticks(void);
     int engine_get_controller_war_sentience_negotiate_deescalation_trim_last_tick(void);
     int engine_get_controller_war_sentience_comeback_bonus_last_tick(void);
+    int engine_get_controller_war_sentience_truce_variant_hits_total(void);
+    int engine_get_controller_war_sentience_truce_variant_hits_banana(void);
+    int engine_get_controller_war_sentience_truce_variant_hits_bean(void);
+    int engine_get_controller_war_sentience_truce_variant_hits_base(void);
+    int engine_get_controller_war_sentience_truce_variant_hits_apex(void);
+    int engine_get_controller_war_sentience_truce_variant_hits_mythic(void);
     int engine_get_controller_war_reinforcement_hits_total(void);
     int engine_get_controller_war_reinforcement_hits_biome(int biome_index);
     int engine_get_controller_war_reinforcement_hits_family_banana_scout(void);

--- a/src/native/engine/win32_dx12_poc/overlay/scene_overlay.c
+++ b/src/native/engine/win32_dx12_poc/overlay/scene_overlay.c
@@ -442,6 +442,16 @@ void banana_poc_render_scene_overlay(BananaPocScene scene,
              engine_get_controller_war_sentience_spawn_mode_hits_bean(2),
              engine_get_controller_war_sentience_spawn_mode_hits_bean(3));
 
+    snprintf(line_twelve,
+             sizeof(line_twelve),
+             "WAR TRUCE HITS T:%d B:%d E:%d BASE:%d AP:%d MY:%d",
+             engine_get_controller_war_sentience_truce_variant_hits_total(),
+             engine_get_controller_war_sentience_truce_variant_hits_banana(),
+             engine_get_controller_war_sentience_truce_variant_hits_bean(),
+             engine_get_controller_war_sentience_truce_variant_hits_base(),
+             engine_get_controller_war_sentience_truce_variant_hits_apex(),
+             engine_get_controller_war_sentience_truce_variant_hits_mythic());
+
     if (has_player && has_target)
     {
         snprintf(line_four,
@@ -490,7 +500,8 @@ void banana_poc_render_scene_overlay(BananaPocScene scene,
     engine_ui_text(22.0f, 162.0f, line_nine);
     engine_ui_text(22.0f, 184.0f, line_ten);
     engine_ui_text(22.0f, 206.0f, line_eleven);
-    engine_ui_text(22.0f, 228.0f, line_four);
+    engine_ui_text(22.0f, 228.0f, line_twelve);
+    engine_ui_text(22.0f, 250.0f, line_four);
     if (scene == BANANA_POC_SCENE_LEVEL_EDITOR)
     {
         char editor_line[160];
@@ -503,7 +514,7 @@ void banana_poc_render_scene_overlay(BananaPocScene scene,
                  editor_height,
                  brush,
                  k_paint_mode_names[mode]);
-        engine_ui_text(22.0f, 250.0f, editor_line);
+        engine_ui_text(22.0f, 272.0f, editor_line);
     }
     else if (!(proto && proto->option_compact_hud))
     {


### PR DESCRIPTION
## Epic Step 3: Truce Telemetry Surfacing

## What this adds
- Engine accessors for the truce telemetry counters added in the prior epic slice:
  - total
  - banana / bean
  - base / apex / mythic
- DX12 overlay HUD line that surfaces the truce counters alongside the existing war sentience and spawn metrics
- Minor overlay layout adjustment to keep the new truce row readable

## Validation
- `get_errors` reports no diagnostics in the edited engine and overlay files
- local native rebuild remains blocked in this worktree by the pre-existing missing `src/native/engine/runtime/engine/demo_frame_export.c` source reference, so the updated HUD could not be rebuilt here

## Files
- src/native/engine/engine.h
- src/native/engine/engine.c
- src/native/engine/win32_dx12_poc/overlay/scene_overlay.c
