### PR TITLE
Epic: add stage-aware truce metrics and HUD surfacing

### DIFF
--- a/src/native/engine/engine.c
+++ b/src/native/engine/engine.c
@@ -723,6 +723,8 @@ static int runtime_engine_war_sentience_mode_hits_at(const int *hits, int mode)
     return hits[mode];
 }
 
+static int runtime_engine_war_reinforcement_stage_hits_at(const int *hits, int stage_index);
+
 int engine_get_controller_war_sentience_spawn_mode_hits_banana(int mode)
 {
     return runtime_engine_war_sentience_mode_hits_at(s_engine_state.war_sentience_spawn_mode_hits_banana,
@@ -778,6 +780,12 @@ int engine_get_controller_war_sentience_truce_variant_hits_apex(void)
 int engine_get_controller_war_sentience_truce_variant_hits_mythic(void)
 {
     return s_engine_state.war_sentience_truce_variant_hits_mythic;
+}
+
+int engine_get_controller_war_sentience_truce_variant_hits_stage(int stage_index)
+{
+    return runtime_engine_war_reinforcement_stage_hits_at(s_engine_state.war_sentience_truce_variant_hits_stage,
+                                                          stage_index);
 }
 
 static int runtime_engine_sum_war_reinforcement_hits(const int *hits)

--- a/src/native/engine/engine.h
+++ b/src/native/engine/engine.h
@@ -206,6 +206,7 @@ extern "C"
     int engine_get_controller_war_sentience_truce_variant_hits_base(void);
     int engine_get_controller_war_sentience_truce_variant_hits_apex(void);
     int engine_get_controller_war_sentience_truce_variant_hits_mythic(void);
+    int engine_get_controller_war_sentience_truce_variant_hits_stage(int stage_index);
     int engine_get_controller_war_reinforcement_hits_total(void);
     int engine_get_controller_war_reinforcement_hits_biome(int biome_index);
     int engine_get_controller_war_reinforcement_hits_family_banana_scout(void);

--- a/src/native/engine/win32_dx12_poc/overlay/scene_overlay.c
+++ b/src/native/engine/win32_dx12_poc/overlay/scene_overlay.c
@@ -444,13 +444,15 @@ void banana_poc_render_scene_overlay(BananaPocScene scene,
 
     snprintf(line_twelve,
              sizeof(line_twelve),
-             "WAR TRUCE HITS T:%d B:%d E:%d BASE:%d AP:%d MY:%d",
+             "WAR TRUCE HITS T:%d B:%d E:%d BASE:%d AP:%d MY:%d STG[%d]:%d",
              engine_get_controller_war_sentience_truce_variant_hits_total(),
              engine_get_controller_war_sentience_truce_variant_hits_banana(),
              engine_get_controller_war_sentience_truce_variant_hits_bean(),
              engine_get_controller_war_sentience_truce_variant_hits_base(),
              engine_get_controller_war_sentience_truce_variant_hits_apex(),
-             engine_get_controller_war_sentience_truce_variant_hits_mythic());
+             engine_get_controller_war_sentience_truce_variant_hits_mythic(),
+             war_stage,
+             engine_get_controller_war_sentience_truce_variant_hits_stage(war_stage));
 
     if (has_player && has_target)
     {

--- a/tests/native/feedback/native_feedback_loop_factory.c
+++ b/tests/native/feedback/native_feedback_loop_factory.c
@@ -1326,6 +1326,19 @@ static int read_metric_value(const Dx12PlayloopRunner *runner, const char *metri
         return 1;
     }
 
+    if (strcmp(metric_name, "truce-hits-stage-current") == 0)
+    {
+        int stage_index = runner->context.telemetry.war_intelligence_stage;
+
+        if (stage_index < 0)
+            stage_index = 0;
+        if (stage_index >= BANANA_ENGINE_WAR_INTELLIGENCE_STAGE_BUCKETS)
+            stage_index = BANANA_ENGINE_WAR_INTELLIGENCE_STAGE_BUCKETS - 1;
+
+        *out_value = runner->context.telemetry.war_sentience_truce_variant_hits_stage[stage_index];
+        return 1;
+    }
+
     return 0;
 }
 

--- a/tests/native/feedback/scripts/negotiate.dx12play
+++ b/tests/native/feedback/scripts/negotiate.dx12play
@@ -8,5 +8,6 @@ expect.mode bean negotiate
 expect.metric negotiate-streak gte 1
 expect.metric trim gte 1
 expect.metric truce-hits-total eq 0
+expect.metric truce-hits-stage-current eq 0
 snapshot negotiate-baseline
 note negotiate_baseline_validated

--- a/tests/native/feedback/scripts/truce.dx12play
+++ b/tests/native/feedback/scripts/truce.dx12play
@@ -10,5 +10,6 @@ expect.metric negotiate-streak gte 1
 expect.team-count neutral gte 1
 expect.metric truce-hits-total gte 1
 expect.metric truce-hits-apex gte 1
+expect.metric truce-hits-stage-current gte 1
 snapshot truce-baseline
 note truce_baseline_validated


### PR DESCRIPTION
## Epic Step 4: Stage-Aware Truce Metrics

## What this adds
- Engine API accessor for stage-indexed truce telemetry:
  - `engine_get_controller_war_sentience_truce_variant_hits_stage(stage_index)`
- HUD extension to display current-stage truce hit count (`STG[stage]:count`) on the truce telemetry row
- Feedback script metric `truce-hits-stage-current` derived from current intelligence stage bucket
- Tightened playloop script assertions:
  - `negotiate.dx12play` asserts stage-current truce hits remain zero
  - `truce.dx12play` asserts stage-current truce hits are non-zero

## Validation
- `get_errors` reports no diagnostics in edited files
- Local runtime binary remains stale in this worktree because native rebuild is blocked by missing `src/native/engine/runtime/engine/demo_frame_export.c`
- Due stale binary, local `banana_native_feedback_loop_factory_negotiate_smoke` still reports unknown truce metrics

## Files
- src/native/engine/engine.h
- src/native/engine/engine.c
- src/native/engine/win32_dx12_poc/overlay/scene_overlay.c
- tests/native/feedback/native_feedback_loop_factory.c
- tests/native/feedback/scripts/negotiate.dx12play
- tests/native/feedback/scripts/truce.dx12play
