### PR TITLE
feat(architecture): add non-breaking k3h4 orchestration layers across native/api/frontend

### DIFF
--- a/artifacts/native/k3h4/k3h4-hypersphere-spec-report.md
+++ b/artifacts/native/k3h4/k3h4-hypersphere-spec-report.md
@@ -1,0 +1,64 @@
+# K3H4 Hypersphere Architecture Report
+
+## Scope
+This report ties together the k3h4 model intent across native, API, and frontend layers, with focus on:
+- hypersphere-first orchestration
+- endianness-safe contract transport
+- harmonic/spectral interpretation
+
+## Executive Summary
+- Native now has a top-level k3h4 layer under `src/native/k3h4` used by API-facing scaffold exports.
+- Runtime netcode orchestration uses k3h4 pipeline paths that produce deterministic hypersphere outputs and contract metadata.
+- API and frontend surfaces were renamed from hypersphere-kmeans terminology to k3h4 for contract alignment.
+- Endianness is handled as serialization/transport correctness, not as geometry semantics.
+- Harmonic interpretation is represented by spectral proxy outputs derived from hypersphere radius behavior.
+
+## Architecture Flow
+1. Native API export (`src/native/scaffold/native_entry.c`) receives request input.
+2. Export calls top-level k3h4 bridge (`src/native/k3h4/k3h4_native_orchestrator.c`).
+3. Bridge delegates into runtime netcode ABI/orchestration (`src/native/engine/runtime/abi/netcode/netcode_abi.c`).
+4. Runtime k3h4 orchestration computes vector + hypersphere + observability and envelope metadata.
+5. API consumes native outputs and exposes k3h4 contract payloads.
+6. Frontend renders orchestrated values only (no production recompute fallback).
+
+## Endianness Interpretation
+### Mathematical intent
+- K3h4 geometry is defined over interpreted numeric values.
+- Endianness does not alter geometry if bytes are decoded with the correct byte order contract.
+
+### Engineering contract
+- Envelope/version/CRC validation protects interpretation correctness.
+- Mixed-endianness handling is explicit via decode-path metadata and validation behavior.
+- Invalid version, malformed payload, and CRC mismatch paths fail deterministically.
+
+## Harmonic Interpretation
+- Spectral proxy fields provide harmonic interpretation of cluster/hypersphere state.
+- Radius-derived spectral values are deterministic and ordered by stable cluster identity.
+- This supports a resonance-style interpretation without coupling harmonic semantics to byte order.
+
+## DDD and SOLID Alignment
+### Domain boundaries
+- Native domain: deterministic k3h4 compute and contract envelope formation.
+- API application boundary: orchestration and transport mapping to HTTP contract.
+- Frontend presentation boundary: render-only consumption of authoritative outputs.
+
+### SOLID mapping
+- Single Responsibility: k3h4 native layer isolates API-facing orchestration entrypoints.
+- Open/Closed: runtime k3h4 internals can evolve while preserving stable bridge contracts.
+- Liskov Substitution: deterministic contract behavior is preserved across callers.
+- Interface Segregation: scaffold uses focused build functions rather than cross-domain dependencies.
+- Dependency Inversion: higher layers depend on k3h4 abstraction, not raw runtime internals.
+
+## Validation Signals
+- Native build and focused k3h4/netcode test suites pass for determinism, edge cases, orchestrator parity, and ABI envelope checks.
+- Contract naming parity was migrated to k3h4 across native/API/frontend/spec artifacts.
+
+## Operational Guidance
+- New native model work should enter via `src/native/k3h4` first.
+- API-facing scaffold exports should continue using the k3h4 bridge.
+- ABI envelope and endianness tests remain mandatory gates for transport integrity.
+- Frontend should treat k3h4 values as authoritative render inputs.
+
+## Note on Term Naming
+- This repository uses `k3h4` as the canonical model identifier.
+- If `k34h` is preferred as an alias in external docs, it should be documented as an alias while keeping code symbols stable under `k3h4`.

--- a/artifacts/native/k3h4/k3h4-hypersphere-spec-report.md
+++ b/artifacts/native/k3h4/k3h4-hypersphere-spec-report.md
@@ -1,64 +1,114 @@
-# K3H4 Hypersphere Architecture Report
+# K3H4 Endianness, Geometry, and Harmonic Recap Report
 
-## Scope
-This report ties together the k3h4 model intent across native, API, and frontend layers, with focus on:
-- hypersphere-first orchestration
-- endianness-safe contract transport
-- harmonic/spectral interpretation
+## Purpose
+This report summarizes how the full discussion ties together mathematically and architecturally, and how that maps to the Banana k3h4 implementation from native to API to frontend.
 
-## Executive Summary
-- Native now has a top-level k3h4 layer under `src/native/k3h4` used by API-facing scaffold exports.
-- Runtime netcode orchestration uses k3h4 pipeline paths that produce deterministic hypersphere outputs and contract metadata.
-- API and frontend surfaces were renamed from hypersphere-kmeans terminology to k3h4 for contract alignment.
-- Endianness is handled as serialization/transport correctness, not as geometry semantics.
-- Harmonic interpretation is represented by spectral proxy outputs derived from hypersphere radius behavior.
+## Core Conclusion
+At the mathematical layer, endianness does not change k-means, Voronoi partitions, hyperspheres, or fixed-point convergence.
+At the representation layer, endianness is critical because bytes must be interpreted correctly before geometry exists.
 
-## Architecture Flow
-1. Native API export (`src/native/scaffold/native_entry.c`) receives request input.
-2. Export calls top-level k3h4 bridge (`src/native/k3h4/k3h4_native_orchestrator.c`).
-3. Bridge delegates into runtime netcode ABI/orchestration (`src/native/engine/runtime/abi/netcode/netcode_abi.c`).
-4. Runtime k3h4 orchestration computes vector + hypersphere + observability and envelope metadata.
-5. API consumes native outputs and exposes k3h4 contract payloads.
-6. Frontend renders orchestrated values only (no production recompute fallback).
+Short form:
+- Geometry is invariant under correct decode.
+- Geometry collapses under incorrect decode.
+- Therefore endianness belongs to transport and contract integrity, not clustering semantics.
 
