### PR TITLE
Epic: add truce gate reason diagnostics

### DIFF
--- a/src/native/engine/engine.c
+++ b/src/native/engine/engine.c
@@ -788,6 +788,41 @@ int engine_get_controller_war_sentience_truce_variant_hits_stage(int stage_index
                                                           stage_index);
 }
 
+int engine_get_controller_war_sentience_truce_gate_checks_total(void)
+{
+    return s_engine_state.war_sentience_truce_gate_checks_total;
+}
+
+int engine_get_controller_war_sentience_truce_gate_checks_granted(void)
+{
+    return s_engine_state.war_sentience_truce_gate_checks_granted;
+}
+
+int engine_get_controller_war_sentience_truce_gate_block_behavior(void)
+{
+    return s_engine_state.war_sentience_truce_gate_block_behavior;
+}
+
+int engine_get_controller_war_sentience_truce_gate_block_empathy(void)
+{
+    return s_engine_state.war_sentience_truce_gate_block_empathy;
+}
+
+int engine_get_controller_war_sentience_truce_gate_block_coordination(void)
+{
+    return s_engine_state.war_sentience_truce_gate_block_coordination;
+}
+
+int engine_get_controller_war_sentience_truce_gate_block_streak(void)
+{
+    return s_engine_state.war_sentience_truce_gate_block_streak;
+}
+
+int engine_get_controller_war_sentience_truce_gate_block_intelligence(void)
+{
+    return s_engine_state.war_sentience_truce_gate_block_intelligence;
+}
+
 static int runtime_engine_sum_war_reinforcement_hits(const int *hits)
 {
     int total = 0;

--- a/src/native/engine/engine.h
+++ b/src/native/engine/engine.h
@@ -207,6 +207,13 @@ extern "C"
     int engine_get_controller_war_sentience_truce_variant_hits_apex(void);
     int engine_get_controller_war_sentience_truce_variant_hits_mythic(void);
     int engine_get_controller_war_sentience_truce_variant_hits_stage(int stage_index);
+    int engine_get_controller_war_sentience_truce_gate_checks_total(void);
+    int engine_get_controller_war_sentience_truce_gate_checks_granted(void);
+    int engine_get_controller_war_sentience_truce_gate_block_behavior(void);
+    int engine_get_controller_war_sentience_truce_gate_block_empathy(void);
+    int engine_get_controller_war_sentience_truce_gate_block_coordination(void);
+    int engine_get_controller_war_sentience_truce_gate_block_streak(void);
+    int engine_get_controller_war_sentience_truce_gate_block_intelligence(void);
     int engine_get_controller_war_reinforcement_hits_total(void);
     int engine_get_controller_war_reinforcement_hits_biome(int biome_index);
     int engine_get_controller_war_reinforcement_hits_family_banana_scout(void);

--- a/src/native/engine/runtime/engine/engine_state.h
+++ b/src/native/engine/runtime/engine/engine_state.h
@@ -130,6 +130,13 @@ typedef struct EngineRuntimeState
     int war_sentience_truce_variant_hits_base;
     int war_sentience_truce_variant_hits_apex;
     int war_sentience_truce_variant_hits_mythic;
+    int war_sentience_truce_gate_checks_total;
+    int war_sentience_truce_gate_checks_granted;
+    int war_sentience_truce_gate_block_behavior;
+    int war_sentience_truce_gate_block_empathy;
+    int war_sentience_truce_gate_block_coordination;
+    int war_sentience_truce_gate_block_streak;
+    int war_sentience_truce_gate_block_intelligence;
     int war_sentience_negotiate_streak_ticks;
     int war_sentience_negotiate_deescalation_trim_last_tick;
     int war_sentience_comeback_bonus_last_tick;

--- a/src/native/engine/runtime/engine/gameplay_service.c
+++ b/src/native/engine/runtime/engine/gameplay_service.c
@@ -250,6 +250,16 @@ typedef enum RuntimeWarReinforcementVisualTier
     RUNTIME_WAR_REINFORCEMENT_VISUAL_TIER_MYTHIC = 2,
 } RuntimeWarReinforcementVisualTier;
 
