### PR TITLE
feat(db): stabilize Fly PG18 + pg_durable runtime

### DIFF
--- a/docker/pg-durable/banana-entrypoint.sh
+++ b/docker/pg-durable/banana-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "postgres" ]]; then
+  exec "$@"
+fi
+
+: "${POSTGRES_USER:=postgres}"
+: "${POSTGRES_DB:=postgres}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}"
+: "${PGDATA:=/var/lib/postgresql/data/pgdata}"
+
+mkdir -p "$PGDATA"
+chown -R postgres:postgres /var/lib/postgresql
+chmod 700 "$PGDATA" || true
+
+if [[ ! -s "$PGDATA/PG_VERSION" ]]; then
+  tmp_pw="$(mktemp)"
+  trap 'rm -f "$tmp_pw"' EXIT
+  printf '%s' "$POSTGRES_PASSWORD" > "$tmp_pw"
+  chown postgres:postgres "$tmp_pw"
+  chmod 600 "$tmp_pw"
+
+  gosu postgres initdb -D "$PGDATA" --username="$POSTGRES_USER" --pwfile="$tmp_pw"
+  {
+    echo "host all all all scram-sha-256"
+    echo "host all all all md5"
+  } >> "$PGDATA/pg_hba.conf"
+
+  gosu postgres pg_ctl -D "$PGDATA" -o "-c listen_addresses=localhost -c shared_preload_libraries=pg_durable -c pg_durable.worker_role=postgres" -w start
+
+  if ! gosu postgres psql --username "$POSTGRES_USER" --dbname postgres -tc "SELECT 1 FROM pg_database WHERE datname='$POSTGRES_DB'" | grep -q 1; then
+    gosu postgres psql --username "$POSTGRES_USER" --dbname postgres -c "CREATE DATABASE \"$POSTGRES_DB\";"
+  fi
+
+  gosu postgres psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS pg_durable;"
+  gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop
+fi
+
+exec gosu postgres postgres -D "$PGDATA" -c shared_preload_libraries=pg_durable -c pg_durable.worker_role=postgres -c listen_addresses='*'

--- a/docker/pg-durable/initdb/010-create-extension.sh
+++ b/docker/pg-durable/initdb/010-create-extension.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# pg_durable must be loaded via shared_preload_libraries before this runs.
+# docker-entrypoint-initdb.d scripts run as the postgres superuser on first init.
 set -euo pipefail
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres <<'SQL'

--- a/docker/postgres-pg-durable.Dockerfile
+++ b/docker/postgres-pg-durable.Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:17-bookworm
+FROM postgres:18-bookworm
 
 ARG PG_DURABLE_VERSION=0.2.2
 ARG TARGETARCH=amd64
@@ -8,7 +8,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
-    package="pg-durable-postgresql-17_${PG_DURABLE_VERSION}-1_${TARGETARCH}.deb"; \
+    package="pg-durable-postgresql-18_${PG_DURABLE_VERSION}-1_${TARGETARCH}.deb"; \
     url="https://github.com/microsoft/pg_durable/releases/download/v${PG_DURABLE_VERSION}/${package}"; \
     curl -fsSL "$url" -o "/tmp/${package}"; \
         if ! dpkg -i "/tmp/${package}"; then \
@@ -18,8 +18,17 @@ RUN set -eux; \
     rm -f "/tmp/${package}"; \
     rm -rf /var/lib/apt/lists/*
 
+# Preload pg_durable on every start and create the extension on first init
 COPY docker/pg-durable/initdb/010-create-extension.sh /docker-entrypoint-initdb.d/010-create-extension.sh
-
 RUN chmod +x /docker-entrypoint-initdb.d/010-create-extension.sh
+COPY docker/pg-durable/banana-entrypoint.sh /usr/local/bin/banana-db-v2-entrypoint.sh
+RUN chmod +x /usr/local/bin/banana-db-v2-entrypoint.sh
 
+ENV PGDATA=/var/lib/postgresql/data/pgdata
+
+# The upstream image defaults to a non-root user. Running as root here allows
+# docker-entrypoint.sh to prepare/chown mounted Fly volumes before dropping privileges.
+USER root
+
+ENTRYPOINT ["bash", "/usr/local/bin/banana-db-v2-entrypoint.sh"]
 CMD ["postgres", "-c", "shared_preload_libraries=pg_durable", "-c", "pg_durable.worker_role=postgres"]

--- a/scripts/build-fly-pg-durable-image.sh
+++ b/scripts/build-fly-pg-durable-image.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-APP_NAME="${FLY_DB_APP_NAME:-banana-db}"
+APP_NAME="${FLY_DB_APP_NAME:-banana-db-v2}"
 PG_DURABLE_VERSION="${PG_DURABLE_VERSION:-0.2.2}"
-IMAGE_TAG="${FLY_DB_IMAGE_TAG:-pg17-durable-v${PG_DURABLE_VERSION}}"
+IMAGE_TAG="${FLY_DB_IMAGE_TAG:-pg18-durable-v${PG_DURABLE_VERSION}}"
 IMAGE_REF="registry.fly.io/${APP_NAME}:${IMAGE_TAG}"
 
 if ! command -v fly >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- upgrade Fly Postgres image base from postgres 17 to postgres 18 for pg_durable package compatibility
- install pg_durable postgres-18 package and keep preload flags on startup
- add hardened custom entrypoint for Fly volume initialization/chown/initdb flow
- update Fly image build helper defaults to banana-db-v2 + pg18 tag

## Why
Production Fly startup had repeated boot failures around volume/init behavior with stock startup assumptions. This change makes DB startup deterministic on Fly while keeping pg_durable preloaded and extension initialization explicit.

## Files
- docker/postgres-pg-durable.Dockerfile
- docker/pg-durable/banana-entrypoint.sh
- docker/pg-durable/initdb/010-create-extension.sh
- scripts/build-fly-pg-durable-image.sh

## Validation
- built and pushed image tag: pg18-durable-v0.2.2-r3
- banana-db-v2 machine updated to new image and started successfully
- pg_durable worker observed in postgres logs
- API secrets cut over to banana-db-v2.internal
- API machines restarted and /health returned OK

## Notes
- unrelated local workspace edits are intentionally excluded from this PR