-## Endianness Interpretation
-### Mathematical intent
-- K3h4 geometry is defined over interpreted numeric values.
-- Endianness does not alter geometry if bytes are decoded with the correct byte order contract.
+## Conversation Thread, Unified
 
-### Engineering contract
-- Envelope/version/CRC validation protects interpretation correctness.
-- Mixed-endianness handling is explicit via decode-path metadata and validation behavior.
-- Invalid version, malformed payload, and CRC mismatch paths fail deterministically.
+### 1) Geometry and k3h4
+The geometric objects are defined on numeric vectors and distances:
+- coordinates
+- centroids
+- Voronoi cells
+- inscribed hypersphere radii
 
-## Harmonic Interpretation
-- Spectral proxy fields provide harmonic interpretation of cluster/hypersphere state.
-- Radius-derived spectral values are deterministic and ordered by stable cluster identity.
-- This supports a resonance-style interpretation without coupling harmonic semantics to byte order.
+Whether `1.0` is encoded as little-endian or big-endian bytes does not matter once it is decoded into the same numeric value.
 
-## DDD and SOLID Alignment
-### Domain boundaries
-- Native domain: deterministic k3h4 compute and contract envelope formation.
-- API application boundary: orchestration and transport mapping to HTTP contract.
-- Frontend presentation boundary: render-only consumption of authoritative outputs.
+### 2) Where Endianness Actually Enters
+Endianness appears when moving between:
+- memory bytes
+- wire payload bytes
+- interpreted numeric types
 
-### SOLID mapping
-- Single Responsibility: k3h4 native layer isolates API-facing orchestration entrypoints.
-- Open/Closed: runtime k3h4 internals can evolve while preserving stable bridge contracts.
-- Liskov Substitution: deterministic contract behavior is preserved across callers.
-- Interface Segregation: scaffold uses focused build functions rather than cross-domain dependencies.
-- Dependency Inversion: higher layers depend on k3h4 abstraction, not raw runtime internals.
+Conceptually:
+- `ByteString -> interpreted numbers -> vector space -> geometry`
 
-## Validation Signals
-- Native build and focused k3h4/netcode test suites pass for determinism, edge cases, orchestrator parity, and ABI envelope checks.
-- Contract naming parity was migrated to k3h4 across native/API/frontend/spec artifacts.
+If byte order is misinterpreted, decoded numbers are wrong and all downstream geometry (distance, assignment, radius, score) becomes invalid.
 
-## Operational Guidance
-- New native model work should enter via `src/native/k3h4` first.
-- API-facing scaffold exports should continue using the k3h4 bridge.
-- ABI envelope and endianness tests remain mandatory gates for transport integrity.
-- Frontend should treat k3h4 values as authoritative render inputs.
+### 3) Lambda Calculus and Stack Positioning
+Pure lambda calculus has no native byte-order concern.
+Endianness appears only after compilation/runtime lowers values into machine words and byte sequences.
 