+typedef enum RuntimeWarTruceGateResult
+{
+    RUNTIME_WAR_TRUCE_GATE_GRANTED = 0,
+    RUNTIME_WAR_TRUCE_GATE_BLOCK_BEHAVIOR = 1,
+    RUNTIME_WAR_TRUCE_GATE_BLOCK_EMPATHY = 2,
+    RUNTIME_WAR_TRUCE_GATE_BLOCK_COORDINATION = 3,
+    RUNTIME_WAR_TRUCE_GATE_BLOCK_STREAK = 4,
+    RUNTIME_WAR_TRUCE_GATE_BLOCK_INTELLIGENCE = 5,
+} RuntimeWarTruceGateResult;
+
 static int runtime_gameplay_clamp_biome_index(int war_biome_stage_index)
 {
     int model_count = (int)(sizeof(k_banana_skirmish_models) / sizeof(k_banana_skirmish_models[0]));
@@ -554,6 +564,65 @@ static int runtime_gameplay_should_use_truce_variant(const EngineRuntimeState *r
         return 0;
 
     return 1;
+}
+
+static RuntimeWarTruceGateResult runtime_gameplay_evaluate_truce_gate(const EngineRuntimeState *runtime_state,
+                                                                      RuntimeWarSentienceBehaviorMode behavior_mode,
+                                                                      int war_intelligence_stage,
+                                                                      int *out_use_truce_variant)
+{
+    int use_truce_variant = runtime_gameplay_should_use_truce_variant(runtime_state,
+                                                                       behavior_mode,
+                                                                       war_intelligence_stage);
+
+    if (out_use_truce_variant)
+        *out_use_truce_variant = use_truce_variant;
+
+    if (use_truce_variant)
+        return RUNTIME_WAR_TRUCE_GATE_GRANTED;
+
+    if (behavior_mode != RUNTIME_WAR_SENTIENCE_BEHAVIOR_NEGOTIATE)
+        return RUNTIME_WAR_TRUCE_GATE_BLOCK_BEHAVIOR;
+    if (!runtime_state || runtime_state->war_sentience_empathy_level < 7)
+        return RUNTIME_WAR_TRUCE_GATE_BLOCK_EMPATHY;
+    if (runtime_state->war_sentience_coordination_level < 5)
+        return RUNTIME_WAR_TRUCE_GATE_BLOCK_COORDINATION;
+    if (runtime_state->war_sentience_negotiate_streak_ticks < 2)
+        return RUNTIME_WAR_TRUCE_GATE_BLOCK_STREAK;
+
+    return RUNTIME_WAR_TRUCE_GATE_BLOCK_INTELLIGENCE;
+}
+
+static void runtime_gameplay_record_truce_gate_result(EngineRuntimeState *runtime_state,
+                                                      RuntimeWarTruceGateResult gate_result)
+{
+    if (!runtime_state)
+        return;
+
+    runtime_state->war_sentience_truce_gate_checks_total += 1;
+
+    switch (gate_result)
+    {
+        case RUNTIME_WAR_TRUCE_GATE_GRANTED:
+            runtime_state->war_sentience_truce_gate_checks_granted += 1;
+            break;
+        case RUNTIME_WAR_TRUCE_GATE_BLOCK_BEHAVIOR:
+            runtime_state->war_sentience_truce_gate_block_behavior += 1;
+            break;
+        case RUNTIME_WAR_TRUCE_GATE_BLOCK_EMPATHY:
+            runtime_state->war_sentience_truce_gate_block_empathy += 1;
+            break;
+        case RUNTIME_WAR_TRUCE_GATE_BLOCK_COORDINATION:
+            runtime_state->war_sentience_truce_gate_block_coordination += 1;
+            break;
+        case RUNTIME_WAR_TRUCE_GATE_BLOCK_STREAK:
+            runtime_state->war_sentience_truce_gate_block_streak += 1;
+            break;
+        case RUNTIME_WAR_TRUCE_GATE_BLOCK_INTELLIGENCE:
+        default:
+            runtime_state->war_sentience_truce_gate_block_intelligence += 1;
+            break;
+    }
 }
 
 static const char *runtime_gameplay_behavioral_elite_model_id_for_family(
@@ -1170,6 +1239,7 @@ static int runtime_gameplay_spawn_war_reinforcement(World *world,
     Entity *entity = NULL;
     uint32_t controller_id = 0;
     int use_truce_variant = 0;
+    RuntimeWarTruceGateResult truce_gate_result = RUNTIME_WAR_TRUCE_GATE_BLOCK_BEHAVIOR;
 
     if (!world || !controllers || !inout_controller_count || max_controllers <= 0)
         return 0;
@@ -1195,9 +1265,11 @@ static int runtime_gameplay_spawn_war_reinforcement(World *world,
     }
     else
     {
-        use_truce_variant = runtime_gameplay_should_use_truce_variant(runtime_state,
-                                                                      behavior_mode,
-                                                                      war_intelligence_stage);
+        truce_gate_result = runtime_gameplay_evaluate_truce_gate(runtime_state,
+                                                                 behavior_mode,
+                                                                 war_intelligence_stage,
+                                                                 &use_truce_variant);
+        runtime_gameplay_record_truce_gate_result(runtime_state, truce_gate_result);
         gameplay_model_id = runtime_gameplay_reinforcement_model_id_for_family(family,
                                                                                 behavior_mode,
                                                                                 war_intelligence_stage,

--- a/src/native/engine/win32_dx12_poc/overlay/scene_overlay.c
+++ b/src/native/engine/win32_dx12_poc/overlay/scene_overlay.c
@@ -454,6 +454,17 @@ void banana_poc_render_scene_overlay(BananaPocScene scene,
              war_stage,
              engine_get_controller_war_sentience_truce_variant_hits_stage(war_stage));
 
+    snprintf(line_thirteen,
+             sizeof(line_thirteen),
+             "WAR TRUCE GATE CK:%d OK:%d BLK B/E/C/S/I:%d/%d/%d/%d/%d",
+             engine_get_controller_war_sentience_truce_gate_checks_total(),
+             engine_get_controller_war_sentience_truce_gate_checks_granted(),
+             engine_get_controller_war_sentience_truce_gate_block_behavior(),
+             engine_get_controller_war_sentience_truce_gate_block_empathy(),
+             engine_get_controller_war_sentience_truce_gate_block_coordination(),
+             engine_get_controller_war_sentience_truce_gate_block_streak(),
+             engine_get_controller_war_sentience_truce_gate_block_intelligence());
+
     if (has_player && has_target)
     {
         snprintf(line_four,
@@ -503,7 +514,8 @@ void banana_poc_render_scene_overlay(BananaPocScene scene,
     engine_ui_text(22.0f, 184.0f, line_ten);
     engine_ui_text(22.0f, 206.0f, line_eleven);
     engine_ui_text(22.0f, 228.0f, line_twelve);
-    engine_ui_text(22.0f, 250.0f, line_four);
+    engine_ui_text(22.0f, 250.0f, line_thirteen);
+    engine_ui_text(22.0f, 272.0f, line_four);
     if (scene == BANANA_POC_SCENE_LEVEL_EDITOR)
     {
         char editor_line[160];
@@ -516,7 +528,7 @@ void banana_poc_render_scene_overlay(BananaPocScene scene,
                  editor_height,
                  brush,
                  k_paint_mode_names[mode]);
-        engine_ui_text(22.0f, 272.0f, editor_line);
+        engine_ui_text(22.0f, 294.0f, editor_line);
     }
     else if (!(proto && proto->option_compact_hud))
     {

--- a/tests/native/feedback/native_feedback_loop_factory.c
+++ b/tests/native/feedback/native_feedback_loop_factory.c
@@ -983,7 +983,8 @@ static void emit_snapshot(FILE *stream,
             "bananaMode=%s beanMode=%s negotiateStreak=%d trim=%d comebackBonus=%d "
             "bananaHits={hold:%d flank:%d regroup:%d negotiate:%d} "
             "beanHits={hold:%d flank:%d regroup:%d negotiate:%d} "
-            "truceHits={total:%d banana:%d bean:%d base:%d apex:%d mythic:%d}\n",
+            "truceHits={total:%d banana:%d bean:%d base:%d apex:%d mythic:%d} "
+            "truceGate={checks:%d ok:%d behavior:%d empathy:%d coord:%d streak:%d intel:%d}\n",
             tick,
             scenario_name,
             label ? label : "-",
@@ -1009,7 +1010,14 @@ static void emit_snapshot(FILE *stream,
             context->telemetry.war_sentience_truce_variant_hits_bean,
             context->telemetry.war_sentience_truce_variant_hits_base,
             context->telemetry.war_sentience_truce_variant_hits_apex,
-            context->telemetry.war_sentience_truce_variant_hits_mythic);
+            context->telemetry.war_sentience_truce_variant_hits_mythic,
+            context->telemetry.war_sentience_truce_gate_checks_total,
+            context->telemetry.war_sentience_truce_gate_checks_granted,
+            context->telemetry.war_sentience_truce_gate_block_behavior,
+            context->telemetry.war_sentience_truce_gate_block_empathy,
+            context->telemetry.war_sentience_truce_gate_block_coordination,
+            context->telemetry.war_sentience_truce_gate_block_streak,
+            context->telemetry.war_sentience_truce_gate_block_intelligence);
 }
 
 static void emit_snapshot_dual(Dx12PlayloopRunner *runner, const char *label)
@@ -1336,6 +1344,48 @@ static int read_metric_value(const Dx12PlayloopRunner *runner, const char *metri
             stage_index = BANANA_ENGINE_WAR_INTELLIGENCE_STAGE_BUCKETS - 1;
 
         *out_value = runner->context.telemetry.war_sentience_truce_variant_hits_stage[stage_index];
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-gate-checks") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_gate_checks_total;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-gate-granted") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_gate_checks_granted;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-gate-block-behavior") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_gate_block_behavior;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-gate-block-empathy") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_gate_block_empathy;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-gate-block-coordination") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_gate_block_coordination;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-gate-block-streak") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_gate_block_streak;
+        return 1;
+    }
+
+    if (strcmp(metric_name, "truce-gate-block-intelligence") == 0)
+    {
+        *out_value = runner->context.telemetry.war_sentience_truce_gate_block_intelligence;
         return 1;
     }
 

--- a/tests/native/feedback/scripts/negotiate.dx12play
+++ b/tests/native/feedback/scripts/negotiate.dx12play
@@ -9,5 +9,7 @@ expect.metric negotiate-streak gte 1
 expect.metric trim gte 1
 expect.metric truce-hits-total eq 0
 expect.metric truce-hits-stage-current eq 0
+expect.metric truce-gate-checks gte 1
+expect.metric truce-gate-block-empathy gte 1
 snapshot negotiate-baseline
 note negotiate_baseline_validated

--- a/tests/native/feedback/scripts/truce.dx12play
+++ b/tests/native/feedback/scripts/truce.dx12play
@@ -11,5 +11,6 @@ expect.team-count neutral gte 1
 expect.metric truce-hits-total gte 1
 expect.metric truce-hits-apex gte 1
 expect.metric truce-hits-stage-current gte 1
+expect.metric truce-gate-granted gte 1
 snapshot truce-baseline
 note truce_baseline_validated


### PR DESCRIPTION
## Epic Step 5: Truce Gate Reason Diagnostics

## What this adds
- Runtime counters for truce gate evaluations:
  - checks total
  - granted
  - blocked by: behavior, empathy, coordination, streak, intelligence
- Gameplay service instrumentation to evaluate and record truce gate outcome per reinforcement routing decision
- Engine API accessors for all truce gate counters
- Overlay HUD row for truce gate diagnostics
- Feedback loop metrics and snapshot output for truce gate counters
- Script assertions updated to validate gate behavior:
  - negotiate scenario checks empathy-block counters
  - truce scenario checks granted counters

## Validation
- `get_errors` reports no diagnostics in edited files
- local `ctest` still executes a stale feedback-loop binary in this worktree, reporting unknown truce metrics (`truce-hits-total`) due pre-existing native rebuild blocker (`demo_frame_export.c` missing in this environment)

## Files
- src/native/engine/runtime/engine/engine_state.h
- src/native/engine/runtime/engine/gameplay_service.c
- src/native/engine/engine.h
- src/native/engine/engine.c
- src/native/engine/win32_dx12_poc/overlay/scene_overlay.c
- tests/native/feedback/native_feedback_loop_factory.c
- tests/native/feedback/scripts/negotiate.dx12play
- tests/native/feedback/scripts/truce.dx12play
