### PR TITLE
refactor(ddd): extract k3h4 composition roots for api and frontend

### DIFF
--- a/src/typescript/api/src/composition/k3h4/k3h4CompositionRoot.ts
+++ b/src/typescript/api/src/composition/k3h4/k3h4CompositionRoot.ts
@@ -1,6 +1,5 @@
 import {createK3h4ApplicationService, type K3h4ApplicationService,} from '../../application/k3h4/k3h4ApplicationService.ts';
 import {createNativeK3h4AuthoritativeAnalyticsAdapter,} from '../../infrastructure/k3h4/nativeK3h4AuthoritativeAnalyticsAdapter.ts';
-
 import type {NativeNetcodeService} from '../../services/nativeNetcode.ts';
 
 export function composeK3h4ApplicationService(

--- a/src/typescript/api/src/composition/k3h4/k3h4CompositionRoot.ts
+++ b/src/typescript/api/src/composition/k3h4/k3h4CompositionRoot.ts
@@ -1,0 +1,11 @@
+import {createK3h4ApplicationService, type K3h4ApplicationService,} from '../../application/k3h4/k3h4ApplicationService.ts';
+import {createNativeK3h4AuthoritativeAnalyticsAdapter,} from '../../infrastructure/k3h4/nativeK3h4AuthoritativeAnalyticsAdapter.ts';
+
+import type {NativeNetcodeService} from '../../services/nativeNetcode.ts';
+
+export function composeK3h4ApplicationService(
+    netcode: NativeNetcodeService,
+    ): K3h4ApplicationService {
+  const analyticsPort = createNativeK3h4AuthoritativeAnalyticsAdapter(netcode);
+  return createK3h4ApplicationService(analyticsPort);
+}

--- a/src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts
+++ b/src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts
@@ -1,5 +1,5 @@
-import {createK3h4ApplicationService, type K3h4ApplicationService,} from '../application/k3h4/k3h4ApplicationService.ts';
-import {createNativeK3h4AuthoritativeAnalyticsAdapter,} from '../infrastructure/k3h4/nativeK3h4AuthoritativeAnalyticsAdapter.ts';
+import {composeK3h4ApplicationService,} from '../composition/k3h4/k3h4CompositionRoot.ts';
+import type {K3h4ApplicationService} from '../application/k3h4/k3h4ApplicationService.ts';
 
 import type {NativeNetcodeService} from './nativeNetcode.ts';
 import type {NetcodeAnalyticsAuthoritativeRequest, NetcodeAnalyticsAuthoritativeResult, NetcodeHypersphereRollout,} from './netcodeAuthoritativeComputeOrchestrator.ts';
@@ -28,7 +28,6 @@ class DefaultK3h4ApplicationOrchestrationLayer implements
 export function createK3h4ApplicationOrchestrationLayer(
     netcode: NativeNetcodeService,
     ): K3h4ApplicationOrchestrationLayer {
-  const analyticsPort = createNativeK3h4AuthoritativeAnalyticsAdapter(netcode);
-  const applicationService = createK3h4ApplicationService(analyticsPort);
+  const applicationService = composeK3h4ApplicationService(netcode);
   return new DefaultK3h4ApplicationOrchestrationLayer(applicationService);
 }

--- a/src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts
+++ b/src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts
@@ -1,5 +1,5 @@
-import {composeK3h4ApplicationService,} from '../composition/k3h4/k3h4CompositionRoot.ts';
 import type {K3h4ApplicationService} from '../application/k3h4/k3h4ApplicationService.ts';
+import {composeK3h4ApplicationService,} from '../composition/k3h4/k3h4CompositionRoot.ts';
 
 import type {NativeNetcodeService} from './nativeNetcode.ts';
 import type {NetcodeAnalyticsAuthoritativeRequest, NetcodeAnalyticsAuthoritativeResult, NetcodeHypersphereRollout,} from './netcodeAuthoritativeComputeOrchestrator.ts';

--- a/src/typescript/react/src/application/notebook/k3h4/k3h4PresentationCompositionRoot.ts
+++ b/src/typescript/react/src/application/notebook/k3h4/k3h4PresentationCompositionRoot.ts
@@ -1,5 +1,6 @@
-import {createK3h4PresentationApplicationService, type K3h4PresentationApplicationService,} from './k3h4PresentationApplicationService';
 import {createK3h4PresentationMapperAdapter,} from '../../../infrastructure/notebook/k3h4/k3h4PresentationMapperAdapter';
+
+import {createK3h4PresentationApplicationService, type K3h4PresentationApplicationService,} from './k3h4PresentationApplicationService';
 
 export function composeK3h4PresentationApplicationService():
     K3h4PresentationApplicationService {

--- a/src/typescript/react/src/application/notebook/k3h4/k3h4PresentationCompositionRoot.ts
+++ b/src/typescript/react/src/application/notebook/k3h4/k3h4PresentationCompositionRoot.ts
@@ -1,0 +1,8 @@
+import {createK3h4PresentationApplicationService, type K3h4PresentationApplicationService,} from './k3h4PresentationApplicationService';
+import {createK3h4PresentationMapperAdapter,} from '../../../infrastructure/notebook/k3h4/k3h4PresentationMapperAdapter';
+
+export function composeK3h4PresentationApplicationService():
+    K3h4PresentationApplicationService {
+  const mapperPort = createK3h4PresentationMapperAdapter();
+  return createK3h4PresentationApplicationService(mapperPort);
+}

--- a/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
+++ b/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
@@ -96,7 +96,7 @@ const DEFAULT_ANALYTICS_AVAILABILITY: NetcodeAnalyticsAvailabilityModel = {
 };
 
 const k3h4PresentationApplicationService =
-  composeK3h4PresentationApplicationService();
+    composeK3h4PresentationApplicationService();
 
 function mapNativeNodeId(value: number): ContractNodeId {
   if (value === 1) return 'objectives';

--- a/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
+++ b/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
@@ -1,7 +1,6 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 
-import {createK3h4PresentationApplicationService,} from '../../application/notebook/k3h4/k3h4PresentationApplicationService';
-import {createK3h4PresentationMapperAdapter,} from '../../infrastructure/notebook/k3h4/k3h4PresentationMapperAdapter';
+import {composeK3h4PresentationApplicationService,} from '../../application/notebook/k3h4/k3h4PresentationCompositionRoot';
 import {fetchNetcodeAnalytics, fetchNetcodeLearning, NetcodeAnalyticsError, resolveApiBaseUrl,} from '../../lib/api';
 
 import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, NetcodeAnalyticsAvailabilityModel, NodeInteractionAction, NodeInteractionLearningModel, NodeInteractionLedger, NodeLinkConfidenceModel, RewardSignalModel,} from './network-domain';
@@ -97,8 +96,7 @@ const DEFAULT_ANALYTICS_AVAILABILITY: NetcodeAnalyticsAvailabilityModel = {
 };
 
 const k3h4PresentationApplicationService =
-    createK3h4PresentationApplicationService(
-        createK3h4PresentationMapperAdapter());
+  composeK3h4PresentationApplicationService();
 
 function mapNativeNodeId(value: number): ContractNodeId {
   if (value === 1) return 'objectives';


### PR DESCRIPTION
## Summary
- extract API k3h4 constructor wiring into an explicit composition-root module
- extract frontend k3h4 presentation constructor wiring into an explicit composition-root module
- keep existing orchestration layer and hook behavior unchanged while delegating composition to dedicated modules

## Changes
- add `src/typescript/api/src/composition/k3h4/k3h4CompositionRoot.ts`
- update `src/typescript/api/src/services/k3h4ApplicationOrchestrationLayer.ts` to use composition root
- add `src/typescript/react/src/application/notebook/k3h4/k3h4PresentationCompositionRoot.ts`
- update `src/typescript/react/src/domain/notebook/useNetcodeSession.ts` to use composition root

## Validation
- API smoke task: pass
- UI smoke task: pass
- diagnostics for touched files: no errors
