### PR TITLE
Epic: split envoy and truce silhouette profiles

### DIFF
--- a/src/native/engine/runtime/engine/gameplay_model_profile.c
+++ b/src/native/engine/runtime/engine/gameplay_model_profile.c
@@ -64,18 +64,19 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
             *out_curve_scale -= 0.18f;
             *out_tip_taper += 0.03f;
         }
-        else if (has_diplomacy_tag)
+        else if (has_envoy_tag)
         {
-            *out_length_scale += 0.08f;
-            *out_curve_scale -= 0.34f;
-            *out_tip_taper += 0.09f;
-
-            if (has_truce_tag)
-            {
-                *out_radius_scale += 0.06f;
-                *out_curve_scale -= 0.06f;
-                *out_tip_taper += 0.02f;
-            }
+            *out_radius_scale -= 0.04f;
+            *out_length_scale += 0.12f;
+            *out_curve_scale -= 0.26f;
+            *out_tip_taper += 0.07f;
+        }
+        else if (has_truce_tag)
+        {
+            *out_radius_scale += 0.08f;
+            *out_length_scale += 0.04f;
+            *out_curve_scale -= 0.42f;
+            *out_tip_taper += 0.12f;
         }
 
         if (has_banana_tag)
@@ -132,18 +133,19 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
             *out_curve_scale -= 0.16f;
             *out_tip_taper += 0.02f;
         }
-        else if (has_diplomacy_tag)
+        else if (has_envoy_tag)
         {
-            *out_length_scale += 0.07f;
-            *out_curve_scale -= 0.28f;
-            *out_tip_taper += 0.07f;
-
-            if (has_truce_tag)
-            {
-                *out_radius_scale += 0.05f;
-                *out_curve_scale -= 0.05f;
-                *out_tip_taper += 0.02f;
-            }
+            *out_radius_scale -= 0.03f;
+            *out_length_scale += 0.10f;
+            *out_curve_scale -= 0.22f;
+            *out_tip_taper += 0.06f;
+        }
+        else if (has_truce_tag)
+        {
+            *out_radius_scale += 0.07f;
+            *out_length_scale += 0.03f;
+            *out_curve_scale -= 0.34f;
+            *out_tip_taper += 0.10f;
         }
 
         if (has_banana_tag)
@@ -213,18 +215,19 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
             *out_curve_scale -= 0.14f;
             *out_tip_taper += 0.02f;
         }
-        else if (has_diplomacy_tag)
+        else if (has_envoy_tag)
         {
-            *out_length_scale += 0.06f;
-            *out_curve_scale -= 0.24f;
-            *out_tip_taper += 0.06f;
-
-            if (has_truce_tag)
-            {
-                *out_radius_scale += 0.04f;
-                *out_curve_scale -= 0.04f;
-                *out_tip_taper += 0.02f;
-            }
+            *out_radius_scale -= 0.02f;
+            *out_length_scale += 0.08f;
+            *out_curve_scale -= 0.18f;
+            *out_tip_taper += 0.05f;
+        }
+        else if (has_truce_tag)
+        {
+            *out_radius_scale += 0.06f;
+            *out_length_scale += 0.02f;
+            *out_curve_scale -= 0.30f;
+            *out_tip_taper += 0.09f;
         }
 
         return 1;
@@ -248,18 +251,19 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
             *out_radius_scale += 0.10f;
             *out_curve_scale -= 0.22f;
         }
-        else if (has_diplomacy_tag)
+        else if (has_envoy_tag)
         {
-            *out_length_scale += 0.05f;
-            *out_curve_scale -= 0.36f;
-            *out_tip_taper += 0.08f;
-
-            if (has_truce_tag)
-            {
-                *out_radius_scale += 0.03f;
-                *out_curve_scale -= 0.06f;
-                *out_tip_taper += 0.02f;
-            }
+            *out_radius_scale -= 0.03f;
+            *out_length_scale += 0.10f;
+            *out_curve_scale -= 0.28f;
+            *out_tip_taper += 0.07f;
+        }
+        else if (has_truce_tag)
+        {
+            *out_radius_scale += 0.05f;
+            *out_length_scale += 0.03f;
+            *out_curve_scale -= 0.46f;
+            *out_tip_taper += 0.12f;
         }
 
         if (strstr(model_id, "urban") != NULL)

--- a/src/native/engine/runtime/engine/gameplay_model_profile.c
+++ b/src/native/engine/runtime/engine/gameplay_model_profile.c
@@ -13,7 +13,6 @@ int runtime_gameplay_model_vector_profile_for_model_id(const char *model_id,
     const int has_regroup_tag = model_id && strstr(model_id, "regroup") != NULL;
     const int has_envoy_tag = model_id && strstr(model_id, "envoy") != NULL;
     const int has_truce_tag = model_id && strstr(model_id, "truce") != NULL;
-    const int has_diplomacy_tag = has_envoy_tag || has_truce_tag;
     const int has_banana_tag = model_id && strstr(model_id, "banana-") != NULL;
     const int has_bean_tag = model_id && strstr(model_id, "bean-") != NULL;
 


### PR DESCRIPTION
## Epic Step 7: Split Envoy and Truce Silhouette Profiles

## What this changes
- Refines `runtime_gameplay_model_vector_profile_for_model_id` so diplomacy variants no longer share one generic adjustment path.
- Splits `envoy` and `truce` shaping independently across all reinforcement tiers:
  - mythic (`archon` / `leviathan`)
  - apex (`phalanx` / `colossus`)
  - siege (`commander` / `warbrute`)
  - skirmish (`scout` / `raider`)
- Envoy variants now read as slimmer/longer negotiation silhouettes.
- Truce variants now read as broader/straighter reconciliation silhouettes.

## Why
The prior profile logic treated both diplomacy variants as one shared branch and only added a small truce offset. That flattened the art read between negotiate-only envoy spawns and granted truce spawns within the same tier/family.

## Validation
- Editor/native diagnostics are clean for the touched file.
- Targeted native core build still fails in this worktree on the pre-existing missing source blocker:
  - `src/native/engine/runtime/engine/demo_frame_export.c`
- The touched file (`gameplay_model_profile.c`) compiled as part of that build before the unrelated blocker stopped the target.

## File
- src/native/engine/runtime/engine/gameplay_model_profile.c
