### PR TITLE
feat(architecture): strict DDD orchestration wrappers across native api frontend

### DIFF
--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(banana_native SHARED
 	scaffold/native_entry.c
 	k3h4/k3h4_native_orchestrator.c
 	k3h4/k3h4_hypersphere_orchestration_layer.c
+	k3h4/application/k3h4_hypersphere_application_service.c
+	k3h4/infrastructure/k3h4_hypersphere_infrastructure_adapter.c
 )
 set_target_properties(banana_native PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/src/native/engine/CMakeLists.txt
+++ b/src/native/engine/CMakeLists.txt
@@ -383,6 +383,8 @@ if(BUILD_TESTING)
     ${CMAKE_CURRENT_SOURCE_DIR}/../scaffold/native_entry.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../k3h4/k3h4_native_orchestrator.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../k3h4/k3h4_hypersphere_orchestration_layer.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../k3h4/application/k3h4_hypersphere_application_service.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../k3h4/infrastructure/k3h4_hypersphere_infrastructure_adapter.c
   )
   target_link_libraries(banana_native_feedback_loop_factory PRIVATE banana_engine_core)
   target_include_directories(banana_native_feedback_loop_factory PRIVATE

--- a/src/native/k3h4/application/k3h4_hypersphere_application_service.c
+++ b/src/native/k3h4/application/k3h4_hypersphere_application_service.c
@@ -1,0 +1,52 @@
+#include "k3h4_hypersphere_application_service.h"
+
+int banana_native_k3h4_application_build_learning(
+    const BananaNativeK3h4DomainPort *domain_port,
+    RuntimeNetcodeSignalInput signal_input,
+    RuntimeNetcodeLearningOutput *out_output)
+{
+    if (!domain_port || !domain_port->build_learning)
+        return -1;
+    return domain_port->build_learning(signal_input, out_output);
+}
+
+int banana_native_k3h4_application_build_reward(
+    const BananaNativeK3h4DomainPort *domain_port,
+    RuntimeNetcodeSignalInput signal_input,
+    int interaction_signal,
+    RuntimeNetcodeRewardOutput *out_output)
+{
+    if (!domain_port || !domain_port->build_reward)
+        return -1;
+    return domain_port->build_reward(signal_input, interaction_signal, out_output);
+}
+
+int banana_native_k3h4_application_build_link(
+    const BananaNativeK3h4DomainPort *domain_port,
+    RuntimeNetcodeLinkSignalInput signal_input,
+    RuntimeNetcodeLinkOutput *out_output)
+{
+    if (!domain_port || !domain_port->build_link)
+        return -1;
+    return domain_port->build_link(signal_input, out_output);
+}
+
+int banana_native_k3h4_application_build_vector(
+    const BananaNativeK3h4DomainPort *domain_port,
+    RuntimeNetcodeVectorSignalInput signal_input,
+    RuntimeNetcodeVectorOutput *out_output)
+{
+    if (!domain_port || !domain_port->build_vector)
+        return -1;
+    return domain_port->build_vector(signal_input, out_output);
+}
+
+int banana_native_k3h4_application_build_hypersphere(
+    const BananaNativeK3h4DomainPort *domain_port,
+    RuntimeNetcodeVectorSignalInput signal_input,
+    RuntimeNetcodeHypersphereOutput *out_output)
+{
+    if (!domain_port || !domain_port->build_hypersphere)
+        return -1;
+    return domain_port->build_hypersphere(signal_input, out_output);
+}

--- a/src/native/k3h4/application/k3h4_hypersphere_application_service.h
+++ b/src/native/k3h4/application/k3h4_hypersphere_application_service.h
@@ -1,0 +1,41 @@
+#ifndef BANANA_NATIVE_K3H4_APPLICATION_SERVICE_H
+#define BANANA_NATIVE_K3H4_APPLICATION_SERVICE_H
+
+#include "../domain/k3h4_hypersphere_domain_port.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    int banana_native_k3h4_application_build_learning(
+        const BananaNativeK3h4DomainPort *domain_port,
+        RuntimeNetcodeSignalInput signal_input,
+        RuntimeNetcodeLearningOutput *out_output);
+
+    int banana_native_k3h4_application_build_reward(
+        const BananaNativeK3h4DomainPort *domain_port,
+        RuntimeNetcodeSignalInput signal_input,
+        int interaction_signal,
+        RuntimeNetcodeRewardOutput *out_output);
+
+    int banana_native_k3h4_application_build_link(
+        const BananaNativeK3h4DomainPort *domain_port,
+        RuntimeNetcodeLinkSignalInput signal_input,
+        RuntimeNetcodeLinkOutput *out_output);
+
+    int banana_native_k3h4_application_build_vector(
+        const BananaNativeK3h4DomainPort *domain_port,
+        RuntimeNetcodeVectorSignalInput signal_input,
+        RuntimeNetcodeVectorOutput *out_output);
+
+    int banana_native_k3h4_application_build_hypersphere(
+        const BananaNativeK3h4DomainPort *domain_port,
+        RuntimeNetcodeVectorSignalInput signal_input,
+        RuntimeNetcodeHypersphereOutput *out_output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/native/k3h4/domain/k3h4_hypersphere_domain_port.h
+++ b/src/native/k3h4/domain/k3h4_hypersphere_domain_port.h
@@ -1,0 +1,30 @@
+#ifndef BANANA_NATIVE_K3H4_DOMAIN_PORT_H
+#define BANANA_NATIVE_K3H4_DOMAIN_PORT_H
+
+#include "runtime/abi/netcode/netcode_abi.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct BananaNativeK3h4DomainPort
+    {
+        int (*build_learning)(RuntimeNetcodeSignalInput signal_input,
+                              RuntimeNetcodeLearningOutput *out_output);
+        int (*build_reward)(RuntimeNetcodeSignalInput signal_input,
+                            int interaction_signal,
+                            RuntimeNetcodeRewardOutput *out_output);
+        int (*build_link)(RuntimeNetcodeLinkSignalInput signal_input,
+                          RuntimeNetcodeLinkOutput *out_output);
+        int (*build_vector)(RuntimeNetcodeVectorSignalInput signal_input,
+                            RuntimeNetcodeVectorOutput *out_output);
+        int (*build_hypersphere)(RuntimeNetcodeVectorSignalInput signal_input,
+                                 RuntimeNetcodeHypersphereOutput *out_output);
+    } BananaNativeK3h4DomainPort;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/native/k3h4/infrastructure/k3h4_hypersphere_infrastructure_adapter.c
+++ b/src/native/k3h4/infrastructure/k3h4_hypersphere_infrastructure_adapter.c
@@ -1,0 +1,14 @@
+#include "k3h4_hypersphere_infrastructure_adapter.h"
+
+#include "../k3h4_native_orchestrator.h"
+
+BananaNativeK3h4DomainPort banana_native_k3h4_infrastructure_create_domain_port(void)
+{
+    BananaNativeK3h4DomainPort port;
+    port.build_learning = banana_native_k3h4_build_learning;
+    port.build_reward = banana_native_k3h4_build_reward;
+    port.build_link = banana_native_k3h4_build_link;
+    port.build_vector = banana_native_k3h4_build_vector;
+    port.build_hypersphere = banana_native_k3h4_build_hypersphere;
+    return port;
+}

--- a/src/native/k3h4/infrastructure/k3h4_hypersphere_infrastructure_adapter.h
+++ b/src/native/k3h4/infrastructure/k3h4_hypersphere_infrastructure_adapter.h
@@ -1,0 +1,17 @@
+#ifndef BANANA_NATIVE_K3H4_INFRA_ADAPTER_H
+#define BANANA_NATIVE_K3H4_INFRA_ADAPTER_H
+
+#include "../domain/k3h4_hypersphere_domain_port.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    BananaNativeK3h4DomainPort banana_native_k3h4_infrastructure_create_domain_port(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/native/k3h4/k3h4_hypersphere_orchestration_layer.c
+++ b/src/native/k3h4/k3h4_hypersphere_orchestration_layer.c
@@ -1,32 +1,61 @@
 #include "k3h4_hypersphere_orchestration_layer.h"
 
+#include "application/k3h4_hypersphere_application_service.h"
+#include "infrastructure/k3h4_hypersphere_infrastructure_adapter.h"
+
+static BananaNativeK3h4DomainPort resolve_domain_port(void)
+{
+    return banana_native_k3h4_infrastructure_create_domain_port();
+}
+
 int banana_native_k3h4_layer_build_learning(RuntimeNetcodeSignalInput signal_input,
                                             RuntimeNetcodeLearningOutput *out_output)
 {
-    return banana_native_k3h4_build_learning(signal_input, out_output);
+    BananaNativeK3h4DomainPort domain_port = resolve_domain_port();
+    return banana_native_k3h4_application_build_learning(
+        &domain_port,
+        signal_input,
+        out_output);
 }
 
 int banana_native_k3h4_layer_build_reward(RuntimeNetcodeSignalInput signal_input,
                                           int interaction_signal,
                                           RuntimeNetcodeRewardOutput *out_output)
 {
-    return banana_native_k3h4_build_reward(signal_input, interaction_signal, out_output);
+    BananaNativeK3h4DomainPort domain_port = resolve_domain_port();
+    return banana_native_k3h4_application_build_reward(
+        &domain_port,
+        signal_input,
+        interaction_signal,
+        out_output);
 }
 
 int banana_native_k3h4_layer_build_link(RuntimeNetcodeLinkSignalInput signal_input,
                                         RuntimeNetcodeLinkOutput *out_output)
 {
-    return banana_native_k3h4_build_link(signal_input, out_output);
+    BananaNativeK3h4DomainPort domain_port = resolve_domain_port();
+    return banana_native_k3h4_application_build_link(
+        &domain_port,
+        signal_input,
+        out_output);
 }
 
 int banana_native_k3h4_layer_build_vector(RuntimeNetcodeVectorSignalInput signal_input,
                                           RuntimeNetcodeVectorOutput *out_output)
 {
-    return banana_native_k3h4_build_vector(signal_input, out_output);
+    BananaNativeK3h4DomainPort domain_port = resolve_domain_port();
+    return banana_native_k3h4_application_build_vector(
+        &domain_port,
+        signal_input,
+        out_output);
 }
 
 int banana_native_k3h4_layer_build_hypersphere(RuntimeNetcodeVectorSignalInput signal_input,
                                                RuntimeNetcodeHypersphereOutput *out_output)
 {
-    return banana_native_k3h4_build_hypersphere(signal_input, out_output);
+    BananaNativeK3h4DomainPort domain_port = resolve_domain_port();
+    return banana_native_k3h4_application_build_hypersphere(
+        &domain_port,
+        signal_input,
+        out_output);
 }

--- a/src/typescript/api/src/application/k3h4/k3h4ApplicationService.ts
+++ b/src/typescript/api/src/application/k3h4/k3h4ApplicationService.ts
@@ -1,0 +1,25 @@
+import type {K3h4AuthoritativeAnalyticsPort, K3h4AuthoritativeRequest, K3h4AuthoritativeResult, K3h4Rollout,} from '../../domain/k3h4/k3h4AuthoritativeAnalytics.ts';
+
+export interface K3h4ApplicationService {
+  compute(
+      request: K3h4AuthoritativeRequest,
+      rollout: K3h4Rollout,
+      ): Promise<K3h4AuthoritativeResult>;
+}
+
+class DefaultK3h4ApplicationService implements K3h4ApplicationService {
+  constructor(private readonly analyticsPort: K3h4AuthoritativeAnalyticsPort) {}
+
+  public compute(
+      request: K3h4AuthoritativeRequest,
+      rollout: K3h4Rollout,
+      ): Promise<K3h4AuthoritativeResult> {
+    return this.analyticsPort.compute(request, rollout);
+  }
+}
+
+export function createK3h4ApplicationService(
+    analyticsPort: K3h4AuthoritativeAnalyticsPort,
+    ): K3h4ApplicationService {
+  return new DefaultK3h4ApplicationService(analyticsPort);
+}

--- a/src/typescript/api/src/domain/k3h4/k3h4AuthoritativeAnalytics.ts
+++ b/src/typescript/api/src/domain/k3h4/k3h4AuthoritativeAnalytics.ts
@@ -1,0 +1,12 @@
+import type {NetcodeAnalyticsAuthoritativeRequest, NetcodeAnalyticsAuthoritativeResult, NetcodeHypersphereRollout,} from '../../services/netcodeAuthoritativeComputeOrchestrator.ts';
+
+export type K3h4AuthoritativeRequest = NetcodeAnalyticsAuthoritativeRequest;
+export type K3h4AuthoritativeResult = NetcodeAnalyticsAuthoritativeResult;
+export type K3h4Rollout = NetcodeHypersphereRollout;
+
+export interface K3h4AuthoritativeAnalyticsPort {
+  compute(
+      request: K3h4AuthoritativeRequest,
+      rollout: K3h4Rollout,
+      ): Promise<K3h4AuthoritativeResult>;
+}

--- a/src/typescript/api/src/infrastructure/k3h4/nativeK3h4AuthoritativeAnalyticsAdapter.ts
+++ b/src/typescript/api/src/infrastructure/k3h4/nativeK3h4AuthoritativeAnalyticsAdapter.ts
@@ -1,6 +1,6 @@
+import type {K3h4AuthoritativeAnalyticsPort} from '../../domain/k3h4/k3h4AuthoritativeAnalytics.ts';
 import type {NativeNetcodeService} from '../../services/nativeNetcode.ts';
 import {createNetcodeAnalyticsAuthoritativeComputeOrchestrator,} from '../../services/netcodeAuthoritativeComputeOrchestrator.ts';
-import type {K3h4AuthoritativeAnalyticsPort} from '../../domain/k3h4/k3h4AuthoritativeAnalytics.ts';
 
 export function createNativeK3h4AuthoritativeAnalyticsAdapter(
     netcode: NativeNetcodeService,

--- a/src/typescript/api/src/infrastructure/k3h4/nativeK3h4AuthoritativeAnalyticsAdapter.ts
+++ b/src/typescript/api/src/infrastructure/k3h4/nativeK3h4AuthoritativeAnalyticsAdapter.ts
@@ -1,0 +1,9 @@
+import type {NativeNetcodeService} from '../../services/nativeNetcode.ts';
+import {createNetcodeAnalyticsAuthoritativeComputeOrchestrator,} from '../../services/netcodeAuthoritativeComputeOrchestrator.ts';
+import type {K3h4AuthoritativeAnalyticsPort} from '../../domain/k3h4/k3h4AuthoritativeAnalytics.ts';
+
+export function createNativeK3h4AuthoritativeAnalyticsAdapter(
+    netcode: NativeNetcodeService,
+    ): K3h4AuthoritativeAnalyticsPort {
+  return createNetcodeAnalyticsAuthoritativeComputeOrchestrator(netcode);
+}

--- a/src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts
+++ b/src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts
@@ -1,5 +1,7 @@
 import type {NativeNetcodeService} from './nativeNetcode.ts';
-import {createNetcodeAnalyticsAuthoritativeComputeOrchestrator, type NetcodeAnalyticsAuthoritativeComputeOrchestrator, type NetcodeAnalyticsAuthoritativeRequest, type NetcodeAnalyticsAuthoritativeResult, type NetcodeHypersphereRollout,} from './netcodeAuthoritativeComputeOrchestrator.ts';
+import type {NetcodeAnalyticsAuthoritativeRequest, NetcodeAnalyticsAuthoritativeResult, NetcodeHypersphereRollout,} from './netcodeAuthoritativeComputeOrchestrator.ts';
+import {createK3h4ApplicationService, type K3h4ApplicationService,} from '../application/k3h4/k3h4ApplicationService.ts';
+import {createNativeK3h4AuthoritativeAnalyticsAdapter,} from '../infrastructure/k3h4/nativeK3h4AuthoritativeAnalyticsAdapter.ts';
 
 export interface K3h4ApplicationOrchestrationLayer {
   compute(
@@ -11,8 +13,7 @@ export interface K3h4ApplicationOrchestrationLayer {
 class DefaultK3h4ApplicationOrchestrationLayer implements
     K3h4ApplicationOrchestrationLayer {
   constructor(
-      private readonly delegate:
-          NetcodeAnalyticsAuthoritativeComputeOrchestrator,
+    private readonly delegate: K3h4ApplicationService,
   ) {}
 
   public compute(
@@ -26,6 +27,7 @@ class DefaultK3h4ApplicationOrchestrationLayer implements
 export function createK3h4ApplicationOrchestrationLayer(
     netcode: NativeNetcodeService,
     ): K3h4ApplicationOrchestrationLayer {
-  return new DefaultK3h4ApplicationOrchestrationLayer(
-      createNetcodeAnalyticsAuthoritativeComputeOrchestrator(netcode));
+  const analyticsPort = createNativeK3h4AuthoritativeAnalyticsAdapter(netcode);
+  const applicationService = createK3h4ApplicationService(analyticsPort);
+  return new DefaultK3h4ApplicationOrchestrationLayer(applicationService);
 }

--- a/src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts
+++ b/src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts
@@ -1,7 +1,8 @@
-import type {NativeNetcodeService} from './nativeNetcode.ts';
-import type {NetcodeAnalyticsAuthoritativeRequest, NetcodeAnalyticsAuthoritativeResult, NetcodeHypersphereRollout,} from './netcodeAuthoritativeComputeOrchestrator.ts';
 import {createK3h4ApplicationService, type K3h4ApplicationService,} from '../application/k3h4/k3h4ApplicationService.ts';
 import {createNativeK3h4AuthoritativeAnalyticsAdapter,} from '../infrastructure/k3h4/nativeK3h4AuthoritativeAnalyticsAdapter.ts';
+
+import type {NativeNetcodeService} from './nativeNetcode.ts';
+import type {NetcodeAnalyticsAuthoritativeRequest, NetcodeAnalyticsAuthoritativeResult, NetcodeHypersphereRollout,} from './netcodeAuthoritativeComputeOrchestrator.ts';
 
 export interface K3h4ApplicationOrchestrationLayer {
   compute(
@@ -13,7 +14,7 @@ export interface K3h4ApplicationOrchestrationLayer {
 class DefaultK3h4ApplicationOrchestrationLayer implements
     K3h4ApplicationOrchestrationLayer {
   constructor(
-    private readonly delegate: K3h4ApplicationService,
+      private readonly delegate: K3h4ApplicationService,
   ) {}
 
   public compute(

--- a/src/typescript/react/src/application/notebook/k3h4/k3h4PresentationApplicationService.ts
+++ b/src/typescript/react/src/application/notebook/k3h4/k3h4PresentationApplicationService.ts
@@ -1,13 +1,13 @@
-import type {NetcodeAnalyticsResponse} from '../../../lib/api';
-import type {K3h4AnalyticsPresentationState} from '../../../domain/notebook/k3h4AnalyticsOrchestrationLayer';
 import type {K3h4PresentationMapperPort} from '../../../domain/notebook/k3h4/k3h4PresentationDomain';
+import type {K3h4AnalyticsPresentationState} from '../../../domain/notebook/k3h4AnalyticsOrchestrationLayer';
+import type {NetcodeAnalyticsResponse} from '../../../lib/api';
 
 export interface K3h4PresentationApplicationService {
   map(analytics: NetcodeAnalyticsResponse): K3h4AnalyticsPresentationState;
 }
 
-class DefaultK3h4PresentationApplicationService
-    implements K3h4PresentationApplicationService {
+class DefaultK3h4PresentationApplicationService implements
+    K3h4PresentationApplicationService {
   constructor(private readonly mapperPort: K3h4PresentationMapperPort) {}
 
   public map(

--- a/src/typescript/react/src/application/notebook/k3h4/k3h4PresentationApplicationService.ts
+++ b/src/typescript/react/src/application/notebook/k3h4/k3h4PresentationApplicationService.ts
@@ -1,0 +1,24 @@
+import type {NetcodeAnalyticsResponse} from '../../../lib/api';
+import type {K3h4AnalyticsPresentationState} from '../../../domain/notebook/k3h4AnalyticsOrchestrationLayer';
+import type {K3h4PresentationMapperPort} from '../../../domain/notebook/k3h4/k3h4PresentationDomain';
+
+export interface K3h4PresentationApplicationService {
+  map(analytics: NetcodeAnalyticsResponse): K3h4AnalyticsPresentationState;
+}
+
+class DefaultK3h4PresentationApplicationService
+    implements K3h4PresentationApplicationService {
+  constructor(private readonly mapperPort: K3h4PresentationMapperPort) {}
+
+  public map(
+      analytics: NetcodeAnalyticsResponse,
+      ): K3h4AnalyticsPresentationState {
+    return this.mapperPort.map(analytics);
+  }
+}
+
+export function createK3h4PresentationApplicationService(
+    mapperPort: K3h4PresentationMapperPort,
+    ): K3h4PresentationApplicationService {
+  return new DefaultK3h4PresentationApplicationService(mapperPort);
+}

--- a/src/typescript/react/src/domain/notebook/k3h4/k3h4PresentationDomain.ts
+++ b/src/typescript/react/src/domain/notebook/k3h4/k3h4PresentationDomain.ts
@@ -1,0 +1,6 @@
+import type {NetcodeAnalyticsResponse} from '../../../lib/api';
+import type {K3h4AnalyticsPresentationState} from '../k3h4AnalyticsOrchestrationLayer';
+
+export interface K3h4PresentationMapperPort {
+  map(analytics: NetcodeAnalyticsResponse): K3h4AnalyticsPresentationState;
+}

--- a/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
+++ b/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
@@ -1,9 +1,9 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 
-import {fetchNetcodeAnalytics, fetchNetcodeLearning, NetcodeAnalyticsError, resolveApiBaseUrl,} from '../../lib/api';
-
 import {createK3h4PresentationApplicationService,} from '../../application/notebook/k3h4/k3h4PresentationApplicationService';
 import {createK3h4PresentationMapperAdapter,} from '../../infrastructure/notebook/k3h4/k3h4PresentationMapperAdapter';
+import {fetchNetcodeAnalytics, fetchNetcodeLearning, NetcodeAnalyticsError, resolveApiBaseUrl,} from '../../lib/api';
+
 import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, NetcodeAnalyticsAvailabilityModel, NodeInteractionAction, NodeInteractionLearningModel, NodeInteractionLedger, NodeLinkConfidenceModel, RewardSignalModel,} from './network-domain';
 
 type NetcodeSignals = {
@@ -97,8 +97,8 @@ const DEFAULT_ANALYTICS_AVAILABILITY: NetcodeAnalyticsAvailabilityModel = {
 };
 
 const k3h4PresentationApplicationService =
-  createK3h4PresentationApplicationService(
-    createK3h4PresentationMapperAdapter());
+    createK3h4PresentationApplicationService(
+        createK3h4PresentationMapperAdapter());
 
 function mapNativeNodeId(value: number): ContractNodeId {
   if (value === 1) return 'objectives';
@@ -281,7 +281,7 @@ export function useNetcodeSession({
             }
 
             const presentationState =
-              k3h4PresentationApplicationService.map(analytics);
+                k3h4PresentationApplicationService.map(analytics);
             setRewardSignal(presentationState.rewardSignal);
             setLinkConfidence(presentationState.linkConfidence);
             setContractVectors(presentationState.contractVectors);

--- a/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
+++ b/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
@@ -2,7 +2,8 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 
 import {fetchNetcodeAnalytics, fetchNetcodeLearning, NetcodeAnalyticsError, resolveApiBaseUrl,} from '../../lib/api';
 
-import {mapK3h4AnalyticsToPresentationState,} from './k3h4AnalyticsOrchestrationLayer';
+import {createK3h4PresentationApplicationService,} from '../../application/notebook/k3h4/k3h4PresentationApplicationService';
+import {createK3h4PresentationMapperAdapter,} from '../../infrastructure/notebook/k3h4/k3h4PresentationMapperAdapter';
 import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, NetcodeAnalyticsAvailabilityModel, NodeInteractionAction, NodeInteractionLearningModel, NodeInteractionLedger, NodeLinkConfidenceModel, RewardSignalModel,} from './network-domain';
 
 type NetcodeSignals = {
@@ -94,6 +95,10 @@ const DEFAULT_ANALYTICS_AVAILABILITY: NetcodeAnalyticsAvailabilityModel = {
     cohort: 'default',
   },
 };
+
+const k3h4PresentationApplicationService =
+  createK3h4PresentationApplicationService(
+    createK3h4PresentationMapperAdapter());
 
 function mapNativeNodeId(value: number): ContractNodeId {
   if (value === 1) return 'objectives';
@@ -276,7 +281,7 @@ export function useNetcodeSession({
             }
 
             const presentationState =
-                mapK3h4AnalyticsToPresentationState(analytics);
+              k3h4PresentationApplicationService.map(analytics);
             setRewardSignal(presentationState.rewardSignal);
             setLinkConfidence(presentationState.linkConfidence);
             setContractVectors(presentationState.contractVectors);

--- a/src/typescript/react/src/infrastructure/notebook/k3h4/k3h4PresentationMapperAdapter.ts
+++ b/src/typescript/react/src/infrastructure/notebook/k3h4/k3h4PresentationMapperAdapter.ts
@@ -1,0 +1,9 @@
+import type {K3h4PresentationMapperPort} from '../../../domain/notebook/k3h4/k3h4PresentationDomain';
+import {mapK3h4AnalyticsToPresentationState,} from '../../../domain/notebook/k3h4AnalyticsOrchestrationLayer';
+
+export function createK3h4PresentationMapperAdapter():
+    K3h4PresentationMapperPort {
+  return {
+    map: (analytics) => mapK3h4AnalyticsToPresentationState(analytics),
+  };
+}


### PR DESCRIPTION
## Summary
- add explicit domain/application/infrastructure orchestration wrappers across native, API, and frontend
- keep existing orchestrators and behavior intact while routing through new wrapper layers
- preserve current contracts and runtime outputs

## Native
- added domain port: `src/native/k3h4/domain/k3h4_hypersphere_domain_port.h`
- added application service: `src/native/k3h4/application/k3h4_hypersphere_application_service.h/.c`
- added infrastructure adapter: `src/native/k3h4/infrastructure/k3h4_hypersphere_infrastructure_adapter.h/.c`
- updated orchestration layer implementation to flow through app+infra wrappers
- updated CMake targets to compile/link new wrappers

## API
- added domain contract port: `src/typescript/api/src/domain/k3h4/k3h4AuthoritativeAnalytics.ts`
- added application service: `src/typescript/api/src/application/k3h4/k3h4ApplicationService.ts`
- added infrastructure adapter: `src/typescript/api/src/infrastructure/k3h4/nativeK3h4AuthoritativeAnalyticsAdapter.ts`
- updated `src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts` to use new wrappers

## Frontend
- added domain mapper port: `src/typescript/react/src/domain/notebook/k3h4/k3h4PresentationDomain.ts`
- added application service: `src/typescript/react/src/application/notebook/k3h4/k3h4PresentationApplicationService.ts`
- added infrastructure adapter: `src/typescript/react/src/infrastructure/notebook/k3h4/k3h4PresentationMapperAdapter.ts`
- updated `src/typescript/react/src/domain/notebook/useNetcodeSession.ts` to consume mapping via application service

## Validation
- `cmake -S src/native -B out/v3-native`
- `cmake --build out/v3-native -- -m:1`
- `ctest -C Debug --test-dir out/v3-native -R "banana_runtime_netcode_(k3h4_orchestrator|k3h4_determinism|k3h4_edge_cases)_test" --output-on-failure`
- `API: smoke (v3)` task