-## Note on Term Naming
-- This repository uses `k3h4` as the canonical model identifier.
-- If `k34h` is preferred as an alias in external docs, it should be documented as an alias while keeping code symbols stable under `k3h4`.
+Stack view:
+- lambda/fixed-point semantics
+- typed numeric values
+- machine representation
+- bytes in memory/transport
+
+So endianness is a lower-layer implementation contract, not a higher-layer mathematical law.
+
+### 4) Harmonic Analogy
+Big-endian vs little-endian are not harmonics by themselves.
+But if a byte sequence is treated as a sampled signal, reversing bit order resembles time reversal:
+- magnitude spectrum can remain similar
+- phase relationships change
+
+This gives a useful analogy:
+- byte-order convention affects representation phase
+- cluster/hypersphere structure reflects geometric invariants after correct interpretation
+
+### 5) Hypersphere and Spectral Interpretation
+The discussion linked hypersphere radius to a resonance-style interpretation:
+- larger radius -> lower characteristic frequency proxy
+- smaller radius -> higher characteristic frequency proxy
+
+In k3h4, this maps to deterministic spectral proxy outputs derived from hypersphere metrics.
+
+## How This Maps to Banana Implementation
+
+### Native Layering
+Native is now explicit about top-level model orchestration:
+- `src/native/k3h4` is the API-facing native orchestration layer.
+- Scaffold exports route through k3h4 bridge functions.
+- Runtime netcode orchestration computes deterministic k3h4 outputs and envelope metadata.
+
+### Contract Integrity
+Endianness and payload correctness are enforced by the ABI envelope path:
+- contract version checks
+- payload length checks
+- CRC checks
+- deterministic error status mapping
+
+This enforces the exact boundary where representation correctness must be guaranteed before geometry is trusted.
+
+### API and Frontend Role
+- API remains orchestration/transport boundary for contract-safe outputs.
+- Frontend remains presentation-only for authoritative k3h4 values.
+
+This preserves the intended ownership chain:
+- native compute authority
+- API contract authority
+- frontend render authority
+
+## DDD / SOLID Recap
+
+### Domain Breakdown
+- Native domain: compute, determinism, envelope integrity.
+- API application domain: request orchestration and response shaping.
+- Frontend presentation domain: rendering and UX state only.
+
+### SOLID Interpretation
+- SRP: k3h4 bridge isolates model orchestration responsibilities.
+- OCP: runtime internals can evolve while preserving bridge/ABI contracts.
+- LSP: callers see stable behavior for supported contract versions.
+- ISP: consumers call focused build endpoints.
+- DIP: upper layers depend on stable k3h4 abstractions, not low-level internals.
+
+## Operational Rules Going Forward
+- Treat endianness as a contract-gate concern, never a geometry concern.
+- Keep k3h4 model integration entering through `src/native/k3h4` for API-facing paths.
+- Keep ABI validation and mixed-endian tests as mandatory for release safety.
+- Keep frontend free of production recompute and tied to authoritative payloads.
+
+## Final Recap Statement
+The entire conversation converges on one system principle:
+math and geometry define what should happen, while endianness and ABI contracts ensure every machine agrees on the same numbers so that geometry can exist reliably in production.

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(engine)
 add_library(banana_native SHARED
 	scaffold/native_entry.c
 	k3h4/k3h4_native_orchestrator.c
+	k3h4/k3h4_hypersphere_orchestration_layer.c
 )
 set_target_properties(banana_native PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/src/native/engine/CMakeLists.txt
+++ b/src/native/engine/CMakeLists.txt
@@ -382,6 +382,7 @@ if(BUILD_TESTING)
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/native/feedback/native_feedback_loop_factory.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../scaffold/native_entry.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../k3h4/k3h4_native_orchestrator.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../k3h4/k3h4_hypersphere_orchestration_layer.c
   )
   target_link_libraries(banana_native_feedback_loop_factory PRIVATE banana_engine_core)
   target_include_directories(banana_native_feedback_loop_factory PRIVATE

--- a/src/native/k3h4/README.md
+++ b/src/native/k3h4/README.md
@@ -4,5 +4,8 @@ This folder provides the top-level native `k3h4` orchestration layer used by API
 
 - `k3h4_native_orchestrator.h/.c` defines the native bridge surface for k3h4 model build calls.
 - Scaffold exports in `scaffold/native_entry.c` should call this layer instead of directly calling runtime netcode ABI builders.
+- The k3h4 contract is hypersphere-centric: vector and cluster outputs flow through the k3h4 orchestration path that emits hypersphere metrics and ABI envelope metadata.
+- Endianness is treated as a representation-layer concern (decode/encode correctness), not a geometric-layer concern (cluster geometry is invariant after correct decode).
+- Harmonic interpretation is represented through spectral proxy outputs that are derived deterministically from the same hypersphere radius model.
 
 This keeps the API/native orchestration boundary explicit under `src/native/k3h4`.

--- a/src/native/k3h4/k3h4_hypersphere_orchestration_layer.c
+++ b/src/native/k3h4/k3h4_hypersphere_orchestration_layer.c
@@ -1,0 +1,32 @@
+#include "k3h4_hypersphere_orchestration_layer.h"
+
+int banana_native_k3h4_layer_build_learning(RuntimeNetcodeSignalInput signal_input,
+                                            RuntimeNetcodeLearningOutput *out_output)
+{
+    return banana_native_k3h4_build_learning(signal_input, out_output);
+}
+
+int banana_native_k3h4_layer_build_reward(RuntimeNetcodeSignalInput signal_input,
+                                          int interaction_signal,
+                                          RuntimeNetcodeRewardOutput *out_output)
+{
+    return banana_native_k3h4_build_reward(signal_input, interaction_signal, out_output);
+}
+
+int banana_native_k3h4_layer_build_link(RuntimeNetcodeLinkSignalInput signal_input,
+                                        RuntimeNetcodeLinkOutput *out_output)
+{
+    return banana_native_k3h4_build_link(signal_input, out_output);
+}
+
+int banana_native_k3h4_layer_build_vector(RuntimeNetcodeVectorSignalInput signal_input,
+                                          RuntimeNetcodeVectorOutput *out_output)
+{
+    return banana_native_k3h4_build_vector(signal_input, out_output);
+}
+
+int banana_native_k3h4_layer_build_hypersphere(RuntimeNetcodeVectorSignalInput signal_input,
+                                               RuntimeNetcodeHypersphereOutput *out_output)
+{
+    return banana_native_k3h4_build_hypersphere(signal_input, out_output);
+}

--- a/src/native/k3h4/k3h4_hypersphere_orchestration_layer.h
+++ b/src/native/k3h4/k3h4_hypersphere_orchestration_layer.h
@@ -1,0 +1,31 @@
+#ifndef BANANA_NATIVE_K3H4_HYPERSPHERE_ORCHESTRATION_LAYER_H
+#define BANANA_NATIVE_K3H4_HYPERSPHERE_ORCHESTRATION_LAYER_H
+
+#include "k3h4_native_orchestrator.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    int banana_native_k3h4_layer_build_learning(RuntimeNetcodeSignalInput signal_input,
+                                                RuntimeNetcodeLearningOutput *out_output);
+
+    int banana_native_k3h4_layer_build_reward(RuntimeNetcodeSignalInput signal_input,
+                                              int interaction_signal,
+                                              RuntimeNetcodeRewardOutput *out_output);
+
+    int banana_native_k3h4_layer_build_link(RuntimeNetcodeLinkSignalInput signal_input,
+                                            RuntimeNetcodeLinkOutput *out_output);
+
+    int banana_native_k3h4_layer_build_vector(RuntimeNetcodeVectorSignalInput signal_input,
+                                              RuntimeNetcodeVectorOutput *out_output);
+
+    int banana_native_k3h4_layer_build_hypersphere(RuntimeNetcodeVectorSignalInput signal_input,
+                                                   RuntimeNetcodeHypersphereOutput *out_output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/native/scaffold/native_entry.c
+++ b/src/native/scaffold/native_entry.c
@@ -1,4 +1,5 @@
 #include "banana_native_v3.h"
+#include "k3h4/k3h4_hypersphere_orchestration_layer.h"
 #include "k3h4/k3h4_native_orchestrator.h"
 #include "runtime/engine/engine_aux_abi.h"
 #include "runtime/engine/engine_host.h"
@@ -241,7 +242,7 @@ int banana_native_v3_netcode_build_learning(const banana_native_v3_netcode_signa
 	native_input.branch_pressure = signal_input->branch_pressure;
 	native_input.workflow_depth = signal_input->workflow_depth;
 
-	if (banana_native_k3h4_build_learning(native_input, &native_output) != 0)
+	if (banana_native_k3h4_layer_build_learning(native_input, &native_output) != 0)
 	{
 		return -1;
 	}
@@ -281,7 +282,7 @@ int banana_native_v3_netcode_build_reward(const banana_native_v3_netcode_signal_
 	native_input.branch_pressure = signal_input->branch_pressure;
 	native_input.workflow_depth = signal_input->workflow_depth;
 
-	if (banana_native_k3h4_build_reward(native_input, interaction_signal, &native_output) != 0)
+	if (banana_native_k3h4_layer_build_reward(native_input, interaction_signal, &native_output) != 0)
 	{
 		return -1;
 	}
@@ -312,7 +313,7 @@ int banana_native_v3_netcode_build_link(const banana_native_v3_netcode_link_inpu
 	native_input.dependency_pulse = signal_input->dependency_pulse;
 	native_input.interaction_signal = signal_input->interaction_signal;
 
-	if (banana_native_k3h4_build_link(native_input, &native_output) != 0)
+	if (banana_native_k3h4_layer_build_link(native_input, &native_output) != 0)
 	{
 		return -1;
 	}
@@ -350,7 +351,7 @@ int banana_native_v3_netcode_build_vector(const banana_native_v3_netcode_vector_
 	native_input.model_confidence = signal_input->model_confidence;
 	native_input.policy_momentum = signal_input->policy_momentum;
 
-	if (banana_native_k3h4_build_vector(native_input, &native_output) != 0)
+	if (banana_native_k3h4_layer_build_vector(native_input, &native_output) != 0)
 	{
 		return -1;
 	}
@@ -395,7 +396,7 @@ int banana_native_v3_netcode_build_hypersphere(const banana_native_v3_netcode_ve
 	native_input.model_confidence = signal_input->model_confidence;
 	native_input.policy_momentum = signal_input->policy_momentum;
 
-	if (banana_native_k3h4_build_hypersphere(native_input, &native_output) != 0)
+	if (banana_native_k3h4_layer_build_hypersphere(native_input, &native_output) != 0)
 	{
 		return -1;
 	}

--- a/src/typescript/api/src/routes/netcode.ts
+++ b/src/typescript/api/src/routes/netcode.ts
@@ -2,10 +2,12 @@ import type {FastifyInstance} from 'fastify';
 
 import {getNativeNetcodeService, type NativeNetcodeService,} from '../services/nativeNetcode.ts';
 import {createNetcodeAnalyticsAuthoritativeComputeOrchestrator, type NetcodeAnalyticsAuthoritativeComputeOrchestrator, NetcodeAnalyticsOrchestrationError, type NetcodeHypersphereRollout,} from '../services/netcodeAuthoritativeComputeOrchestrator.ts';
+import {createK3h4ApplicationOrchestrationLayer, type K3h4ApplicationOrchestrationLayer,} from '../services/k3h4ApplicationOrchestrationLayer.ts';
 
 type NetcodeRouteOptions = {
   netcodeAuthoritativeComputeOrchestrator?:
       NetcodeAnalyticsAuthoritativeComputeOrchestrator;
+  k3h4ApplicationOrchestrationLayer?: K3h4ApplicationOrchestrationLayer;
   netcodeService?: NativeNetcodeService;
 };
 
@@ -30,6 +32,12 @@ export async function registerNetcodeRoutes(
   const netcodeAuthoritativeComputeOrchestrator =
       options.netcodeAuthoritativeComputeOrchestrator ??
       createNetcodeAnalyticsAuthoritativeComputeOrchestrator(netcode);
+    const k3h4ApplicationOrchestrationLayer =
+      options.k3h4ApplicationOrchestrationLayer ??
+      (options.netcodeAuthoritativeComputeOrchestrator ? {
+      compute: (request, rollout) =>
+        netcodeAuthoritativeComputeOrchestrator.compute(request, rollout),
+      } : createK3h4ApplicationOrchestrationLayer(netcode));
 
   app.post<{
     Body: {
@@ -185,8 +193,8 @@ export async function registerNetcodeRoutes(
 
     let orchestratedAnalytics;
     try {
-      orchestratedAnalytics =
-          await netcodeAuthoritativeComputeOrchestrator.compute(body, rollout);
+        orchestratedAnalytics =
+          await k3h4ApplicationOrchestrationLayer.compute(body, rollout);
     } catch (error) {
       if (error instanceof NetcodeAnalyticsOrchestrationError) {
         return reply.status(502).send({

--- a/src/typescript/api/src/routes/netcode.ts
+++ b/src/typescript/api/src/routes/netcode.ts
@@ -1,8 +1,8 @@
 import type {FastifyInstance} from 'fastify';
 
+import {createK3h4ApplicationOrchestrationLayer, type K3h4ApplicationOrchestrationLayer,} from '../services/k3h4ApplicationOrchestrationLayer.ts';
 import {getNativeNetcodeService, type NativeNetcodeService,} from '../services/nativeNetcode.ts';
 import {createNetcodeAnalyticsAuthoritativeComputeOrchestrator, type NetcodeAnalyticsAuthoritativeComputeOrchestrator, NetcodeAnalyticsOrchestrationError, type NetcodeHypersphereRollout,} from '../services/netcodeAuthoritativeComputeOrchestrator.ts';
-import {createK3h4ApplicationOrchestrationLayer, type K3h4ApplicationOrchestrationLayer,} from '../services/k3h4ApplicationOrchestrationLayer.ts';
 
 type NetcodeRouteOptions = {
   netcodeAuthoritativeComputeOrchestrator?:
@@ -13,14 +13,11 @@ type NetcodeRouteOptions = {
 
 function resolveNetcodeHypersphereKmeansRollout(): NetcodeHypersphereRollout {
   const enabledRaw =
-      (process.env.BANANA_NETCODE_K3H4_ENABLED ?? 'true')
-          .trim()
-          .toLowerCase();
+      (process.env.BANANA_NETCODE_K3H4_ENABLED ?? 'true').trim().toLowerCase();
   const enabled =
       enabledRaw !== 'false' && enabledRaw !== '0' && enabledRaw !== 'off';
   const cohort =
-      (process.env.BANANA_NETCODE_K3H4_COHORT ?? 'all').trim() ||
-      'all';
+      (process.env.BANANA_NETCODE_K3H4_COHORT ?? 'all').trim() || 'all';
   return {enabled, cohort};
 }
 
@@ -32,12 +29,15 @@ export async function registerNetcodeRoutes(
   const netcodeAuthoritativeComputeOrchestrator =
       options.netcodeAuthoritativeComputeOrchestrator ??
       createNetcodeAnalyticsAuthoritativeComputeOrchestrator(netcode);
-    const k3h4ApplicationOrchestrationLayer =
+  const k3h4ApplicationOrchestrationLayer =
       options.k3h4ApplicationOrchestrationLayer ??
-      (options.netcodeAuthoritativeComputeOrchestrator ? {
-      compute: (request, rollout) =>
-        netcodeAuthoritativeComputeOrchestrator.compute(request, rollout),
-      } : createK3h4ApplicationOrchestrationLayer(netcode));
+      (options.netcodeAuthoritativeComputeOrchestrator ?
+           {
+             compute: (request, rollout) =>
+                 netcodeAuthoritativeComputeOrchestrator.compute(
+                     request, rollout),
+           } :
+           createK3h4ApplicationOrchestrationLayer(netcode));
 
   app.post<{
     Body: {
@@ -193,7 +193,7 @@ export async function registerNetcodeRoutes(
 
     let orchestratedAnalytics;
     try {
-        orchestratedAnalytics =
+      orchestratedAnalytics =
           await k3h4ApplicationOrchestrationLayer.compute(body, rollout);
     } catch (error) {
       if (error instanceof NetcodeAnalyticsOrchestrationError) {

--- a/src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts
+++ b/src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts
@@ -1,0 +1,31 @@
+import type {NativeNetcodeService} from './nativeNetcode.ts';
+import {createNetcodeAnalyticsAuthoritativeComputeOrchestrator, type NetcodeAnalyticsAuthoritativeComputeOrchestrator, type NetcodeAnalyticsAuthoritativeRequest, type NetcodeAnalyticsAuthoritativeResult, type NetcodeHypersphereRollout,} from './netcodeAuthoritativeComputeOrchestrator.ts';
+
+export interface K3h4ApplicationOrchestrationLayer {
+  compute(
+      request: NetcodeAnalyticsAuthoritativeRequest,
+      rollout: NetcodeHypersphereRollout,
+      ): Promise<NetcodeAnalyticsAuthoritativeResult>;
+}
+
+class DefaultK3h4ApplicationOrchestrationLayer implements
+    K3h4ApplicationOrchestrationLayer {
+  constructor(
+      private readonly delegate:
+          NetcodeAnalyticsAuthoritativeComputeOrchestrator,
+  ) {}
+
+  public compute(
+      request: NetcodeAnalyticsAuthoritativeRequest,
+      rollout: NetcodeHypersphereRollout,
+      ): Promise<NetcodeAnalyticsAuthoritativeResult> {
+    return this.delegate.compute(request, rollout);
+  }
+}
+
+export function createK3h4ApplicationOrchestrationLayer(
+    netcode: NativeNetcodeService,
+    ): K3h4ApplicationOrchestrationLayer {
+  return new DefaultK3h4ApplicationOrchestrationLayer(
+      createNetcodeAnalyticsAuthoritativeComputeOrchestrator(netcode));
+}

--- a/src/typescript/react/src/domain/notebook/k3h4AnalyticsOrchestrationLayer.ts
+++ b/src/typescript/react/src/domain/notebook/k3h4AnalyticsOrchestrationLayer.ts
@@ -1,5 +1,6 @@
 import type {NetcodeAnalyticsResponse} from '../../lib/api';
-import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, RewardSignalModel, NodeLinkConfidenceModel,} from './network-domain';
+
+import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, NodeLinkConfidenceModel, RewardSignalModel,} from './network-domain';
 
 const NODE_ORDER: ContractNodeId[] = ['intel', 'objectives', 'player', 'ops'];
 
@@ -22,8 +23,7 @@ const LABELING_BAND = {
 } as const;
 
 export type K3h4AnalyticsPresentationState = {
-  rewardSignal: RewardSignalModel;
-  linkConfidence: NodeLinkConfidenceModel;
+  rewardSignal: RewardSignalModel; linkConfidence: NodeLinkConfidenceModel;
   contractVectors: readonly ContractNodeVectorModel[];
   hypersphereProjection: ContractHypersphereProjectionModel;
   k3h4: ContractHypersphereKmeansModel;
@@ -32,62 +32,67 @@ export type K3h4AnalyticsPresentationState = {
 export function mapK3h4AnalyticsToPresentationState(
     analytics: NetcodeAnalyticsResponse,
     ): K3h4AnalyticsPresentationState {
-  const rewardTier = analytics.reward.rewardTier === 0 ?
-      'Elite Signal' :
-      analytics.reward.rewardTier === 1 ? 'Relevant' :
-                                          'Needs Labeling';
+  const rewardTier = analytics.reward.rewardTier === 0 ? 'Elite Signal' :
+      analytics.reward.rewardTier === 1                ? 'Relevant' :
+                                                         'Needs Labeling';
   const rewardBand = rewardTier === 'Elite Signal' ? ELITE_BAND :
       rewardTier === 'Relevant'                    ? RELEVANT_BAND :
                                                      LABELING_BAND;
 
-  const contractVectors = NODE_ORDER.map((id, index) => ({
-    id,
-    dimensions: [...(analytics.vector.nodeVectors[index] ?? [])],
-    contractStrength: analytics.vector.contractStrength[index] ?? 0,
-  }));
+  const contractVectors = NODE_ORDER.map(
+      (id, index) => ({
+        id,
+        dimensions: [...(analytics.vector.nodeVectors[index] ?? [])],
+        contractStrength: analytics.vector.contractStrength[index] ?? 0,
+      }));
 
   const hypersphereProjection = {
     dimensions: analytics.hypersphere.dimensions,
-    nodes: NODE_ORDER.map((id, index) => ({
-      id,
-      x: analytics.hypersphere.nodes[index]?.x ?? 0,
-      y: analytics.hypersphere.nodes[index]?.y ?? 0,
-      z: analytics.hypersphere.nodes[index]?.z ?? 0,
-      coherence: analytics.hypersphere.nodes[index]?.coherence ?? 0,
-      inradius: analytics.hypersphere.nodes[index]?.inradius ?? 0,
-      nearestNeighborDistance:
-          analytics.hypersphere.nodes[index]?.nearestNeighborDistance ?? 0,
-    })),
+    nodes: NODE_ORDER.map(
+        (id, index) => ({
+          id,
+          x: analytics.hypersphere.nodes[index]?.x ?? 0,
+          y: analytics.hypersphere.nodes[index]?.y ?? 0,
+          z: analytics.hypersphere.nodes[index]?.z ?? 0,
+          coherence: analytics.hypersphere.nodes[index]?.coherence ?? 0,
+          inradius: analytics.hypersphere.nodes[index]?.inradius ?? 0,
+          nearestNeighborDistance:
+              analytics.hypersphere.nodes[index]?.nearestNeighborDistance ?? 0,
+        })),
     alignment: analytics.hypersphere.alignment,
     radialStability: analytics.hypersphere.radialStability,
   };
 
   const k3h4 = {
-    centers: analytics.k3h4.centers.map((center) => ({
-      clusterId: center.clusterId,
-      centerQ16: [...center.centerQ16],
-      memberVectorIds: [...center.memberVectorIds],
-      memberCount: center.memberCount,
-    })),
-    radii: analytics.k3h4.radii.map((radius) => ({
-      clusterId: radius.clusterId,
-      nearestNeighborDistanceQ16: radius.nearestNeighborDistanceQ16,
-      inscribedRadiusQ16: radius.inscribedRadiusQ16,
-      radiusState: radius.radiusState,
-    })),
-    weightedVoronoiScores: analytics.k3h4.weightedVoronoiScores.map((score) => ({
-      vectorId: score.vectorId,
-      clusterId: score.clusterId,
-      distanceToCenterQ16: score.distanceToCenterQ16,
-      weightedScoreQ16: score.weightedScoreQ16,
-      scoreValidity: score.scoreValidity,
-    })),
-    spectralProxy: analytics.k3h4.spectralProxy.map((entry) => ({
-      clusterId: entry.clusterId,
-      frequencyProxyQ16: entry.frequencyProxyQ16,
-      amplitudeProxyQ16: entry.amplitudeProxyQ16,
-      spectralState: entry.spectralState,
-    })),
+    centers: analytics.k3h4.centers.map(
+        (center) => ({
+          clusterId: center.clusterId,
+          centerQ16: [...center.centerQ16],
+          memberVectorIds: [...center.memberVectorIds],
+          memberCount: center.memberCount,
+        })),
+    radii: analytics.k3h4.radii.map(
+        (radius) => ({
+          clusterId: radius.clusterId,
+          nearestNeighborDistanceQ16: radius.nearestNeighborDistanceQ16,
+          inscribedRadiusQ16: radius.inscribedRadiusQ16,
+          radiusState: radius.radiusState,
+        })),
+    weightedVoronoiScores: analytics.k3h4.weightedVoronoiScores.map(
+        (score) => ({
+          vectorId: score.vectorId,
+          clusterId: score.clusterId,
+          distanceToCenterQ16: score.distanceToCenterQ16,
+          weightedScoreQ16: score.weightedScoreQ16,
+          scoreValidity: score.scoreValidity,
+        })),
+    spectralProxy: analytics.k3h4.spectralProxy.map(
+        (entry) => ({
+          clusterId: entry.clusterId,
+          frequencyProxyQ16: entry.frequencyProxyQ16,
+          amplitudeProxyQ16: entry.amplitudeProxyQ16,
+          spectralState: entry.spectralState,
+        })),
     observability: {
       convergenceStatus: analytics.k3h4.observability.convergenceStatus,
       iterationCount: analytics.k3h4.observability.iterationCount,

--- a/src/typescript/react/src/domain/notebook/k3h4AnalyticsOrchestrationLayer.ts
+++ b/src/typescript/react/src/domain/notebook/k3h4AnalyticsOrchestrationLayer.ts
@@ -1,0 +1,118 @@
+import type {NetcodeAnalyticsResponse} from '../../lib/api';
+import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, RewardSignalModel, NodeLinkConfidenceModel,} from './network-domain';
+
+const NODE_ORDER: ContractNodeId[] = ['intel', 'objectives', 'player', 'ops'];
+
+const ELITE_BAND = {
+  line: '#22c55e',
+  soft: 'rgba(34, 197, 94, 0.28)',
+  glow: 'rgba(34, 197, 94, 0.42)',
+} as const;
+
+const RELEVANT_BAND = {
+  line: '#f59e0b',
+  soft: 'rgba(245, 158, 11, 0.26)',
+  glow: 'rgba(245, 158, 11, 0.4)',
+} as const;
+
+const LABELING_BAND = {
+  line: '#f97316',
+  soft: 'rgba(249, 115, 22, 0.24)',
+  glow: 'rgba(249, 115, 22, 0.36)',
+} as const;
+
+export type K3h4AnalyticsPresentationState = {
+  rewardSignal: RewardSignalModel;
+  linkConfidence: NodeLinkConfidenceModel;
+  contractVectors: readonly ContractNodeVectorModel[];
+  hypersphereProjection: ContractHypersphereProjectionModel;
+  k3h4: ContractHypersphereKmeansModel;
+};
+
+export function mapK3h4AnalyticsToPresentationState(
+    analytics: NetcodeAnalyticsResponse,
+    ): K3h4AnalyticsPresentationState {
+  const rewardTier = analytics.reward.rewardTier === 0 ?
+      'Elite Signal' :
+      analytics.reward.rewardTier === 1 ? 'Relevant' :
+                                          'Needs Labeling';
+  const rewardBand = rewardTier === 'Elite Signal' ? ELITE_BAND :
+      rewardTier === 'Relevant'                    ? RELEVANT_BAND :
+                                                     LABELING_BAND;
+
+  const contractVectors = NODE_ORDER.map((id, index) => ({
+    id,
+    dimensions: [...(analytics.vector.nodeVectors[index] ?? [])],
+    contractStrength: analytics.vector.contractStrength[index] ?? 0,
+  }));
+
+  const hypersphereProjection = {
+    dimensions: analytics.hypersphere.dimensions,
+    nodes: NODE_ORDER.map((id, index) => ({
+      id,
+      x: analytics.hypersphere.nodes[index]?.x ?? 0,
+      y: analytics.hypersphere.nodes[index]?.y ?? 0,
+      z: analytics.hypersphere.nodes[index]?.z ?? 0,
+      coherence: analytics.hypersphere.nodes[index]?.coherence ?? 0,
+      inradius: analytics.hypersphere.nodes[index]?.inradius ?? 0,
+      nearestNeighborDistance:
+          analytics.hypersphere.nodes[index]?.nearestNeighborDistance ?? 0,
+    })),
+    alignment: analytics.hypersphere.alignment,
+    radialStability: analytics.hypersphere.radialStability,
+  };
+
+  const k3h4 = {
+    centers: analytics.k3h4.centers.map((center) => ({
+      clusterId: center.clusterId,
+      centerQ16: [...center.centerQ16],
+      memberVectorIds: [...center.memberVectorIds],
+      memberCount: center.memberCount,
+    })),
+    radii: analytics.k3h4.radii.map((radius) => ({
+      clusterId: radius.clusterId,
+      nearestNeighborDistanceQ16: radius.nearestNeighborDistanceQ16,
+      inscribedRadiusQ16: radius.inscribedRadiusQ16,
+      radiusState: radius.radiusState,
+    })),
+    weightedVoronoiScores: analytics.k3h4.weightedVoronoiScores.map((score) => ({
+      vectorId: score.vectorId,
+      clusterId: score.clusterId,
+      distanceToCenterQ16: score.distanceToCenterQ16,
+      weightedScoreQ16: score.weightedScoreQ16,
+      scoreValidity: score.scoreValidity,
+    })),
+    spectralProxy: analytics.k3h4.spectralProxy.map((entry) => ({
+      clusterId: entry.clusterId,
+      frequencyProxyQ16: entry.frequencyProxyQ16,
+      amplitudeProxyQ16: entry.amplitudeProxyQ16,
+      spectralState: entry.spectralState,
+    })),
+    observability: {
+      convergenceStatus: analytics.k3h4.observability.convergenceStatus,
+      iterationCount: analytics.k3h4.observability.iterationCount,
+      assignmentChangesLastIteration:
+          analytics.k3h4.observability.assignmentChangesLastIteration,
+      scoringValidity: analytics.k3h4.observability.scoringValidity,
+      deterministicHash: analytics.k3h4.observability.deterministicHash,
+    },
+  };
+
+  return {
+    rewardSignal: {
+      neuralRelevanceScore: analytics.reward.neuralRelevanceScore,
+      projectedRewardXp: analytics.reward.projectedRewardXp,
+      rewardTier,
+      rewardBand,
+    },
+    linkConfidence: {
+      intel: analytics.link.intel,
+      objectives: analytics.link.objectives,
+      player: analytics.link.player,
+      ops: analytics.link.ops,
+    },
+    contractVectors,
+    hypersphereProjection,
+    k3h4,
+  };
+}

--- a/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
+++ b/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
@@ -2,8 +2,8 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 
 import {fetchNetcodeAnalytics, fetchNetcodeLearning, NetcodeAnalyticsError, resolveApiBaseUrl,} from '../../lib/api';
 
-import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, NetcodeAnalyticsAvailabilityModel, NodeInteractionAction, NodeInteractionLearningModel, NodeInteractionLedger, NodeLinkConfidenceModel, RewardSignalModel,} from './network-domain';
 import {mapK3h4AnalyticsToPresentationState,} from './k3h4AnalyticsOrchestrationLayer';
+import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, NetcodeAnalyticsAvailabilityModel, NodeInteractionAction, NodeInteractionLearningModel, NodeInteractionLedger, NodeLinkConfidenceModel, RewardSignalModel,} from './network-domain';
 
 type NetcodeSignals = {
   readonly callDensity: number; readonly questPercent: number; readonly comboStreak: number; readonly branchPressure: number; readonly workflowDepth: 1 | 2 | 3; readonly playerLevel: number; readonly dependencyPulse: number; readonly networkDimensions:
@@ -135,7 +135,7 @@ type ApiLearningResponse = {
 
 export type NetcodeSessionHook = {
   readonly learningModel: NodeInteractionLearningModel; readonly ledger: NodeInteractionLedger; readonly recordNodeTap: (node: ContractNodeId) => void; readonly recordAction: (action: NodeInteractionAction) => void; readonly rewardSignal: RewardSignalModel; readonly linkConfidence: NodeLinkConfidenceModel; readonly contractVectors: readonly ContractNodeVectorModel[]; readonly hypersphereProjection: ContractHypersphereProjectionModel; readonly k3h4: ContractHypersphereKmeansModel; readonly analyticsAvailability:
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               NetcodeAnalyticsAvailabilityModel;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  NetcodeAnalyticsAvailabilityModel;
 };
 
 export function useNetcodeSession({

--- a/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
+++ b/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
@@ -3,23 +3,12 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import {fetchNetcodeAnalytics, fetchNetcodeLearning, NetcodeAnalyticsError, resolveApiBaseUrl,} from '../../lib/api';
 
 import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, NetcodeAnalyticsAvailabilityModel, NodeInteractionAction, NodeInteractionLearningModel, NodeInteractionLedger, NodeLinkConfidenceModel, RewardSignalModel,} from './network-domain';
+import {mapK3h4AnalyticsToPresentationState,} from './k3h4AnalyticsOrchestrationLayer';
 
 type NetcodeSignals = {
   readonly callDensity: number; readonly questPercent: number; readonly comboStreak: number; readonly branchPressure: number; readonly workflowDepth: 1 | 2 | 3; readonly playerLevel: number; readonly dependencyPulse: number; readonly networkDimensions:
                                                                                                                                                                                                                                               number;
 };
-
-const ELITE_BAND = {
-  line: '#22c55e',
-  soft: 'rgba(34, 197, 94, 0.28)',
-  glow: 'rgba(34, 197, 94, 0.42)',
-} as const;
-
-const RELEVANT_BAND = {
-  line: '#f59e0b',
-  soft: 'rgba(245, 158, 11, 0.26)',
-  glow: 'rgba(245, 158, 11, 0.4)',
-} as const;
 
 const LABELING_BAND = {
   line: '#f97316',
@@ -105,8 +94,6 @@ const DEFAULT_ANALYTICS_AVAILABILITY: NetcodeAnalyticsAvailabilityModel = {
     cohort: 'default',
   },
 };
-
-const NODE_ORDER: ContractNodeId[] = ['intel', 'objectives', 'player', 'ops'];
 
 function mapNativeNodeId(value: number): ContractNodeId {
   if (value === 1) return 'objectives';
@@ -288,101 +275,13 @@ export function useNetcodeSession({
               return;
             }
 
-            const rewardTier = analytics.reward.rewardTier === 0 ?
-                'Elite Signal' :
-                analytics.reward.rewardTier === 1 ? 'Relevant' :
-                                                    'Needs Labeling';
-            const rewardBand = rewardTier === 'Elite Signal' ? ELITE_BAND :
-                rewardTier === 'Relevant'                    ? RELEVANT_BAND :
-                                                               LABELING_BAND;
-            setRewardSignal({
-              neuralRelevanceScore: analytics.reward.neuralRelevanceScore,
-              projectedRewardXp: analytics.reward.projectedRewardXp,
-              rewardTier,
-              rewardBand,
-            });
-
-            setLinkConfidence({
-              intel: analytics.link.intel,
-              objectives: analytics.link.objectives,
-              player: analytics.link.player,
-              ops: analytics.link.ops,
-            });
-
-            const mappedVectors = NODE_ORDER.map(
-                (id, index) => ({
-                  id,
-                  dimensions: [...(analytics.vector.nodeVectors[index] ?? [])],
-                  contractStrength:
-                      analytics.vector.contractStrength[index] ?? 0,
-                }));
-            setContractVectors(mappedVectors);
-
-            const mappedNodes = NODE_ORDER.map(
-                (id, index) => ({
-                  id,
-                  x: analytics.hypersphere.nodes[index]?.x ?? 0,
-                  y: analytics.hypersphere.nodes[index]?.y ?? 0,
-                  z: analytics.hypersphere.nodes[index]?.z ?? 0,
-                  coherence: analytics.hypersphere.nodes[index]?.coherence ?? 0,
-                  inradius: analytics.hypersphere.nodes[index]?.inradius ?? 0,
-                  nearestNeighborDistance: analytics.hypersphere.nodes[index]
-                                               ?.nearestNeighborDistance ??
-                      0,
-                }));
-            setHypersphereProjection({
-              dimensions: analytics.hypersphere.dimensions,
-              nodes: mappedNodes,
-              alignment: analytics.hypersphere.alignment,
-              radialStability: analytics.hypersphere.radialStability,
-            });
-
-            setHypersphereKmeans({
-              centers: analytics.k3h4.centers.map(
-                  (center) => ({
-                    clusterId: center.clusterId,
-                    centerQ16: [...center.centerQ16],
-                    memberVectorIds: [...center.memberVectorIds],
-                    memberCount: center.memberCount,
-                  })),
-              radii: analytics.k3h4.radii.map(
-                  (radius) => ({
-                    clusterId: radius.clusterId,
-                    nearestNeighborDistanceQ16:
-                        radius.nearestNeighborDistanceQ16,
-                    inscribedRadiusQ16: radius.inscribedRadiusQ16,
-                    radiusState: radius.radiusState,
-                  })),
-              weightedVoronoiScores:
-                  analytics.k3h4.weightedVoronoiScores.map(
-                      (score) => ({
-                        vectorId: score.vectorId,
-                        clusterId: score.clusterId,
-                        distanceToCenterQ16: score.distanceToCenterQ16,
-                        weightedScoreQ16: score.weightedScoreQ16,
-                        scoreValidity: score.scoreValidity,
-                      })),
-              spectralProxy: analytics.k3h4.spectralProxy.map(
-                  (entry) => ({
-                    clusterId: entry.clusterId,
-                    frequencyProxyQ16: entry.frequencyProxyQ16,
-                    amplitudeProxyQ16: entry.amplitudeProxyQ16,
-                    spectralState: entry.spectralState,
-                  })),
-              observability: {
-                convergenceStatus:
-                    analytics.k3h4.observability.convergenceStatus,
-                iterationCount:
-                    analytics.k3h4.observability.iterationCount,
-                assignmentChangesLastIteration:
-                    analytics.k3h4.observability
-                        .assignmentChangesLastIteration,
-                scoringValidity:
-                    analytics.k3h4.observability.scoringValidity,
-                deterministicHash:
-                    analytics.k3h4.observability.deterministicHash,
-              },
-            });
+            const presentationState =
+                mapK3h4AnalyticsToPresentationState(analytics);
+            setRewardSignal(presentationState.rewardSignal);
+            setLinkConfidence(presentationState.linkConfidence);
+            setContractVectors(presentationState.contractVectors);
+            setHypersphereProjection(presentationState.hypersphereProjection);
+            setHypersphereKmeans(presentationState.k3h4);
 
             const rollout = analytics.rollout;
             setAnalyticsAvailability({


### PR DESCRIPTION
## Summary
- add non-breaking orchestration layers for k3h4 across native, API, and frontend
- keep existing orchestrators/paths intact while routing through new wrapper layers
- add/update native k3h4 architecture recap report with endianness/geometry/harmonic interpretation context

## Changes
### Native
- add `src/native/k3h4/k3h4_hypersphere_orchestration_layer.h`
- add `src/native/k3h4/k3h4_hypersphere_orchestration_layer.c`
- wire new layer into native build targets and scaffold routing
- keep existing `k3h4_native_orchestrator` APIs intact

### API
- add `src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts`
- update `src/typescript/api/src/routes/netcode.ts` to support/use the new layer while preserving existing orchestrator injection behavior

### Frontend
- add `src/typescript/react/src/domain/notebook/k3h4AnalyticsOrchestrationLayer.ts`
- update `src/typescript/react/src/domain/notebook/useNetcodeSession.ts` to map analytics via the new adapter layer while preserving hook contract

### Documentation
- update `artifacts/native/k3h4/k3h4-hypersphere-spec-report.md`

## Validation
- native configure/build passed:
  - `cmake -S src/native -B out/v3-native`
  - `cmake --build out/v3-native -- -m:1`
- focused tests passed:
  - `ctest -C Debug --test-dir out/v3-native -R "banana_runtime_netcode_(k3h4_orchestrator|k3h4_determinism|k3h4_edge_cases)_test" --output-on-failure`
- API smoke task passed:
  - `API: smoke (v3)`

## Branch Commits
- `55a369fe` docs(native): add k3h4 hypersphere architecture report
- `ceeedfbf` feat(architecture): add non-breaking k3h4 orchestration layers
- `0fe54586` refactor(k3h4): finalize orchestration layer integration and recap
