### PR TITLE
feat(api): blend reward fallback signals for k3h4

### DIFF
--- a/src/typescript/api/src/routes/netcode.contract.test.ts
+++ b/src/typescript/api/src/routes/netcode.contract.test.ts
@@ -262,6 +262,64 @@ describe('netcode analytics contract', () => {
     await app.close();
   });
 
+  test('rejects non-finite analytics payload values', async () => {
+    const app = await createApp(createFakeNetcode({}));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/netcode/analytics',
+      payload: {
+        callDensity: Number.NaN,
+        questPercent: 20,
+        playerLevel: 30,
+        comboStreak: 40,
+        branchPressure: 50,
+        dependencyPulse: 60,
+        workflowDepth: 2,
+        networkDimensions: 6,
+        modelConfidence: 77,
+        policyMomentum: 66,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: 'Invalid netcode analytics payload',
+    });
+
+    await app.close();
+  });
+
+  test(
+      'rejects analytics payloads with out-of-range k3h4 dimensions',
+      async () => {
+        const app = await createApp(createFakeNetcode({}));
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/netcode/analytics',
+          payload: {
+            callDensity: 10,
+            questPercent: 20,
+            playerLevel: 30,
+            comboStreak: 40,
+            branchPressure: 50,
+            dependencyPulse: 60,
+            workflowDepth: 2,
+            networkDimensions: 17,
+            modelConfidence: 77,
+            policyMomentum: 66,
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toMatchObject({
+          error: 'Invalid netcode analytics payload',
+        });
+
+        await app.close();
+      });
+
   test('returns deterministic unsupported-version error payload', async () => {
     const captured: CapturedArgs = {};
     const failingService: NativeNetcodeService = {

--- a/src/typescript/api/src/routes/netcode.contract.test.ts
+++ b/src/typescript/api/src/routes/netcode.contract.test.ts
@@ -200,7 +200,7 @@ describe('netcode analytics contract', () => {
         });
 
         expect(response.statusCode).toBe(200);
-        expect(captured.rewardSignal).toBe(77);
+  expect(captured.rewardSignal).toBe(73);
         expect(captured.linkSignal).toBe(66);
         const json = response.json();
         expect(json).toMatchObject({
@@ -234,6 +234,35 @@ describe('netcode analytics contract', () => {
 
         await app.close();
       });
+
+  test('prefers explicit interactionSignal over blended fallback', async () => {
+    const captured: CapturedArgs = {};
+    const app = await createApp(createFakeNetcode(captured));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/netcode/analytics',
+      payload: {
+        callDensity: 10,
+        questPercent: 20,
+        playerLevel: 30,
+        comboStreak: 40,
+        branchPressure: 50,
+        dependencyPulse: 60,
+        workflowDepth: 2,
+        networkDimensions: 6,
+        modelConfidence: 77,
+        policyMomentum: 66,
+        interactionSignal: 91,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(captured.rewardSignal).toBe(91);
+    expect(captured.linkSignal).toBe(66);
+
+    await app.close();
+  });
 
   test('rejects invalid analytics payloads', async () => {
     const app = await createApp(createFakeNetcode({}));

--- a/src/typescript/api/src/routes/netcode.ts
+++ b/src/typescript/api/src/routes/netcode.ts
@@ -11,6 +11,19 @@ type NetcodeRouteOptions = {
   netcodeService?: NativeNetcodeService;
 };
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isValidWorkflowDepth(value: unknown): value is 1|2|3 {
+  return isFiniteNumber(value) && (value === 1 || value === 2 || value === 3);
+}
+
+function isValidNetworkDimensions(value: unknown): boolean {
+  return isFiniteNumber(value) && Number.isInteger(value) && value >= 1 &&
+      value <= 16;
+}
+
 function resolveNetcodeHypersphereKmeansRollout(): NetcodeHypersphereRollout {
   const enabledRaw =
       (process.env.BANANA_NETCODE_K3H4_ENABLED ?? 'true').trim().toLowerCase();
@@ -51,12 +64,11 @@ export async function registerNetcodeRoutes(
       '/api/netcode/learning',
       async (request, reply) => {
         const body = request.body;
-        if (!body || typeof body.callDensity !== 'number' ||
-            typeof body.questPercent !== 'number' ||
-            typeof body.comboStreak !== 'number' ||
-            typeof body.branchPressure !== 'number' ||
-            (body.workflowDepth !== 1 && body.workflowDepth !== 2 &&
-             body.workflowDepth !== 3)) {
+        if (!body || !isFiniteNumber(body.callDensity) ||
+            !isFiniteNumber(body.questPercent) ||
+            !isFiniteNumber(body.comboStreak) ||
+            !isFiniteNumber(body.branchPressure) ||
+            !isValidWorkflowDepth(body.workflowDepth)) {
           return reply.status(400).send({
             error: 'Invalid netcode learning payload',
           });
@@ -99,12 +111,11 @@ export async function registerNetcodeRoutes(
     }
   }>('/api/netcode/reward', async (request, reply) => {
     const body = request.body;
-    if (!body || typeof body.callDensity !== 'number' ||
-        typeof body.questPercent !== 'number' ||
-        typeof body.comboStreak !== 'number' ||
-        typeof body.branchPressure !== 'number' ||
-        (body.workflowDepth !== 1 && body.workflowDepth !== 2 &&
-         body.workflowDepth !== 3)) {
+    if (!body || !isFiniteNumber(body.callDensity) ||
+        !isFiniteNumber(body.questPercent) ||
+        !isFiniteNumber(body.comboStreak) ||
+        !isFiniteNumber(body.branchPressure) ||
+        !isValidWorkflowDepth(body.workflowDepth)) {
       return reply.status(400).send({error: 'Invalid netcode reward payload'});
     }
 
@@ -131,12 +142,12 @@ export async function registerNetcodeRoutes(
     }
   }>('/api/netcode/link', async (request, reply) => {
     const body = request.body;
-    if (!body || typeof body.callDensity !== 'number' ||
-        typeof body.questPercent !== 'number' ||
-        typeof body.playerLevel !== 'number' ||
-        typeof body.comboStreak !== 'number' ||
-        typeof body.branchPressure !== 'number' ||
-        typeof body.dependencyPulse !== 'number') {
+    if (!body || !isFiniteNumber(body.callDensity) ||
+        !isFiniteNumber(body.questPercent) ||
+        !isFiniteNumber(body.playerLevel) ||
+        !isFiniteNumber(body.comboStreak) ||
+        !isFiniteNumber(body.branchPressure) ||
+        !isFiniteNumber(body.dependencyPulse)) {
       return reply.status(400).send({error: 'Invalid netcode link payload'});
     }
 
@@ -176,17 +187,16 @@ export async function registerNetcodeRoutes(
     }
 
     const body = request.body;
-    if (!body || typeof body.callDensity !== 'number' ||
-        typeof body.questPercent !== 'number' ||
-        typeof body.playerLevel !== 'number' ||
-        typeof body.comboStreak !== 'number' ||
-        typeof body.branchPressure !== 'number' ||
-        typeof body.dependencyPulse !== 'number' ||
-        (body.workflowDepth !== 1 && body.workflowDepth !== 2 &&
-         body.workflowDepth !== 3) ||
-        typeof body.networkDimensions !== 'number' ||
-        typeof body.modelConfidence !== 'number' ||
-        typeof body.policyMomentum !== 'number') {
+    if (!body || !isFiniteNumber(body.callDensity) ||
+        !isFiniteNumber(body.questPercent) ||
+        !isFiniteNumber(body.playerLevel) ||
+        !isFiniteNumber(body.comboStreak) ||
+        !isFiniteNumber(body.branchPressure) ||
+        !isFiniteNumber(body.dependencyPulse) ||
+        !isValidWorkflowDepth(body.workflowDepth) ||
+        !isValidNetworkDimensions(body.networkDimensions) ||
+        !isFiniteNumber(body.modelConfidence) ||
+        !isFiniteNumber(body.policyMomentum)) {
       return reply.status(400).send(
           {error: 'Invalid netcode analytics payload'});
     }
@@ -225,18 +235,17 @@ export async function registerNetcodeRoutes(
     }
   }>('/api/netcode/vector', async (request, reply) => {
     const body = request.body;
-    if (!body || typeof body.callDensity !== 'number' ||
-        typeof body.questPercent !== 'number' ||
-        typeof body.playerLevel !== 'number' ||
-        typeof body.comboStreak !== 'number' ||
-        typeof body.branchPressure !== 'number' ||
-        typeof body.dependencyPulse !== 'number' ||
-        (body.workflowDepth !== 1 && body.workflowDepth !== 2 &&
-         body.workflowDepth !== 3) ||
-        typeof body.neuralRelevanceScore !== 'number' ||
-        typeof body.networkDimensions !== 'number' ||
-        typeof body.modelConfidence !== 'number' ||
-        typeof body.policyMomentum !== 'number') {
+    if (!body || !isFiniteNumber(body.callDensity) ||
+        !isFiniteNumber(body.questPercent) ||
+        !isFiniteNumber(body.playerLevel) ||
+        !isFiniteNumber(body.comboStreak) ||
+        !isFiniteNumber(body.branchPressure) ||
+        !isFiniteNumber(body.dependencyPulse) ||
+        !isValidWorkflowDepth(body.workflowDepth) ||
+        !isFiniteNumber(body.neuralRelevanceScore) ||
+        !isValidNetworkDimensions(body.networkDimensions) ||
+        !isFiniteNumber(body.modelConfidence) ||
+        !isFiniteNumber(body.policyMomentum)) {
       return reply.status(400).send({error: 'Invalid netcode vector payload'});
     }
 
@@ -270,18 +279,17 @@ export async function registerNetcodeRoutes(
     }
   }>('/api/netcode/hypersphere', async (request, reply) => {
     const body = request.body;
-    if (!body || typeof body.callDensity !== 'number' ||
-        typeof body.questPercent !== 'number' ||
-        typeof body.playerLevel !== 'number' ||
-        typeof body.comboStreak !== 'number' ||
-        typeof body.branchPressure !== 'number' ||
-        typeof body.dependencyPulse !== 'number' ||
-        (body.workflowDepth !== 1 && body.workflowDepth !== 2 &&
-         body.workflowDepth !== 3) ||
-        typeof body.neuralRelevanceScore !== 'number' ||
-        typeof body.networkDimensions !== 'number' ||
-        typeof body.modelConfidence !== 'number' ||
-        typeof body.policyMomentum !== 'number') {
+    if (!body || !isFiniteNumber(body.callDensity) ||
+        !isFiniteNumber(body.questPercent) ||
+        !isFiniteNumber(body.playerLevel) ||
+        !isFiniteNumber(body.comboStreak) ||
+        !isFiniteNumber(body.branchPressure) ||
+        !isFiniteNumber(body.dependencyPulse) ||
+        !isValidWorkflowDepth(body.workflowDepth) ||
+        !isFiniteNumber(body.neuralRelevanceScore) ||
+        !isValidNetworkDimensions(body.networkDimensions) ||
+        !isFiniteNumber(body.modelConfidence) ||
+        !isFiniteNumber(body.policyMomentum)) {
       return reply.status(400).send(
           {error: 'Invalid netcode hypersphere payload'});
     }

--- a/src/typescript/api/src/services/netcodeAuthoritativeComputeOrchestrator.ts
+++ b/src/typescript/api/src/services/netcodeAuthoritativeComputeOrchestrator.ts
@@ -88,6 +88,16 @@ function mapHypersphereBuildError(error: unknown):
   return undefined;
 }
 
+function resolveRewardInteractionSignal(
+    request: NetcodeAnalyticsAuthoritativeRequest,
+    ): number {
+  if (typeof request.interactionSignal === 'number') {
+    return request.interactionSignal;
+  }
+
+  return Math.round((request.modelConfidence * 2 + request.policyMomentum) / 3);
+}
+
 class NativeNetcodeAuthoritativeComputeOrchestrator implements
     NetcodeAnalyticsAuthoritativeComputeOrchestrator {
   constructor(private readonly netcode: NativeNetcodeService) {}
@@ -104,9 +114,7 @@ class NativeNetcodeAuthoritativeComputeOrchestrator implements
           branchPressure: request.branchPressure,
           workflowDepth: request.workflowDepth,
         },
-        typeof request.interactionSignal === 'number' ?
-            request.interactionSignal :
-            request.modelConfidence,
+        resolveRewardInteractionSignal(request),
     );
 
     const link = await this.netcode.buildLink({


### PR DESCRIPTION
## Summary
- blend model confidence and policy momentum when analytics requests omit `interactionSignal`
- keep explicit `interactionSignal` overrides authoritative
- preserve existing validation hardening for finite values and bounded k3h4 dimensions

## Validation
- `bun test src/typescript/api/src/routes/netcode.contract.test.ts`
- `API: smoke (v3)` task
