### PR TITLE
Add repo-owned Fly pg_durable image and controller training workflow lane

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -26,6 +26,19 @@ Runtime contract notes:
 - `react-overworld` runs the portal on `:5173` and targets `http://localhost:8081`.
 - Session model is single-room overworld (`sessionId=overworld`) with server tick metrics in snapshot payloads.
 
+## Fly Postgres pg_durable Image
+
+Build and push the repo-owned Fly database image with `pg_durable` baked in:
+
+```bash
+bash scripts/build-fly-pg-durable-image.sh
+```
+
+Image source and init artifacts:
+
+- `docker/postgres-pg-durable.Dockerfile`
+- `docker/pg-durable/initdb/010-create-extension.sh`
+
 ## Native-To-Neon Integration (Containerized)
 
 Run the native + API Neon integration lane inside Docker:

--- a/docker/pg-durable/initdb/010-create-extension.sh
+++ b/docker/pg-durable/initdb/010-create-extension.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres <<'SQL'
+CREATE EXTENSION IF NOT EXISTS pg_durable;
+SQL

--- a/docker/postgres-pg-durable.Dockerfile
+++ b/docker/postgres-pg-durable.Dockerfile
@@ -1,0 +1,25 @@
+FROM postgres:17-bookworm
+
+ARG PG_DURABLE_VERSION=0.2.2
+ARG TARGETARCH=amd64
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    package="pg-durable-postgresql-17_${PG_DURABLE_VERSION}-1_${TARGETARCH}.deb"; \
+    url="https://github.com/microsoft/pg_durable/releases/download/v${PG_DURABLE_VERSION}/${package}"; \
+    curl -fsSL "$url" -o "/tmp/${package}"; \
+        if ! dpkg -i "/tmp/${package}"; then \
+            apt-get update; \
+            apt-get install -y --no-install-recommends -f; \
+        fi; \
+    rm -f "/tmp/${package}"; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY docker/pg-durable/initdb/010-create-extension.sh /docker-entrypoint-initdb.d/010-create-extension.sh
+
+RUN chmod +x /docker-entrypoint-initdb.d/010-create-extension.sh
+
+CMD ["postgres", "-c", "shared_preload_libraries=pg_durable", "-c", "pg_durable.worker_role=postgres"]

--- a/docs/under-20-fly-only-postgres-runbook.md
+++ b/docs/under-20-fly-only-postgres-runbook.md
@@ -1,10 +1,11 @@
-# Banana under $20 runbook: Fly-only API + Postgres volume
+# Banana under $20 runbook: Fly-only API + pg_durable Postgres volume
 
 ## Goal
 
 Keep the stack Fly-only while staying near or under $20/month:
 - `banana-api` app on Fly
-- one low-cost Postgres instance on Fly with a single volume
+- one low-cost Postgres 17 instance on Fly with a single volume
+- `pg_durable` installed so durable controller-training workflows can run close to data
 - API wired via Banana DB alias contract
 
 ## Reality check on budget
@@ -35,10 +36,23 @@ From repo root terminal:
 fly apps create banana-db
 ```
 
+Build and push the repo-owned Fly image with `pg_durable` baked in:
+
+```bash
+bash scripts/build-fly-pg-durable-image.sh
+```
+
+Override image version/tag when needed:
+
+```bash
+PG_DURABLE_VERSION=0.2.2 FLY_DB_IMAGE_TAG=pg17-durable-v0.2.2 \
+  bash scripts/build-fly-pg-durable-image.sh
+```
+
 Provision a small machine and volume (example defaults):
 
 ```bash
-fly machine run flyio/postgres:15 \
+fly machine run registry.fly.io/banana-db:pg17-durable-v0.2.2 \
   --app banana-db \
   --region iad \
   --name banana-db-1 \
@@ -53,6 +67,7 @@ fly machine run flyio/postgres:15 \
 Notes:
 - Keep volume small at first (10GB) for cost control.
 - This is single-node and not HA.
+- Keep image tags immutable (for example `pg17-durable-v0.2.2`) so rollbacks are deterministic.
 
 ## 2) Validate DB machine is healthy
 
@@ -71,6 +86,19 @@ postgresql://banana_app:REPLACE_WITH_STRONG_PASSWORD@banana-db.internal:5432/ban
 ```
 
 For tighter security later, move to private networking only and rotated credentials.
+
+On first boot, ensure the database creates the extension:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_durable;
+```
+
+If your app role needs durable workflow access, grant usage after bootstrap.
+
+The repo-owned image already runs with:
+
+- `shared_preload_libraries=pg_durable`
+- init script `docker/pg-durable/initdb/010-create-extension.sh`
 
 ## 4) Set Banana API Fly secrets
 

--- a/scripts/build-fly-pg-durable-image.sh
+++ b/scripts/build-fly-pg-durable-image.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_NAME="${FLY_DB_APP_NAME:-banana-db}"
+PG_DURABLE_VERSION="${PG_DURABLE_VERSION:-0.2.2}"
+IMAGE_TAG="${FLY_DB_IMAGE_TAG:-pg17-durable-v${PG_DURABLE_VERSION}}"
+IMAGE_REF="registry.fly.io/${APP_NAME}:${IMAGE_TAG}"
+
+if ! command -v fly >/dev/null 2>&1; then
+  echo "[fly-db-image] ERROR: fly CLI is required but not installed or not on PATH." >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[fly-db-image] ERROR: docker CLI is required but not installed or not on PATH." >&2
+  exit 1
+fi
+
+echo "[fly-db-image] authenticating docker to Fly registry"
+fly auth docker
+
+echo "[fly-db-image] building ${IMAGE_REF} with pg_durable ${PG_DURABLE_VERSION}"
+docker build \
+  -f "${ROOT_DIR}/docker/postgres-pg-durable.Dockerfile" \
+  --build-arg "PG_DURABLE_VERSION=${PG_DURABLE_VERSION}" \
+  -t "${IMAGE_REF}" \
+  "${ROOT_DIR}"
+
+echo "[fly-db-image] pushing ${IMAGE_REF}"
+docker push "${IMAGE_REF}"
+
+echo "[fly-db-image] complete"
+echo "[fly-db-image] image ref: ${IMAGE_REF}"

--- a/src/typescript/api/README.md
+++ b/src/typescript/api/README.md
@@ -56,22 +56,37 @@ set `BANANA_FLY_SKIP_PARITY_GATE=true` before running deploy.
 `banana` project. To rotate it later, add the new value with `vercel env add`
 or replace the secret through the Vercel project settings, then redeploy.
 
-This repository does not provision Neon itself; it deploys the app against a
-self-hosted Neon-backed PostgreSQL endpoint.
+This repository does not provision PostgreSQL itself; it deploys the app
+against a self-hosted authoritative PostgreSQL endpoint.
 
-Recommended database hostname for the self-hosted Neon instance:
+For Fly production, that endpoint can be a Fly-hosted PostgreSQL 17 instance
+using the repo-owned image built from `docker/postgres-pg-durable.Dockerfile`
+with `pg_durable` installed and `BANANA_PG_CONNECTION` pointing at the Fly
+private DNS host.
+
+Recommended database hostname for the self-hosted instance:
 
 - `db.banana.engineer`
 
 Use that hostname in the connection string that you pass via
 `NEON_DATABASE_URL`.
 
+If the Fly database is running `pg_durable`, create the extension during
+bootstrap and keep the app pointed at the same authoritative URL through all
+three aliases.
+
+Build and publish the DB image to Fly registry from repo root:
+
+```bash
+bash scripts/build-fly-pg-durable-image.sh
+```
+
 ```bash
 bash scripts/deploy-api-fly.sh
 ```
 
-For the database cutover, set `NEON_DATABASE_URL` from your self-hosted Neon
-instance before invoking the script.
+For the database cutover, set `NEON_DATABASE_URL` from your self-hosted
+PostgreSQL instance before invoking the script.
 The deploy helper exits with an error if no replacement connection string is
 provided.
 
@@ -92,11 +107,11 @@ fly releases rollback <version> -a banana-api
 - `GET /auth/session` validates active session state.
 - `POST /auth/logout` revokes active session state.
 
-Session persistence uses Neon/PostgreSQL when `NEON_DATABASE_URL` (or
+Session persistence uses PostgreSQL when `NEON_DATABASE_URL` (or
 `DATABASE_URL` / `BANANA_PG_CONNECTION`) is present, with a memory fallback for
 local/non-strict development.
 
-## Authoritative Neon Runtime Contract
+## Authoritative PostgreSQL Runtime Contract
 
 The API now resolves a single authoritative database URL at startup in this
 order:
@@ -106,7 +121,7 @@ order:
 3. `BANANA_PG_CONNECTION`
 
 When any one of these is present, startup syncs all three env aliases to the
-same value so route/services/native integrations use one consistent Neon
+same value so route/services/native integrations use one consistent PostgreSQL
 endpoint.
 
 Optional runtime controls:

--- a/src/typescript/react/bun.lock
+++ b/src/typescript/react/bun.lock
@@ -16,7 +16,7 @@
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0",
         "tailwind-merge": "^2.5.0",
-        "zustand": "^4.5.5",
+        "zustand": "^5.0.8",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^15.0.0",
@@ -457,8 +457,6 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
-    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
-
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
@@ -469,7 +467,7 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+    "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/src/typescript/react/package.json
+++ b/src/typescript/react/package.json
@@ -24,7 +24,7 @@
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0",
         "tailwind-merge": "^2.5.0",
-        "zustand": "^4.5.5"
+        "zustand": "^5.0.8"
     },
     "devDependencies": {
         "@types/bun": "latest",

--- a/src/typescript/react/scripts/dedupe-react.mjs
+++ b/src/typescript/react/scripts/dedupe-react.mjs
@@ -42,7 +42,7 @@ for (const scopedPkg of ["react", "react-dom"]) {
   console.log(`[dedupe-react] linked @types/${scopedPkg} -> ${target}`);
 }
 
-for (const pkg of ["react", "react-dom"]) {
+for (const pkg of ["react", "react-dom", "zustand"]) {
   const target = join(reactAppRoot, "node_modules", pkg);
   const link = join(sharedUiNm, pkg);
   if (!existsSync(target)) {

--- a/src/typescript/react/src/components/notebook-client/TrainingOperationsPanel.tsx
+++ b/src/typescript/react/src/components/notebook-client/TrainingOperationsPanel.tsx
@@ -33,7 +33,10 @@ const buttonStyle: CSSProperties = {
     cursor: 'pointer',
 };
 
-function buildBulkQueueTemplate(selectedFile: string):
+function buildBulkQueueTemplate(
+    selectedFile: string,
+    indexedFileCount: number,
+    mode: 'operations' | 'controller'):
     Array<{ title: string; sector: string; rewardXp: number; }> {
     const normalized = selectedFile.replace(/\\/g, '/');
     const lane = normalized.split('/').filter(Boolean).pop() ?? selectedFile;
@@ -41,8 +44,36 @@ function buildBulkQueueTemplate(selectedFile: string):
         .replace(/\.[^.]+$/, '')
         .replace(/[_-]+/g, ' ')
         .replace(/\b\w/g, (match) => match.toUpperCase());
-    const sector = selectedFile.length > 0 ? selectedFile : 'default-sector';
     const targetLabel = sectorLabel.length > 0 ? sectorLabel : 'Frontier Sector';
+
+    if (mode === 'controller') {
+        const controllerSector = 'controller-training';
+        const controllerScale = Math.max(1, Math.min(4, Math.floor(indexedFileCount / 40) + 1));
+        return [
+            {
+                title: `Calibrate controller reward gradients in ${targetLabel}`,
+                sector: controllerSector,
+                rewardXp: 140 + controllerScale * 20,
+            },
+            {
+                title: 'Run imitation pass for AI controller tuning',
+                sector: controllerSector,
+                rewardXp: 190 + controllerScale * 20,
+            },
+            {
+                title: `Validate controller policies against ${indexedFileCount} indexed files`,
+                sector: controllerSector,
+                rewardXp: 260 + controllerScale * 30,
+            },
+            {
+                title: 'Archive controller training telemetry and issue stipend',
+                sector: controllerSector,
+                rewardXp: 160 + controllerScale * 15,
+            },
+        ];
+    }
+
+    const sector = selectedFile.length > 0 ? selectedFile : 'default-sector';
     return [
         {
             title: `Survey frontier output in ${targetLabel}`,
@@ -114,6 +145,7 @@ export function TrainingOperationsPanel(
         queue.reduce((sum, item) => sum + (item.status === 'completed' ? item.rewardXp : 0), 0);
     const completedCount = queue.filter((item) => item.status === 'completed').length;
     const pendingRewards = rewards.filter((reward) => reward.status === 'pending');
+    const controllerDrillCount = queue.filter((item) => item.sector === 'controller-training').length;
 
     useEffect(() => {
         if (!canUseApi) {
@@ -178,16 +210,18 @@ export function TrainingOperationsPanel(
         };
     }, [apiBaseUrl, canUseApi, token]);
 
-    const scaffoldBulkTodos = async () => {
+    const scaffoldWorkflow = async (mode: 'operations' | 'controller') => {
         if (!isApiMode) {
             setErrorMessage(SERVER_REQUIRED_MESSAGE);
             setStatusMessage(SERVER_REQUIRED_MESSAGE);
             return;
         }
 
-        const seeds = buildBulkQueueTemplate(selectedFile);
+        const seeds = buildBulkQueueTemplate(selectedFile, indexedFileCount, mode);
         setErrorMessage(null);
-        setStatusMessage('Drafting operations queue...');
+        setStatusMessage(
+            mode === 'controller' ? 'Drafting AI controller training queue...' : 'Drafting operations queue...',
+        );
 
         setIsBusy(true);
         try {
@@ -199,18 +233,23 @@ export function TrainingOperationsPanel(
                 details: {
                     jobCount: response.jobs.length,
                     selectedFile,
+                    workflowMode: mode,
                 },
             });
-            setStatusMessage(`Scaffolded ${response.jobs.length} jobs in persistent queue.`);
+            setStatusMessage(
+                mode === 'controller' ?
+                    `Scaffolded ${response.jobs.length} AI controller drills in persistent queue.` :
+                    `Scaffolded ${response.jobs.length} jobs in persistent queue.`,
+            );
         } catch (error: unknown) {
             setErrorMessage(error instanceof Error ? error.message : 'Unable to scaffold queue.');
-            setStatusMessage('Draft failed.');
+            setStatusMessage(mode === 'controller' ? 'Controller draft failed.' : 'Draft failed.');
         } finally {
             setIsBusy(false);
         }
     };
 
-    const executeBulkTodos = async () => {
+    const executeWorkflow = async (mode: 'operations' | 'controller') => {
         if (!isApiMode) {
             setErrorMessage(SERVER_REQUIRED_MESSAGE);
             setStatusMessage(SERVER_REQUIRED_MESSAGE);
@@ -218,13 +257,13 @@ export function TrainingOperationsPanel(
         }
 
         setErrorMessage(null);
-        setStatusMessage('Running operations cycle...');
+        setStatusMessage(mode === 'controller' ? 'Running AI controller training cycle...' : 'Running operations cycle...');
 
         const queueToRun =
-            queue.length > 0 ? queue : (await scaffoldTrainingJobs(apiBaseUrl, token, buildBulkQueueTemplate(selectedFile))).jobs;
+            queue.length > 0 ? queue : (await scaffoldTrainingJobs(apiBaseUrl, token, buildBulkQueueTemplate(selectedFile, indexedFileCount, mode))).jobs;
         setQueue(queueToRun);
         setIsBusy(true);
-        const correlationId = makeCorrelationId('queue-execute');
+        const correlationId = makeCorrelationId(mode === 'controller' ? 'controller-execute' : 'queue-execute');
 
         try {
             await recordTrainingTransitionEvent(apiBaseUrl, token, {
@@ -232,6 +271,7 @@ export function TrainingOperationsPanel(
                 correlationId,
                 details: {
                     requestedJobs: queueToRun.length,
+                    workflowMode: mode,
                 },
             });
 
@@ -277,15 +317,36 @@ export function TrainingOperationsPanel(
                 details: {
                     completedJobs: queueToRun.length,
                     selectedFile,
+                    workflowMode: mode,
                 },
             });
-            setStatusMessage(`Cycle complete: ${queueToRun.length} operations processed.`);
+            setStatusMessage(
+                mode === 'controller' ?
+                    `Controller cycle complete: ${queueToRun.length} drills processed.` :
+                    `Cycle complete: ${queueToRun.length} operations processed.`,
+            );
         } catch (error: unknown) {
             setErrorMessage(error instanceof Error ? error.message : 'Queue execution failed.');
-            setStatusMessage('Cycle failed.');
+            setStatusMessage(mode === 'controller' ? 'Controller cycle failed.' : 'Cycle failed.');
         } finally {
             setIsBusy(false);
         }
+    };
+
+    const scaffoldBulkTodos = async () => {
+        await scaffoldWorkflow('operations');
+    };
+
+    const executeBulkTodos = async () => {
+        await executeWorkflow('operations');
+    };
+
+    const scaffoldControllerDrills = async () => {
+        await scaffoldWorkflow('controller');
+    };
+
+    const executeControllerDrills = async () => {
+        await executeWorkflow('controller');
     };
 
     const claimAllRewards = async () => {
@@ -372,6 +433,25 @@ export function TrainingOperationsPanel(
                     <div style={{ fontSize: 12, color: '#fcd34d', textTransform: 'uppercase' }}>Pending Stipends</div>
                     <div style={{ fontWeight: 700, fontSize: 18, marginTop: 3 }}>{pendingRewards.length}</div>
                 </div>
+                <div style={{ border: '1px solid rgba(251, 191, 36, 0.25)', borderRadius: 10, padding: 10, background: 'rgba(120, 53, 15, 0.2)' }}>
+                    <div style={{ fontSize: 12, color: '#fcd34d', textTransform: 'uppercase' }}>Controller Drills</div>
+                    <div style={{ fontWeight: 700, fontSize: 18, marginTop: 3 }}>{controllerDrillCount}</div>
+                </div>
+            </div>
+
+            <h3 style={{ margin: '14px 0 6px', fontSize: 14, color: '#fef08a', letterSpacing: '0.03em', textTransform: 'uppercase' }}>
+                AI Controller Training
+            </h3>
+            <p style={{ margin: '0 0 8px', color: '#fde68a', fontSize: 13 }}>
+                Draft controller drills, run the training cycle, and grant XP through the existing persistent reward economy.
+            </p>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 8 }}>
+                <button type="button" style={buttonStyle} onClick={() => void scaffoldControllerDrills()} disabled={isBusy}>
+                    Draft Controller Drills
+                </button>
+                <button type="button" style={buttonStyle} onClick={() => void executeControllerDrills()} disabled={isBusy || (!isApiMode && queue.length === 0)}>
+                    Run Controller Training
+                </button>
             </div>
 
             <h3 style={{ margin: '14px 0 6px', fontSize: 14, color: '#fef08a', letterSpacing: '0.03em', textTransform: 'uppercase' }}>

--- a/src/typescript/shared/ui/src/components/PanelGroup.tsx
+++ b/src/typescript/shared/ui/src/components/PanelGroup.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode, type CSSProperties } from 'react';
+import { useEffect, useState, type ReactNode, type CSSProperties } from 'react';
 import { ResizablePanel } from './ResizablePanel';
 
 export type PanelGroupEntry = {
@@ -28,6 +28,21 @@ export function PanelGroup({
 }: PanelGroupProps) {
     const [collapsedPanels, setCollapsedPanels] = useState<Set<string>>(new Set());
     const [expandedPanel, setExpandedPanel] = useState<string | null>(null);
+    const [panelSizeById, setPanelSizeById] = useState<Record<string, { width: number; height: number }>>({});
+
+    useEffect(() => {
+        setPanelSizeById((previous) => {
+            const next: Record<string, { width: number; height: number }> = {};
+            for (const entry of entries) {
+                const prior = previous[entry.id];
+                next[entry.id] = prior ?? {
+                    width: entry.defaultWidth ?? 360,
+                    height: entry.defaultHeight ?? 280,
+                };
+            }
+            return next;
+        });
+    }, [entries]);
 
     const toggleCollapse = (panelId: string) => {
         setCollapsedPanels((prev) => {
@@ -91,8 +106,8 @@ export function PanelGroup({
             {/* Main panel area */}
             <div style={activeLayoutStyle}>
                 {activePanels.map((entry, index) => {
-                    const width = entry.defaultWidth ?? 360;
-                    const height = entry.defaultHeight ?? 280;
+                    const width = panelSizeById[entry.id]?.width ?? entry.defaultWidth ?? 360;
+                    const height = panelSizeById[entry.id]?.height ?? entry.defaultHeight ?? 280;
                     const column = layout === 'grid' ? index % Math.max(1, maxColumns) : 0;
                     const row = layout === 'grid' ? Math.floor(index / Math.max(1, maxColumns)) : index;
                     const x = 16 + (column * (width + gap));
@@ -109,7 +124,16 @@ export function PanelGroup({
                             height={height}
                             isCollapsed={expandedPanel === entry.id}
                             onCollapse={() => toggleCollapse(entry.id)}
-                            onResize={(_, rect) => onPanelSizeChange?.(entry.id, rect.width, rect.height)}
+                            onResize={(_, rect) => {
+                                setPanelSizeById((previous) => ({
+                                    ...previous,
+                                    [entry.id]: {
+                                        width: rect.width,
+                                        height: rect.height,
+                                    },
+                                }));
+                                onPanelSizeChange?.(entry.id, rect.width, rect.height);
+                            }}
                             corner={corner}
                         >
                             {entry.children}

--- a/src/typescript/shared/ui/src/components/PanelGroup.tsx
+++ b/src/typescript/shared/ui/src/components/PanelGroup.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode, type CSSProperties } from 'react';
-import { ResizablePanel, type ResizablePanelProps } from './ResizablePanel';
+import { ResizablePanel } from './ResizablePanel';
 
 export type PanelGroupEntry = {
     readonly id: string;
@@ -90,21 +90,32 @@ export function PanelGroup({
         }}>
             {/* Main panel area */}
             <div style={activeLayoutStyle}>
-                {activePanels.map((entry) => (
-                    <ResizablePanel
-                        key={entry.id}
-                        id={entry.id}
-                        title={entry.title}
-                        defaultWidth={entry.defaultWidth}
-                        defaultHeight={entry.defaultHeight}
-                        isCollapsed={expandedPanel === entry.id}
-                        onCollapse={() => toggleCollapse(entry.id)}
-                        onResize={(w, h) => onPanelSizeChange?.(entry.id, w, h)}
-                        corner={corner}
-                    >
-                        {entry.children}
-                    </ResizablePanel>
-                ))}
+                {activePanels.map((entry, index) => {
+                    const width = entry.defaultWidth ?? 360;
+                    const height = entry.defaultHeight ?? 280;
+                    const column = layout === 'grid' ? index % Math.max(1, maxColumns) : 0;
+                    const row = layout === 'grid' ? Math.floor(index / Math.max(1, maxColumns)) : index;
+                    const x = 16 + (column * (width + gap));
+                    const y = 52 + (row * (height + gap));
+
+                    return (
+                        <ResizablePanel
+                            key={entry.id}
+                            id={entry.id}
+                            title={entry.title}
+                            x={x}
+                            y={y}
+                            width={width}
+                            height={height}
+                            isCollapsed={expandedPanel === entry.id}
+                            onCollapse={() => toggleCollapse(entry.id)}
+                            onResize={(_, rect) => onPanelSizeChange?.(entry.id, rect.width, rect.height)}
+                            corner={corner}
+                        >
+                            {entry.children}
+                        </ResizablePanel>
+                    );
+                })}
             </div>
 
             {/* Collapsed tabs sidebar */}

--- a/src/typescript/shared/ui/src/components/ResizableDockGrid.tsx
+++ b/src/typescript/shared/ui/src/components/ResizableDockGrid.tsx
@@ -4,6 +4,7 @@ import { PanelOverlay } from './PanelOverlay';
 import { useResizableDockLayoutStore, type DockCorner } from '../hooks/useResizableDockLayoutStore';
 
 type AnchorLink = { id: string; side: AnchorSide; };
+type DockLayoutStoreState = ReturnType<typeof useResizableDockLayoutStore.getState>;
 
 const groupPalette = ['#22d3ee', '#f59e0b', '#a78bfa', '#34d399', '#f472b6', '#60a5fa'];
 
@@ -28,14 +29,14 @@ export function ResizableDockGrid({ entries, onPanelSizeChange, onPanelClose }: 
     const layoutIdRef = useRef(`dock-${Math.random().toString(36).slice(2)}`);
     const layoutId = layoutIdRef.current;
     const [expandedPanel, setExpandedPanel] = useState<string | null>(null);
-    const initializeLayout = useResizableDockLayoutStore((state) => state.initializeLayout);
-    const focusPanelInStore = useResizableDockLayoutStore((state) => state.focusPanel);
-    const movePanelGroupBy = useResizableDockLayoutStore((state) => state.movePanelGroupBy);
-    const resizePanel = useResizableDockLayoutStore((state) => state.resizePanel);
-    const addAnchorLinkToStore = useResizableDockLayoutStore((state) => state.addAnchorLink);
-    const unlinkPanelFromStore = useResizableDockLayoutStore((state) => state.unlinkPanel);
-    const toggleResizeLockInStore = useResizableDockLayoutStore((state) => state.toggleResizeLock);
-    const layout = useResizableDockLayoutStore((state) => state.layouts[layoutId]);
+    const initializeLayout = useResizableDockLayoutStore((state: DockLayoutStoreState) => state.initializeLayout);
+    const focusPanelInStore = useResizableDockLayoutStore((state: DockLayoutStoreState) => state.focusPanel);
+    const movePanelGroupBy = useResizableDockLayoutStore((state: DockLayoutStoreState) => state.movePanelGroupBy);
+    const resizePanel = useResizableDockLayoutStore((state: DockLayoutStoreState) => state.resizePanel);
+    const addAnchorLinkToStore = useResizableDockLayoutStore((state: DockLayoutStoreState) => state.addAnchorLink);
+    const unlinkPanelFromStore = useResizableDockLayoutStore((state: DockLayoutStoreState) => state.unlinkPanel);
+    const toggleResizeLockInStore = useResizableDockLayoutStore((state: DockLayoutStoreState) => state.toggleResizeLock);
+    const layout = useResizableDockLayoutStore((state: DockLayoutStoreState) => state.layouts[layoutId]);
 
     useEffect(() => {
         const toSeeds = () => entries.map((entry) => ({

--- a/src/typescript/shared/ui/src/components/ResizablePanel.tsx
+++ b/src/typescript/shared/ui/src/components/ResizablePanel.tsx
@@ -135,12 +135,16 @@ export function ResizablePanel({
         });
     };
 
-    const flushResizeUpdate = () => {
+    const flushResizeUpdate = (commitPending: boolean = false) => {
         if (resizeRafRef.current !== null) {
             window.cancelAnimationFrame(resizeRafRef.current);
             resizeRafRef.current = null;
         }
+        const payload = pendingResizeRef.current;
         pendingResizeRef.current = null;
+        if (commitPending && payload) {
+            onResize?.(id, payload);
+        }
     };
 
     const startResize = (direction: ResizeDirection, event: ReactMouseEvent<HTMLDivElement>) => {
@@ -429,6 +433,8 @@ export function ResizablePanel({
         };
 
         const handleMouseUp = () => {
+            // Commit the latest buffered resize so mouseup never drops final size.
+            flushResizeUpdate(true);
             setActiveResize(null);
             resizeOriginRef.current = null;
             setGhostRect(null);
@@ -735,24 +741,38 @@ export function ResizablePanel({
 
     if (isCollapsed) {
         return (
-            <div style={{
-                position: 'fixed',
-                left: 0,
-                top: 0,
-                transform: `translate3d(${x}px, ${y}px, 0)`,
-                width: '40px',
-                height: '40px',
-                background: 'rgba(7, 19, 34, 0.9)',
-                border: '1px solid rgba(20, 184, 166, 0.2)',
-                borderRadius: '4px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                cursor: 'pointer',
-                fontSize: '11px',
-                color: 'rgba(226, 232, 240, 0.6)',
-                overflow: 'hidden',
-            }}>
+            <div
+                style={{
+                    position: 'fixed',
+                    left: 0,
+                    top: 0,
+                    transform: `translate3d(${x}px, ${y}px, 0)`,
+                    width: '40px',
+                    height: '40px',
+                    background: 'rgba(7, 19, 34, 0.9)',
+                    border: '1px solid rgba(20, 184, 166, 0.2)',
+                    borderRadius: '4px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: onExpand ? 'pointer' : 'default',
+                    fontSize: '11px',
+                    color: 'rgba(226, 232, 240, 0.6)',
+                    overflow: 'hidden',
+                }}
+                role={onExpand ? 'button' : undefined}
+                tabIndex={onExpand ? 0 : undefined}
+                onClick={onExpand}
+                onKeyDown={(event) => {
+                    if (!onExpand) {
+                        return;
+                    }
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        onExpand();
+                    }
+                }}
+            >
                 {id.charAt(0).toUpperCase()}
             </div>
         );

--- a/src/typescript/shared/ui/src/hooks/useResizableDockLayoutStore.ts
+++ b/src/typescript/shared/ui/src/hooks/useResizableDockLayoutStore.ts
@@ -144,218 +144,232 @@ export const useResizableDockLayoutStore = create<DockLayoutsStore>(
     (set) => ({
       layouts: {},
 
-      initializeLayout: (layoutId, entries, viewport) => set((state) => {
-        const current = state.layouts[layoutId];
-        const nextPanels: Record<string, DockPanelState> = {};
-        const nextFocusOrder =
-            current?.focusOrder.filter(
-                (id) => entries.some((entry) => entry.id === id)) ??
-            [];
+      initializeLayout: (
+          layoutId: string, entries: DockEntrySeed[], viewport: DockViewport) =>
+          set((state: DockLayoutsStore) => {
+            const current = state.layouts[layoutId];
+            const nextPanels: Record<string, DockPanelState> = {};
+            const nextFocusOrder =
+                current?.focusOrder.filter(
+                    (id) => entries.some((entry) => entry.id === id)) ??
+                [];
 
-        const byCorner: Record<DockCorner, DockEntrySeed[]> = {
-          'top-left': [],
-          'top-right': [],
-          'bottom-left': [],
-          'bottom-right': [],
-        };
-
-        for (const entry of entries) {
-          byCorner[entry.corner].push(entry);
-        }
-
-        for (const entry of entries) {
-          const cornerIndex = byCorner[entry.corner].findIndex(
-              (candidate) => candidate.id === entry.id);
-          const baseRect = getDefaultRect(entry, cornerIndex, viewport);
-          const previous = current?.panels[entry.id];
-          const resetToken = entry.resetToken ?? 0;
-          const rect = !previous || previous.resetToken !== resetToken ?
-              baseRect :
-              clampRectToViewport(previous, viewport);
-
-          nextPanels[entry.id] = {
-            ...rect,
-            corner: entry.corner,
-            zIndex: previous?.zIndex ?? 10 + nextFocusOrder.length,
-            resetToken,
-          };
-
-          if (!nextFocusOrder.includes(entry.id)) {
-            nextFocusOrder.push(entry.id);
-          }
-        }
-
-        nextFocusOrder.forEach((id, index) => {
-          if (nextPanels[id]) {
-            nextPanels[id].zIndex = 10 + index;
-          }
-        });
-
-        const nextAnchorLinks: Record<string, DockAnchorLink[]> = {};
-        for (const [id, links] of Object.entries(current?.anchorLinks ?? {})) {
-          if (!nextPanels[id]) {
-            continue;
-          }
-          const validLinks =
-              links.filter((link) => Boolean(nextPanels[link.id]));
-          if (validLinks.length > 0) {
-            nextAnchorLinks[id] = validLinks;
-          }
-        }
-
-        const nextResizeLocks: Record<string, boolean> = {};
-        for (const [id, locked] of Object.entries(
-                 current?.resizeLockedByPanel ?? {})) {
-          if (nextPanels[id]) {
-            nextResizeLocks[id] = locked;
-          }
-        }
-
-        return {
-          layouts: {
-            ...state.layouts,
-            [layoutId]: {
-              panels: nextPanels,
-              focusOrder: nextFocusOrder,
-              anchorLinks: nextAnchorLinks,
-              resizeLockedByPanel: nextResizeLocks,
-              viewport,
-            },
-          },
-        };
-      }),
-
-      focusPanel: (layoutId, panelId) => set((state) => {
-        const layout = state.layouts[layoutId];
-        if (!layout?.panels[panelId]) {
-          return state;
-        }
-
-        const focusOrder =
-            [...layout.focusOrder.filter((id) => id !== panelId), panelId];
-        const panels = {...layout.panels};
-        focusOrder.forEach((id, index) => {
-          if (panels[id]) {
-            panels[id] = {...panels[id], zIndex: 10 + index};
-          }
-        });
-
-        return {
-          layouts: {
-            ...state.layouts,
-            [layoutId]: {...layout, focusOrder, panels},
-          },
-        };
-      }),
-
-      movePanelGroupBy: (layoutId, panelId, delta) => set((state) => {
-        const layout = state.layouts[layoutId];
-        if (!layout?.panels[panelId]) {
-          return state;
-        }
-
-        const members = getGroupMembers(layout, panelId);
-        const bounds = members.reduce((acc, memberId) => {
-          const panel = layout.panels[memberId];
-          if (!panel) {
-            return acc;
-          }
-          return {
-            left: Math.min(acc.left, panel.x),
-            top: Math.min(acc.top, panel.y),
-            right: Math.max(acc.right, panel.x + panel.width),
-            bottom: Math.max(acc.bottom, panel.y + panel.height),
-          };
-        }, {
-          left: Number.POSITIVE_INFINITY,
-          top: Number.POSITIVE_INFINITY,
-          right: Number.NEGATIVE_INFINITY,
-          bottom: Number.NEGATIVE_INFINITY,
-        });
-
-        const dx = clamp(
-            delta.x, viewportPadding - bounds.left,
-            layout.viewport.width - viewportPadding - bounds.right);
-        const dy = clamp(
-            delta.y, viewportPadding - bounds.top,
-            layout.viewport.height - viewportPadding - bounds.bottom);
-
-        if (dx === 0 && dy === 0) {
-          return state;
-        }
-
-        const panels = {...layout.panels};
-        for (const memberId of members) {
-          const panel = panels[memberId];
-          if (!panel) {
-            continue;
-          }
-          panels[memberId] = {
-            ...panel,
-            x: panel.x + dx,
-            y: panel.y + dy,
-          };
-        }
-
-        return {
-          layouts: {
-            ...state.layouts,
-            [layoutId]: {...layout, panels},
-          },
-        };
-      }),
-
-      resizePanel: (layoutId, panelId, rect) => set((state) => {
-        const layout = state.layouts[layoutId];
-        const panel = layout?.panels[panelId];
-        if (!layout || !panel) {
-          return state;
-        }
-
-        const nextRect = clampRectToViewport(rect, layout.viewport);
-        const dw = nextRect.width - panel.width;
-        const dh = nextRect.height - panel.height;
-
-        const panels = {
-          ...layout.panels,
-          [panelId]: {
-            ...panel,
-            ...nextRect,
-          },
-        };
-
-        if (layout.resizeLockedByPanel[panelId]) {
-          const members =
-              getGroupMembers(layout, panelId).filter((id) => id !== panelId);
-          for (const memberId of members) {
-            const member = panels[memberId];
-            if (!member) {
-              continue;
-            }
-            panels[memberId] = {
-              ...member,
-              ...clampRectToViewport(
-                  {
-                    x: member.x,
-                    y: member.y,
-                    width: member.width + dw,
-                    height: member.height + dh,
-                  },
-                  layout.viewport),
+            const byCorner: Record<DockCorner, DockEntrySeed[]> = {
+              'top-left': [],
+              'top-right': [],
+              'bottom-left': [],
+              'bottom-right': [],
             };
-          }
-        }
 
-        return {
-          layouts: {
-            ...state.layouts,
-            [layoutId]: {...layout, panels},
-          },
-        };
-      }),
+            for (const entry of entries) {
+              byCorner[entry.corner].push(entry);
+            }
+
+            for (const entry of entries) {
+              const cornerIndex = byCorner[entry.corner].findIndex(
+                  (candidate) => candidate.id === entry.id);
+              const baseRect = getDefaultRect(entry, cornerIndex, viewport);
+              const previous = current?.panels[entry.id];
+              const resetToken = entry.resetToken ?? 0;
+              const rect = !previous || previous.resetToken !== resetToken ?
+                  baseRect :
+                  clampRectToViewport(previous, viewport);
+
+              nextPanels[entry.id] = {
+                ...rect,
+                corner: entry.corner,
+                zIndex: previous?.zIndex ?? 10 + nextFocusOrder.length,
+                resetToken,
+              };
+
+              if (!nextFocusOrder.includes(entry.id)) {
+                nextFocusOrder.push(entry.id);
+              }
+            }
+
+            nextFocusOrder.forEach((id, index) => {
+              if (nextPanels[id]) {
+                nextPanels[id].zIndex = 10 + index;
+              }
+            });
+
+            const nextAnchorLinks: Record<string, DockAnchorLink[]> = {};
+            const currentAnchorLinks: Record<string, DockAnchorLink[]> =
+                current?.anchorLinks ?? {};
+            for (const [id, links] of Object.entries(
+                     currentAnchorLinks) as [string, DockAnchorLink[]][]) {
+              if (!nextPanels[id]) {
+                continue;
+              }
+              const validLinks = links.filter(
+                  (link: DockAnchorLink) => Boolean(nextPanels[link.id]));
+              if (validLinks.length > 0) {
+                nextAnchorLinks[id] = validLinks;
+              }
+            }
+
+            const nextResizeLocks: Record<string, boolean> = {};
+            const currentResizeLocks: Record<string, boolean> =
+                current?.resizeLockedByPanel ?? {};
+            for (const [id, locked] of Object.entries(
+                     currentResizeLocks) as [string, boolean][]) {
+              if (nextPanels[id]) {
+                nextResizeLocks[id] = locked;
+              }
+            }
+
+            return {
+              layouts: {
+                ...state.layouts,
+                [layoutId]: {
+                  panels: nextPanels,
+                  focusOrder: nextFocusOrder,
+                  anchorLinks: nextAnchorLinks,
+                  resizeLockedByPanel: nextResizeLocks,
+                  viewport,
+                },
+              },
+            };
+          }),
+
+      focusPanel: (layoutId: string, panelId: string) =>
+          set((state: DockLayoutsStore) => {
+            const layout = state.layouts[layoutId];
+            if (!layout?.panels[panelId]) {
+              return state;
+            }
+
+            const focusOrder = [
+              ...layout.focusOrder.filter((id: string) => id !== panelId),
+              panelId
+            ];
+            const panels = {...layout.panels};
+            focusOrder.forEach((id: string, index: number) => {
+              if (panels[id]) {
+                panels[id] = {...panels[id], zIndex: 10 + index};
+              }
+            });
+
+            return {
+              layouts: {
+                ...state.layouts,
+                [layoutId]: {...layout, focusOrder, panels},
+              },
+            };
+          }),
+
+      movePanelGroupBy:
+          (layoutId: string, panelId: string, delta: {x: number; y: number}) =>
+              set((state: DockLayoutsStore) => {
+                const layout = state.layouts[layoutId];
+                if (!layout?.panels[panelId]) {
+                  return state;
+                }
+
+                const members = getGroupMembers(layout, panelId);
+                const bounds = members.reduce((acc, memberId) => {
+                  const panel = layout.panels[memberId];
+                  if (!panel) {
+                    return acc;
+                  }
+                  return {
+                    left: Math.min(acc.left, panel.x),
+                    top: Math.min(acc.top, panel.y),
+                    right: Math.max(acc.right, panel.x + panel.width),
+                    bottom: Math.max(acc.bottom, panel.y + panel.height),
+                  };
+                }, {
+                  left: Number.POSITIVE_INFINITY,
+                  top: Number.POSITIVE_INFINITY,
+                  right: Number.NEGATIVE_INFINITY,
+                  bottom: Number.NEGATIVE_INFINITY,
+                });
+
+                const dx = clamp(
+                    delta.x, viewportPadding - bounds.left,
+                    layout.viewport.width - viewportPadding - bounds.right);
+                const dy = clamp(
+                    delta.y, viewportPadding - bounds.top,
+                    layout.viewport.height - viewportPadding - bounds.bottom);
+
+                if (dx === 0 && dy === 0) {
+                  return state;
+                }
+
+                const panels = {...layout.panels};
+                for (const memberId of members) {
+                  const panel = panels[memberId];
+                  if (!panel) {
+                    continue;
+                  }
+                  panels[memberId] = {
+                    ...panel,
+                    x: panel.x + dx,
+                    y: panel.y + dy,
+                  };
+                }
+
+                return {
+                  layouts: {
+                    ...state.layouts,
+                    [layoutId]: {...layout, panels},
+                  },
+                };
+              }),
+
+      resizePanel: (layoutId: string, panelId: string, rect: DockPanelRect) =>
+          set((state: DockLayoutsStore) => {
+            const layout = state.layouts[layoutId];
+            const panel = layout?.panels[panelId];
+            if (!layout || !panel) {
+              return state;
+            }
+
+            const nextRect = clampRectToViewport(rect, layout.viewport);
+            const dw = nextRect.width - panel.width;
+            const dh = nextRect.height - panel.height;
+
+            const panels = {
+              ...layout.panels,
+              [panelId]: {
+                ...panel,
+                ...nextRect,
+              },
+            };
+
+            if (layout.resizeLockedByPanel[panelId]) {
+              const members = getGroupMembers(layout, panelId)
+                                  .filter((id: string) => id !== panelId);
+              for (const memberId of members) {
+                const member = panels[memberId];
+                if (!member) {
+                  continue;
+                }
+                panels[memberId] = {
+                  ...member,
+                  ...clampRectToViewport(
+                      {
+                        x: member.x,
+                        y: member.y,
+                        width: member.width + dw,
+                        height: member.height + dh,
+                      },
+                      layout.viewport),
+                };
+              }
+            }
+
+            return {
+              layouts: {
+                ...state.layouts,
+                [layoutId]: {...layout, panels},
+              },
+            };
+          }),
 
       addAnchorLink: (
-          layoutId, sourceId, targetId, sourceSide) => set((state) => {
+          layoutId: string, sourceId: string, targetId: string,
+          sourceSide: DockAnchorSide) => set((state: DockLayoutsStore) => {
         const layout = state.layouts[layoutId];
         if (!layout?.panels[sourceId] || !layout.panels[targetId]) {
           return state;
@@ -364,7 +378,8 @@ export const useResizableDockLayoutStore = create<DockLayoutsStore>(
         const anchorLinks = {...layout.anchorLinks};
         const put = (fromId: string, toId: string, side: DockAnchorSide) => {
           const next = [
-            ...(anchorLinks[fromId] ?? []).filter((link) => link.id !== toId),
+            ...(anchorLinks[fromId] ?? [])
+                .filter((link: DockAnchorLink) => link.id !== toId),
             {id: toId, side}
           ];
           anchorLinks[fromId] = next;
@@ -381,52 +396,56 @@ export const useResizableDockLayoutStore = create<DockLayoutsStore>(
         };
       }),
 
-      unlinkPanel: (layoutId, panelId) => set((state) => {
-        const layout = state.layouts[layoutId];
-        if (!layout?.panels[panelId]) {
-          return state;
-        }
+      unlinkPanel: (layoutId: string, panelId: string) =>
+          set((state: DockLayoutsStore) => {
+            const layout = state.layouts[layoutId];
+            if (!layout?.panels[panelId]) {
+              return state;
+            }
 
-        const anchorLinks: Record<string, DockAnchorLink[]> = {};
-        for (const [id, links] of Object.entries(layout.anchorLinks)) {
-          if (id === panelId) {
-            continue;
-          }
-          const filtered = links.filter((link) => link.id !== panelId);
-          if (filtered.length > 0) {
-            anchorLinks[id] = filtered;
-          }
-        }
+            const anchorLinks: Record<string, DockAnchorLink[]> = {};
+            for (const [id, links] of Object.entries(
+                     layout.anchorLinks) as [string, DockAnchorLink[]][]) {
+              if (id === panelId) {
+                continue;
+              }
+              const filtered =
+                  links.filter((link: DockAnchorLink) => link.id !== panelId);
+              if (filtered.length > 0) {
+                anchorLinks[id] = filtered;
+              }
+            }
 
-        const resizeLockedByPanel = {...layout.resizeLockedByPanel};
-        delete resizeLockedByPanel[panelId];
+            const resizeLockedByPanel = {...layout.resizeLockedByPanel};
+            delete resizeLockedByPanel[panelId];
 
-        return {
-          layouts: {
-            ...state.layouts,
-            [layoutId]: {...layout, anchorLinks, resizeLockedByPanel},
-          },
-        };
-      }),
+            return {
+              layouts: {
+                ...state.layouts,
+                [layoutId]: {...layout, anchorLinks, resizeLockedByPanel},
+              },
+            };
+          }),
 
-      toggleResizeLock: (layoutId, panelId) => set((state) => {
-        const layout = state.layouts[layoutId];
-        if (!layout?.panels[panelId]) {
-          return state;
-        }
+      toggleResizeLock: (layoutId: string, panelId: string) =>
+          set((state: DockLayoutsStore) => {
+            const layout = state.layouts[layoutId];
+            if (!layout?.panels[panelId]) {
+              return state;
+            }
 
-        const group = getGroupMembers(layout, panelId);
-        const locked = layout.resizeLockedByPanel[panelId] ?? false;
-        const resizeLockedByPanel = {...layout.resizeLockedByPanel};
-        for (const memberId of group) {
-          resizeLockedByPanel[memberId] = !locked;
-        }
+            const group = getGroupMembers(layout, panelId);
+            const locked = layout.resizeLockedByPanel[panelId] ?? false;
+            const resizeLockedByPanel = {...layout.resizeLockedByPanel};
+            for (const memberId of group) {
+              resizeLockedByPanel[memberId] = !locked;
+            }
 
-        return {
-          layouts: {
-            ...state.layouts,
-            [layoutId]: {...layout, resizeLockedByPanel},
-          },
-        };
-      }),
+            return {
+              layouts: {
+                ...state.layouts,
+                [layoutId]: {...layout, resizeLockedByPanel},
+              },
+            };
+          }),
     }));

--- a/src/typescript/shared/ui/src/hooks/useResizableDockLayoutStore.ts
+++ b/src/typescript/shared/ui/src/hooks/useResizableDockLayoutStore.ts
@@ -1,4 +1,4 @@
-import {create} from 'zustand';
+import {create, type StateCreator} from 'zustand';
 
 export type DockCorner = 'top-left'|'top-right'|'bottom-left'|'bottom-right';
 export type DockAnchorSide = 'left'|'right'|'top'|'bottom';
@@ -140,8 +140,7 @@ const getGroupMembers =
       return [...visited];
     };
 
-export const useResizableDockLayoutStore = create<DockLayoutsStore>(
-    (set) => ({
+const createDockLayoutsStore: StateCreator<DockLayoutsStore> = (set) => ({
       layouts: {},
 
       initializeLayout: (
@@ -448,4 +447,6 @@ export const useResizableDockLayoutStore = create<DockLayoutsStore>(
               },
             };
           }),
-    }));
+        });
+
+    export const useResizableDockLayoutStore = create<DockLayoutsStore>(createDockLayoutsStore);

--- a/src/typescript/shared/ui/src/hooks/useResizableDockLayoutStore.ts
+++ b/src/typescript/shared/ui/src/hooks/useResizableDockLayoutStore.ts
@@ -141,10 +141,10 @@ const getGroupMembers =
     };
 
 const createDockLayoutsStore: StateCreator<DockLayoutsStore> = (set) => ({
-      layouts: {},
+  layouts: {},
 
-      initializeLayout: (
-          layoutId: string, entries: DockEntrySeed[], viewport: DockViewport) =>
+  initializeLayout:
+      (layoutId: string, entries: DockEntrySeed[], viewport: DockViewport) =>
           set((state: DockLayoutsStore) => {
             const current = state.layouts[layoutId];
             const nextPanels: Record<string, DockPanelState> = {};
@@ -231,131 +231,79 @@ const createDockLayoutsStore: StateCreator<DockLayoutsStore> = (set) => ({
             };
           }),
 
-      focusPanel: (layoutId: string, panelId: string) =>
+  focusPanel: (
+      layoutId: string, panelId: string) => set((state: DockLayoutsStore) => {
+    const layout = state.layouts[layoutId];
+    if (!layout?.panels[panelId]) {
+      return state;
+    }
+
+    const focusOrder =
+        [...layout.focusOrder.filter((id: string) => id !== panelId), panelId];
+    const panels = {...layout.panels};
+    focusOrder.forEach((id: string, index: number) => {
+      if (panels[id]) {
+        panels[id] = {...panels[id], zIndex: 10 + index};
+      }
+    });
+
+    return {
+      layouts: {
+        ...state.layouts,
+        [layoutId]: {...layout, focusOrder, panels},
+      },
+    };
+  }),
+
+  movePanelGroupBy:
+      (layoutId: string, panelId: string, delta: {x: number; y: number}) =>
           set((state: DockLayoutsStore) => {
             const layout = state.layouts[layoutId];
             if (!layout?.panels[panelId]) {
               return state;
             }
 
-            const focusOrder = [
-              ...layout.focusOrder.filter((id: string) => id !== panelId),
-              panelId
-            ];
-            const panels = {...layout.panels};
-            focusOrder.forEach((id: string, index: number) => {
-              if (panels[id]) {
-                panels[id] = {...panels[id], zIndex: 10 + index};
+            const members = getGroupMembers(layout, panelId);
+            const bounds = members.reduce((acc, memberId) => {
+              const panel = layout.panels[memberId];
+              if (!panel) {
+                return acc;
               }
+              return {
+                left: Math.min(acc.left, panel.x),
+                top: Math.min(acc.top, panel.y),
+                right: Math.max(acc.right, panel.x + panel.width),
+                bottom: Math.max(acc.bottom, panel.y + panel.height),
+              };
+            }, {
+              left: Number.POSITIVE_INFINITY,
+              top: Number.POSITIVE_INFINITY,
+              right: Number.NEGATIVE_INFINITY,
+              bottom: Number.NEGATIVE_INFINITY,
             });
 
-            return {
-              layouts: {
-                ...state.layouts,
-                [layoutId]: {...layout, focusOrder, panels},
-              },
-            };
-          }),
+            const dx = clamp(
+                delta.x, viewportPadding - bounds.left,
+                layout.viewport.width - viewportPadding - bounds.right);
+            const dy = clamp(
+                delta.y, viewportPadding - bounds.top,
+                layout.viewport.height - viewportPadding - bounds.bottom);
 
-      movePanelGroupBy:
-          (layoutId: string, panelId: string, delta: {x: number; y: number}) =>
-              set((state: DockLayoutsStore) => {
-                const layout = state.layouts[layoutId];
-                if (!layout?.panels[panelId]) {
-                  return state;
-                }
-
-                const members = getGroupMembers(layout, panelId);
-                const bounds = members.reduce((acc, memberId) => {
-                  const panel = layout.panels[memberId];
-                  if (!panel) {
-                    return acc;
-                  }
-                  return {
-                    left: Math.min(acc.left, panel.x),
-                    top: Math.min(acc.top, panel.y),
-                    right: Math.max(acc.right, panel.x + panel.width),
-                    bottom: Math.max(acc.bottom, panel.y + panel.height),
-                  };
-                }, {
-                  left: Number.POSITIVE_INFINITY,
-                  top: Number.POSITIVE_INFINITY,
-                  right: Number.NEGATIVE_INFINITY,
-                  bottom: Number.NEGATIVE_INFINITY,
-                });
-
-                const dx = clamp(
-                    delta.x, viewportPadding - bounds.left,
-                    layout.viewport.width - viewportPadding - bounds.right);
-                const dy = clamp(
-                    delta.y, viewportPadding - bounds.top,
-                    layout.viewport.height - viewportPadding - bounds.bottom);
-
-                if (dx === 0 && dy === 0) {
-                  return state;
-                }
-
-                const panels = {...layout.panels};
-                for (const memberId of members) {
-                  const panel = panels[memberId];
-                  if (!panel) {
-                    continue;
-                  }
-                  panels[memberId] = {
-                    ...panel,
-                    x: panel.x + dx,
-                    y: panel.y + dy,
-                  };
-                }
-
-                return {
-                  layouts: {
-                    ...state.layouts,
-                    [layoutId]: {...layout, panels},
-                  },
-                };
-              }),
-
-      resizePanel: (layoutId: string, panelId: string, rect: DockPanelRect) =>
-          set((state: DockLayoutsStore) => {
-            const layout = state.layouts[layoutId];
-            const panel = layout?.panels[panelId];
-            if (!layout || !panel) {
+            if (dx === 0 && dy === 0) {
               return state;
             }
 
-            const nextRect = clampRectToViewport(rect, layout.viewport);
-            const dw = nextRect.width - panel.width;
-            const dh = nextRect.height - panel.height;
-
-            const panels = {
-              ...layout.panels,
-              [panelId]: {
-                ...panel,
-                ...nextRect,
-              },
-            };
-
-            if (layout.resizeLockedByPanel[panelId]) {
-              const members = getGroupMembers(layout, panelId)
-                                  .filter((id: string) => id !== panelId);
-              for (const memberId of members) {
-                const member = panels[memberId];
-                if (!member) {
-                  continue;
-                }
-                panels[memberId] = {
-                  ...member,
-                  ...clampRectToViewport(
-                      {
-                        x: member.x,
-                        y: member.y,
-                        width: member.width + dw,
-                        height: member.height + dh,
-                      },
-                      layout.viewport),
-                };
+            const panels = {...layout.panels};
+            for (const memberId of members) {
+              const panel = panels[memberId];
+              if (!panel) {
+                continue;
               }
+              panels[memberId] = {
+                ...panel,
+                x: panel.x + dx,
+                y: panel.y + dy,
+              };
             }
 
             return {
@@ -366,9 +314,59 @@ const createDockLayoutsStore: StateCreator<DockLayoutsStore> = (set) => ({
             };
           }),
 
-      addAnchorLink: (
-          layoutId: string, sourceId: string, targetId: string,
-          sourceSide: DockAnchorSide) => set((state: DockLayoutsStore) => {
+  resizePanel: (layoutId: string, panelId: string, rect: DockPanelRect) =>
+      set((state: DockLayoutsStore) => {
+        const layout = state.layouts[layoutId];
+        const panel = layout?.panels[panelId];
+        if (!layout || !panel) {
+          return state;
+        }
+
+        const nextRect = clampRectToViewport(rect, layout.viewport);
+        const dw = nextRect.width - panel.width;
+        const dh = nextRect.height - panel.height;
+
+        const panels = {
+          ...layout.panels,
+          [panelId]: {
+            ...panel,
+            ...nextRect,
+          },
+        };
+
+        if (layout.resizeLockedByPanel[panelId]) {
+          const members = getGroupMembers(layout, panelId)
+                              .filter((id: string) => id !== panelId);
+          for (const memberId of members) {
+            const member = panels[memberId];
+            if (!member) {
+              continue;
+            }
+            panels[memberId] = {
+              ...member,
+              ...clampRectToViewport(
+                  {
+                    x: member.x,
+                    y: member.y,
+                    width: member.width + dw,
+                    height: member.height + dh,
+                  },
+                  layout.viewport),
+            };
+          }
+        }
+
+        return {
+          layouts: {
+            ...state.layouts,
+            [layoutId]: {...layout, panels},
+          },
+        };
+      }),
+
+  addAnchorLink:
+      (layoutId: string, sourceId: string, targetId: string,
+       sourceSide: DockAnchorSide) => set((state: DockLayoutsStore) => {
         const layout = state.layouts[layoutId];
         if (!layout?.panels[sourceId] || !layout.panels[targetId]) {
           return state;
@@ -395,58 +393,59 @@ const createDockLayoutsStore: StateCreator<DockLayoutsStore> = (set) => ({
         };
       }),
 
-      unlinkPanel: (layoutId: string, panelId: string) =>
-          set((state: DockLayoutsStore) => {
-            const layout = state.layouts[layoutId];
-            if (!layout?.panels[panelId]) {
-              return state;
-            }
+  unlinkPanel: (layoutId: string, panelId: string) =>
+      set((state: DockLayoutsStore) => {
+        const layout = state.layouts[layoutId];
+        if (!layout?.panels[panelId]) {
+          return state;
+        }
 
-            const anchorLinks: Record<string, DockAnchorLink[]> = {};
-            for (const [id, links] of Object.entries(
-                     layout.anchorLinks) as [string, DockAnchorLink[]][]) {
-              if (id === panelId) {
-                continue;
-              }
-              const filtered =
-                  links.filter((link: DockAnchorLink) => link.id !== panelId);
-              if (filtered.length > 0) {
-                anchorLinks[id] = filtered;
-              }
-            }
+        const anchorLinks: Record<string, DockAnchorLink[]> = {};
+        for (const [id, links] of Object.entries(
+                 layout.anchorLinks) as [string, DockAnchorLink[]][]) {
+          if (id === panelId) {
+            continue;
+          }
+          const filtered =
+              links.filter((link: DockAnchorLink) => link.id !== panelId);
+          if (filtered.length > 0) {
+            anchorLinks[id] = filtered;
+          }
+        }
 
-            const resizeLockedByPanel = {...layout.resizeLockedByPanel};
-            delete resizeLockedByPanel[panelId];
+        const resizeLockedByPanel = {...layout.resizeLockedByPanel};
+        delete resizeLockedByPanel[panelId];
 
-            return {
-              layouts: {
-                ...state.layouts,
-                [layoutId]: {...layout, anchorLinks, resizeLockedByPanel},
-              },
-            };
-          }),
+        return {
+          layouts: {
+            ...state.layouts,
+            [layoutId]: {...layout, anchorLinks, resizeLockedByPanel},
+          },
+        };
+      }),
 
-      toggleResizeLock: (layoutId: string, panelId: string) =>
-          set((state: DockLayoutsStore) => {
-            const layout = state.layouts[layoutId];
-            if (!layout?.panels[panelId]) {
-              return state;
-            }
+  toggleResizeLock: (layoutId: string, panelId: string) =>
+      set((state: DockLayoutsStore) => {
+        const layout = state.layouts[layoutId];
+        if (!layout?.panels[panelId]) {
+          return state;
+        }
 
-            const group = getGroupMembers(layout, panelId);
-            const locked = layout.resizeLockedByPanel[panelId] ?? false;
-            const resizeLockedByPanel = {...layout.resizeLockedByPanel};
-            for (const memberId of group) {
-              resizeLockedByPanel[memberId] = !locked;
-            }
+        const group = getGroupMembers(layout, panelId);
+        const locked = layout.resizeLockedByPanel[panelId] ?? false;
+        const resizeLockedByPanel = {...layout.resizeLockedByPanel};
+        for (const memberId of group) {
+          resizeLockedByPanel[memberId] = !locked;
+        }
 
-            return {
-              layouts: {
-                ...state.layouts,
-                [layoutId]: {...layout, resizeLockedByPanel},
-              },
-            };
-          }),
-        });
+        return {
+          layouts: {
+            ...state.layouts,
+            [layoutId]: {...layout, resizeLockedByPanel},
+          },
+        };
+      }),
+});
 
-    export const useResizableDockLayoutStore = create<DockLayoutsStore>(createDockLayoutsStore);
+export const useResizableDockLayoutStore =
+    create<DockLayoutsStore>(createDockLayoutsStore);


### PR DESCRIPTION
## Summary
- add a repo-owned Fly PostgreSQL image with pg_durable baked in
- add init bootstrap to create pg_durable in postgres during first boot
- add  to build and push immutable Fly registry tags
- update Fly/Postgres and API docs to use the repo-owned image path
- extend notebook client training panel with a dedicated AI controller training workflow lane

## Local validation
- built image locally: [1A[1B[0G[?25l
[?25h[1A[0G[?25l[+] Building 0.0s (0/0)                                    docker:desktop-linux
[?25h
- ran container locally with 
- verified extension and preload:
  -  exists in 
  -  includes 
