### PR TITLE
feat(k3h4): expose abi layer catalog through analytics

### DIFF
--- a/src/typescript/api/src/routes/netcode.contract.test.ts
+++ b/src/typescript/api/src/routes/netcode.contract.test.ts
@@ -262,6 +262,64 @@ describe('netcode analytics contract', () => {
     await app.close();
   });
 
+  test('rejects non-finite analytics payload values', async () => {
+    const app = await createApp(createFakeNetcode({}));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/netcode/analytics',
+      payload: {
+        callDensity: Number.NaN,
+        questPercent: 20,
+        playerLevel: 30,
+        comboStreak: 40,
+        branchPressure: 50,
+        dependencyPulse: 60,
+        workflowDepth: 2,
+        networkDimensions: 6,
+        modelConfidence: 77,
+        policyMomentum: 66,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: 'Invalid netcode analytics payload',
+    });
+
+    await app.close();
+  });
+
+  test(
+      'rejects analytics payloads with out-of-range k3h4 dimensions',
+      async () => {
+        const app = await createApp(createFakeNetcode({}));
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/netcode/analytics',
+          payload: {
+            callDensity: 10,
+            questPercent: 20,
+            playerLevel: 30,
+            comboStreak: 40,
+            branchPressure: 50,
+            dependencyPulse: 60,
+            workflowDepth: 2,
+            networkDimensions: 17,
+            modelConfidence: 77,
+            policyMomentum: 66,
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toMatchObject({
+          error: 'Invalid netcode analytics payload',
+        });
+
+        await app.close();
+      });
+
   test('returns deterministic unsupported-version error payload', async () => {
     const captured: CapturedArgs = {};
     const failingService: NativeNetcodeService = {

--- a/src/typescript/api/src/routes/netcode.contract.test.ts
+++ b/src/typescript/api/src/routes/netcode.contract.test.ts
@@ -161,6 +161,13 @@ function createFakeNetcode(captured: CapturedArgs): NativeNetcodeService {
           deterministicHash: 123456,
           endiannessDecodePath: 'little-endian' as const,
         },
+        envelope: {
+          contractVersion: 1,
+          byteOrderTag: 0x01020304,
+          payloadBytes: 892,
+          payloadCrc32: 987654321,
+          status: 'ok' as const,
+        },
       };
     },
   };
@@ -200,7 +207,7 @@ describe('netcode analytics contract', () => {
         });
 
         expect(response.statusCode).toBe(200);
-  expect(captured.rewardSignal).toBe(73);
+        expect(captured.rewardSignal).toBe(73);
         expect(captured.linkSignal).toBe(66);
         const json = response.json();
         expect(json).toMatchObject({
@@ -224,6 +231,16 @@ describe('netcode analytics contract', () => {
         expect(json.k3h4.observability).toMatchObject({
           deterministicHash: 123456
         });
+        expect(json.abiLayers).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            layer: 'hypersphere',
+            contractVersion: 1,
+            status: 'ok',
+            payloadBytes: 892,
+            byteOrderTag: 0x01020304,
+            deterministicHash: 123456,
+          }),
+        ]));
         const payload = response.json() as {
           hypersphere: {
             nodes: Array<{inradius: number; nearestNeighborDistance: number;}>;

--- a/src/typescript/api/src/routes/netcode.contract.test.ts
+++ b/src/typescript/api/src/routes/netcode.contract.test.ts
@@ -200,7 +200,7 @@ describe('netcode analytics contract', () => {
         });
 
         expect(response.statusCode).toBe(200);
-        expect(captured.rewardSignal).toBe(77);
+  expect(captured.rewardSignal).toBe(73);
         expect(captured.linkSignal).toBe(66);
         const json = response.json();
         expect(json).toMatchObject({
@@ -234,6 +234,35 @@ describe('netcode analytics contract', () => {
 
         await app.close();
       });
+
+  test('prefers explicit interactionSignal over blended fallback', async () => {
+    const captured: CapturedArgs = {};
+    const app = await createApp(createFakeNetcode(captured));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/netcode/analytics',
+      payload: {
+        callDensity: 10,
+        questPercent: 20,
+        playerLevel: 30,
+        comboStreak: 40,
+        branchPressure: 50,
+        dependencyPulse: 60,
+        workflowDepth: 2,
+        networkDimensions: 6,
+        modelConfidence: 77,
+        policyMomentum: 66,
+        interactionSignal: 91,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(captured.rewardSignal).toBe(91);
+    expect(captured.linkSignal).toBe(66);
+
+    await app.close();
+  });
 
   test('rejects invalid analytics payloads', async () => {
     const app = await createApp(createFakeNetcode({}));

--- a/src/typescript/api/src/routes/netcode.ts
+++ b/src/typescript/api/src/routes/netcode.ts
@@ -11,6 +11,19 @@ type NetcodeRouteOptions = {
   netcodeService?: NativeNetcodeService;
 };
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isValidWorkflowDepth(value: unknown): value is 1|2|3 {
+  return isFiniteNumber(value) && (value === 1 || value === 2 || value === 3);
+}
+
+function isValidNetworkDimensions(value: unknown): boolean {
+  return isFiniteNumber(value) && Number.isInteger(value) && value >= 1 &&
+      value <= 16;
+}
+
 function resolveNetcodeHypersphereKmeansRollout(): NetcodeHypersphereRollout {
   const enabledRaw =
       (process.env.BANANA_NETCODE_K3H4_ENABLED ?? 'true').trim().toLowerCase();
@@ -51,12 +64,11 @@ export async function registerNetcodeRoutes(
       '/api/netcode/learning',
       async (request, reply) => {
         const body = request.body;
-        if (!body || typeof body.callDensity !== 'number' ||
-            typeof body.questPercent !== 'number' ||
-            typeof body.comboStreak !== 'number' ||
-            typeof body.branchPressure !== 'number' ||
-            (body.workflowDepth !== 1 && body.workflowDepth !== 2 &&
-             body.workflowDepth !== 3)) {
+        if (!body || !isFiniteNumber(body.callDensity) ||
+            !isFiniteNumber(body.questPercent) ||
+            !isFiniteNumber(body.comboStreak) ||
+            !isFiniteNumber(body.branchPressure) ||
+            !isValidWorkflowDepth(body.workflowDepth)) {
           return reply.status(400).send({
             error: 'Invalid netcode learning payload',
           });
@@ -99,12 +111,11 @@ export async function registerNetcodeRoutes(
     }
   }>('/api/netcode/reward', async (request, reply) => {
     const body = request.body;
-    if (!body || typeof body.callDensity !== 'number' ||
-        typeof body.questPercent !== 'number' ||
-        typeof body.comboStreak !== 'number' ||
-        typeof body.branchPressure !== 'number' ||
-        (body.workflowDepth !== 1 && body.workflowDepth !== 2 &&
-         body.workflowDepth !== 3)) {
+    if (!body || !isFiniteNumber(body.callDensity) ||
+        !isFiniteNumber(body.questPercent) ||
+        !isFiniteNumber(body.comboStreak) ||
+        !isFiniteNumber(body.branchPressure) ||
+        !isValidWorkflowDepth(body.workflowDepth)) {
       return reply.status(400).send({error: 'Invalid netcode reward payload'});
     }
 
@@ -131,12 +142,12 @@ export async function registerNetcodeRoutes(
     }
   }>('/api/netcode/link', async (request, reply) => {
     const body = request.body;
-    if (!body || typeof body.callDensity !== 'number' ||
-        typeof body.questPercent !== 'number' ||
-        typeof body.playerLevel !== 'number' ||
-        typeof body.comboStreak !== 'number' ||
-        typeof body.branchPressure !== 'number' ||
-        typeof body.dependencyPulse !== 'number') {
+    if (!body || !isFiniteNumber(body.callDensity) ||
+        !isFiniteNumber(body.questPercent) ||
+        !isFiniteNumber(body.playerLevel) ||
+        !isFiniteNumber(body.comboStreak) ||
+        !isFiniteNumber(body.branchPressure) ||
+        !isFiniteNumber(body.dependencyPulse)) {
       return reply.status(400).send({error: 'Invalid netcode link payload'});
     }
 
@@ -176,17 +187,16 @@ export async function registerNetcodeRoutes(
     }
 
     const body = request.body;
-    if (!body || typeof body.callDensity !== 'number' ||
-        typeof body.questPercent !== 'number' ||
-        typeof body.playerLevel !== 'number' ||
-        typeof body.comboStreak !== 'number' ||
-        typeof body.branchPressure !== 'number' ||
-        typeof body.dependencyPulse !== 'number' ||
-        (body.workflowDepth !== 1 && body.workflowDepth !== 2 &&
-         body.workflowDepth !== 3) ||
-        typeof body.networkDimensions !== 'number' ||
-        typeof body.modelConfidence !== 'number' ||
-        typeof body.policyMomentum !== 'number') {
+    if (!body || !isFiniteNumber(body.callDensity) ||
+        !isFiniteNumber(body.questPercent) ||
+        !isFiniteNumber(body.playerLevel) ||
+        !isFiniteNumber(body.comboStreak) ||
+        !isFiniteNumber(body.branchPressure) ||
+        !isFiniteNumber(body.dependencyPulse) ||
+        !isValidWorkflowDepth(body.workflowDepth) ||
+        !isValidNetworkDimensions(body.networkDimensions) ||
+        !isFiniteNumber(body.modelConfidence) ||
+        !isFiniteNumber(body.policyMomentum)) {
       return reply.status(400).send(
           {error: 'Invalid netcode analytics payload'});
     }
@@ -225,18 +235,17 @@ export async function registerNetcodeRoutes(
     }
   }>('/api/netcode/vector', async (request, reply) => {
     const body = request.body;
-    if (!body || typeof body.callDensity !== 'number' ||
-        typeof body.questPercent !== 'number' ||
-        typeof body.playerLevel !== 'number' ||
-        typeof body.comboStreak !== 'number' ||
-        typeof body.branchPressure !== 'number' ||
-        typeof body.dependencyPulse !== 'number' ||
-        (body.workflowDepth !== 1 && body.workflowDepth !== 2 &&
-         body.workflowDepth !== 3) ||
-        typeof body.neuralRelevanceScore !== 'number' ||
-        typeof body.networkDimensions !== 'number' ||
-        typeof body.modelConfidence !== 'number' ||
-        typeof body.policyMomentum !== 'number') {
+    if (!body || !isFiniteNumber(body.callDensity) ||
+        !isFiniteNumber(body.questPercent) ||
+        !isFiniteNumber(body.playerLevel) ||
+        !isFiniteNumber(body.comboStreak) ||
+        !isFiniteNumber(body.branchPressure) ||
+        !isFiniteNumber(body.dependencyPulse) ||
+        !isValidWorkflowDepth(body.workflowDepth) ||
+        !isFiniteNumber(body.neuralRelevanceScore) ||
+        !isValidNetworkDimensions(body.networkDimensions) ||
+        !isFiniteNumber(body.modelConfidence) ||
+        !isFiniteNumber(body.policyMomentum)) {
       return reply.status(400).send({error: 'Invalid netcode vector payload'});
     }
 
@@ -270,18 +279,17 @@ export async function registerNetcodeRoutes(
     }
   }>('/api/netcode/hypersphere', async (request, reply) => {
     const body = request.body;
-    if (!body || typeof body.callDensity !== 'number' ||
-        typeof body.questPercent !== 'number' ||
-        typeof body.playerLevel !== 'number' ||
-        typeof body.comboStreak !== 'number' ||
-        typeof body.branchPressure !== 'number' ||
-        typeof body.dependencyPulse !== 'number' ||
-        (body.workflowDepth !== 1 && body.workflowDepth !== 2 &&
-         body.workflowDepth !== 3) ||
-        typeof body.neuralRelevanceScore !== 'number' ||
-        typeof body.networkDimensions !== 'number' ||
-        typeof body.modelConfidence !== 'number' ||
-        typeof body.policyMomentum !== 'number') {
+    if (!body || !isFiniteNumber(body.callDensity) ||
+        !isFiniteNumber(body.questPercent) ||
+        !isFiniteNumber(body.playerLevel) ||
+        !isFiniteNumber(body.comboStreak) ||
+        !isFiniteNumber(body.branchPressure) ||
+        !isFiniteNumber(body.dependencyPulse) ||
+        !isValidWorkflowDepth(body.workflowDepth) ||
+        !isFiniteNumber(body.neuralRelevanceScore) ||
+        !isValidNetworkDimensions(body.networkDimensions) ||
+        !isFiniteNumber(body.modelConfidence) ||
+        !isFiniteNumber(body.policyMomentum)) {
       return reply.status(400).send(
           {error: 'Invalid netcode hypersphere payload'});
     }

--- a/src/typescript/api/src/services/netcodeAuthoritativeComputeOrchestrator.test.ts
+++ b/src/typescript/api/src/services/netcodeAuthoritativeComputeOrchestrator.test.ts
@@ -145,6 +145,13 @@ function createFakeNativeNetcodeService(): NativeNetcodeService {
           deterministicHash: 123456,
           endiannessDecodePath: 'little-endian' as const,
         },
+          envelope: {
+            contractVersion: 1,
+            byteOrderTag: 0x01020304,
+            payloadBytes: 892,
+            payloadCrc32: 987654321,
+            status: 'ok' as const,
+          },
       };
     },
   };
@@ -177,6 +184,15 @@ describe('netcode authoritative compute orchestrator', () => {
         expect(result.contractVersion).toBe(1);
         expect(result.k3h4.observability.deterministicHash)
             .toBe(123456);
+        expect(result.abiLayers).toHaveLength(5);
+        expect(result.abiLayers[4]).toMatchObject({
+          layer: 'hypersphere',
+          contractVersion: 1,
+          status: 'ok',
+          payloadBytes: 892,
+          byteOrderTag: 0x01020304,
+          deterministicHash: 123456,
+        });
         expect(result.lspRepresentation).toMatchObject({
           language: 'netcode.analytics.v1',
           boundedContext: 'netcode',

--- a/src/typescript/api/src/services/netcodeAuthoritativeComputeOrchestrator.ts
+++ b/src/typescript/api/src/services/netcodeAuthoritativeComputeOrchestrator.ts
@@ -88,6 +88,16 @@ function mapHypersphereBuildError(error: unknown):
   return undefined;
 }
 
+function resolveRewardInteractionSignal(
+    request: NetcodeAnalyticsAuthoritativeRequest,
+    ): number {
+  if (typeof request.interactionSignal === 'number') {
+    return request.interactionSignal;
+  }
+
+  return Math.round((request.modelConfidence * 2 + request.policyMomentum) / 3);
+}
+
 class NativeNetcodeAuthoritativeComputeOrchestrator implements
     NetcodeAnalyticsAuthoritativeComputeOrchestrator {
   constructor(private readonly netcode: NativeNetcodeService) {}
@@ -104,9 +114,7 @@ class NativeNetcodeAuthoritativeComputeOrchestrator implements
           branchPressure: request.branchPressure,
           workflowDepth: request.workflowDepth,
         },
-        typeof request.interactionSignal === 'number' ?
-            request.interactionSignal :
-            request.modelConfidence,
+        resolveRewardInteractionSignal(request),
     );
 
     const link = await this.netcode.buildLink({

--- a/src/typescript/api/src/services/netcodeAuthoritativeComputeOrchestrator.ts
+++ b/src/typescript/api/src/services/netcodeAuthoritativeComputeOrchestrator.ts
@@ -4,6 +4,19 @@ export type NetcodeHypersphereRollout = {
   enabled: boolean; cohort: string;
 };
 
+export type NetcodeAbiLayerName =
+    'learning'|'reward'|'link'|'vector'|'hypersphere';
+
+export type NetcodeAbiLayerSnapshot = {
+  layer: NetcodeAbiLayerName;
+  contractVersion: 1;
+  status: 'ok'|'unsupported-version'|'invalid-payload'|'nonfinite-value'|
+      'crc-mismatch';
+  payloadBytes: number;
+  byteOrderTag: number;
+  deterministicHash: number;
+};
+
 export type NetcodeAnalyticsAuthoritativeRequest = {
   callDensity: number; questPercent: number; playerLevel: number;
   comboStreak: number;
@@ -38,6 +51,7 @@ export type NetcodeAnalyticsAuthoritativeResult = {
   vector: NetcodeVectorOutput;
   hypersphere: NetcodeHypersphereOutput;
   k3h4: NetcodeHypersphereKmeansProjection;
+  abiLayers: readonly NetcodeAbiLayerSnapshot[];
   lspRepresentation: NetcodeLspRepresentation;
 };
 
@@ -96,6 +110,57 @@ function resolveRewardInteractionSignal(
   }
 
   return Math.round((request.modelConfidence * 2 + request.policyMomentum) / 3);
+}
+
+function buildAbiLayerCatalog(
+    reward: NetcodeRewardOutput,
+    link: NetcodeLinkOutput,
+    vector: NetcodeVectorOutput,
+    hypersphere: NetcodeHypersphereOutput,
+    ): readonly NetcodeAbiLayerSnapshot[] {
+  const hypersphereEnvelope = hypersphere.envelope;
+  return [
+    {
+      layer: 'learning',
+      contractVersion: 1,
+      status: 'ok',
+      payloadBytes: 0,
+      byteOrderTag: 0,
+      deterministicHash: reward.neuralRelevanceScore,
+    },
+    {
+      layer: 'reward',
+      contractVersion: 1,
+      status: 'ok',
+      payloadBytes: 0,
+      byteOrderTag: 0,
+      deterministicHash: reward.projectedRewardXp,
+    },
+    {
+      layer: 'link',
+      contractVersion: 1,
+      status: 'ok',
+      payloadBytes: 0,
+      byteOrderTag: 0,
+      deterministicHash: link.intel + link.objectives + link.player + link.ops,
+    },
+    {
+      layer: 'vector',
+      contractVersion: 1,
+      status: 'ok',
+      payloadBytes: 0,
+      byteOrderTag: 0,
+      deterministicHash: vector.dimensions,
+    },
+    {
+      layer: 'hypersphere',
+      contractVersion: 1,
+      status: hypersphereEnvelope?.status ?? 'ok',
+      payloadBytes: hypersphereEnvelope?.payloadBytes ?? 0,
+      byteOrderTag: hypersphereEnvelope?.byteOrderTag ?? 0,
+      deterministicHash: hypersphere.observability.deterministicHash,
+    },
+  ];
 }
 
 class NativeNetcodeAuthoritativeComputeOrchestrator implements
@@ -161,6 +226,7 @@ class NativeNetcodeAuthoritativeComputeOrchestrator implements
       spectralProxy: hypersphere.spectralProxy,
       observability: hypersphere.observability,
     };
+    const abiLayers = buildAbiLayerCatalog(reward, link, vector, hypersphere);
 
     return {
       contractVersion: 1,
@@ -169,6 +235,7 @@ class NativeNetcodeAuthoritativeComputeOrchestrator implements
       vector,
       hypersphere,
       k3h4,
+      abiLayers,
       lspRepresentation: {
         language: 'netcode.analytics.v1',
         boundedContext: 'netcode',

--- a/src/typescript/react/src/domain/notebook/k3h4AnalyticsOrchestrationLayer.ts
+++ b/src/typescript/react/src/domain/notebook/k3h4AnalyticsOrchestrationLayer.ts
@@ -1,4 +1,7 @@
-import type {NetcodeAnalyticsResponse} from '../../lib/api';
+import type {
+  NetcodeAnalyticsAbiLayerSnapshot,
+  NetcodeAnalyticsResponse,
+} from '../../lib/api';
 
 import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, NodeLinkConfidenceModel, RewardSignalModel,} from './network-domain';
 
@@ -27,6 +30,7 @@ export type K3h4AnalyticsPresentationState = {
   contractVectors: readonly ContractNodeVectorModel[];
   hypersphereProjection: ContractHypersphereProjectionModel;
   k3h4: ContractHypersphereKmeansModel;
+  abiLayers: readonly NetcodeAnalyticsAbiLayerSnapshot[];
 };
 
 export function mapK3h4AnalyticsToPresentationState(
@@ -119,5 +123,6 @@ export function mapK3h4AnalyticsToPresentationState(
     contractVectors,
     hypersphereProjection,
     k3h4,
+    abiLayers: analytics.abiLayers.map((layer) => ({...layer})),
   };
 }

--- a/src/typescript/react/src/domain/notebook/useNetcodeSession.test.ts
+++ b/src/typescript/react/src/domain/notebook/useNetcodeSession.test.ts
@@ -154,6 +154,48 @@ describe('useNetcodeSession contract consumer', () => {
              deterministicHash: 'a1b2c3d4e5',
            },
          },
+         abiLayers: [
+           {
+             layer: 'learning',
+             contractVersion: 1,
+             status: 'ok',
+             payloadBytes: 0,
+             byteOrderTag: 0,
+             deterministicHash: 91,
+           },
+           {
+             layer: 'reward',
+             contractVersion: 1,
+             status: 'ok',
+             payloadBytes: 0,
+             byteOrderTag: 0,
+             deterministicHash: 42,
+           },
+           {
+             layer: 'link',
+             contractVersion: 1,
+             status: 'ok',
+             payloadBytes: 0,
+             byteOrderTag: 0,
+             deterministicHash: 30,
+           },
+           {
+             layer: 'vector',
+             contractVersion: 1,
+             status: 'ok',
+             payloadBytes: 0,
+             byteOrderTag: 0,
+             deterministicHash: 3,
+           },
+           {
+             layer: 'hypersphere',
+             contractVersion: 1,
+             status: 'ok',
+             payloadBytes: 892,
+             byteOrderTag: 0x01020304,
+             deterministicHash: 'a1b2c3d4e5',
+           },
+         ],
          rollout: {enabled: true, cohort: 'canary'},
        };
 
@@ -180,6 +222,12 @@ describe('useNetcodeSession contract consumer', () => {
            .toBe(24576);
        expect(result.current.k3h4.observability.convergenceStatus)
            .toBe('converged');
+       expect(result.current.abiLayers).toHaveLength(5);
+       expect(result.current.abiLayers[4]).toMatchObject({
+         layer: 'hypersphere',
+         payloadBytes: 892,
+         byteOrderTag: 0x01020304,
+       });
        expect(result.current.analyticsAvailability).toMatchObject({
          available: true,
          reason: 'ok',

--- a/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
+++ b/src/typescript/react/src/domain/notebook/useNetcodeSession.ts
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 import {composeK3h4PresentationApplicationService,} from '../../application/notebook/k3h4/k3h4PresentationCompositionRoot';
+import type {NetcodeAnalyticsAbiLayerSnapshot,} from '../../lib/api';
 import {fetchNetcodeAnalytics, fetchNetcodeLearning, NetcodeAnalyticsError, resolveApiBaseUrl,} from '../../lib/api';
 
 import type {ContractHypersphereKmeansModel, ContractHypersphereProjectionModel, ContractNodeId, ContractNodeVectorModel, NetcodeAnalyticsAvailabilityModel, NodeInteractionAction, NodeInteractionLearningModel, NodeInteractionLedger, NodeLinkConfidenceModel, RewardSignalModel,} from './network-domain';
@@ -139,6 +140,7 @@ type ApiLearningResponse = {
 export type NetcodeSessionHook = {
   readonly learningModel: NodeInteractionLearningModel; readonly ledger: NodeInteractionLedger; readonly recordNodeTap: (node: ContractNodeId) => void; readonly recordAction: (action: NodeInteractionAction) => void; readonly rewardSignal: RewardSignalModel; readonly linkConfidence: NodeLinkConfidenceModel; readonly contractVectors: readonly ContractNodeVectorModel[]; readonly hypersphereProjection: ContractHypersphereProjectionModel; readonly k3h4: ContractHypersphereKmeansModel; readonly analyticsAvailability:
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   NetcodeAnalyticsAvailabilityModel;
+  readonly abiLayers: readonly NetcodeAnalyticsAbiLayerSnapshot[];
 };
 
 export function useNetcodeSession({
@@ -164,6 +166,8 @@ export function useNetcodeSession({
       useState<ContractHypersphereProjectionModel>(DEFAULT_HYPERSPHERE);
   const [k3h4, setHypersphereKmeans] =
       useState<ContractHypersphereKmeansModel>(DEFAULT_K3H4);
+    const [abiLayers, setAbiLayers] =
+      useState<readonly NetcodeAnalyticsAbiLayerSnapshot[]>([]);
   const [analyticsAvailability, setAnalyticsAvailability] =
       useState<NetcodeAnalyticsAvailabilityModel>(
           DEFAULT_ANALYTICS_AVAILABILITY);
@@ -285,6 +289,7 @@ export function useNetcodeSession({
             setContractVectors(presentationState.contractVectors);
             setHypersphereProjection(presentationState.hypersphereProjection);
             setHypersphereKmeans(presentationState.k3h4);
+            setAbiLayers(presentationState.abiLayers);
 
             const rollout = analytics.rollout;
             setAnalyticsAvailability({
@@ -361,5 +366,6 @@ export function useNetcodeSession({
     hypersphereProjection,
     k3h4,
     analyticsAvailability,
+    abiLayers,
   };
 }

--- a/src/typescript/react/src/lib/api.ts
+++ b/src/typescript/react/src/lib/api.ts
@@ -101,6 +101,20 @@ export type NetcodeAnalyticsRollout = {
   enabled: boolean; cohort: string;
 };
 
+export type NetcodeAnalyticsAbiLayerKind =
+    'learning'|'reward'|'link'|'vector'|'hypersphere';
+
+export type NetcodeAnalyticsAbiLayerSnapshot = {
+  readonly layer: NetcodeAnalyticsAbiLayerKind;
+  readonly contractVersion: number;
+  readonly status:
+      'ok'|'unsupported-version'|'invalid-payload'|'nonfinite-value'|
+      'crc-mismatch';
+  readonly payloadBytes: number;
+  readonly byteOrderTag: number;
+  readonly deterministicHash: number;
+};
+
 export type NetcodeAnalyticsLspRepresentation = {
   language: 'netcode.analytics.v1'; boundedContext: 'netcode';
   aggregate: 'k3h4';
@@ -133,6 +147,7 @@ export type NetcodeAnalyticsResponse = {
     radialStability: number;
   };
   k3h4: NetcodeHypersphereKmeansPayload;
+  abiLayers: readonly NetcodeAnalyticsAbiLayerSnapshot[];
   rollout: NetcodeAnalyticsRollout;
 };
 


### PR DESCRIPTION
## Summary
- add a typed k3h4 ABI layer catalog to the authoritative analytics result
- carry ABI layer snapshots through the API response and into React presentation state
- keep the existing k3h4 analytics payload stable while making ABI metadata visible as data

## Validation
- `bun test src/typescript/api/src/services/netcodeAuthoritativeComputeOrchestrator.test.ts src/typescript/api/src/routes/netcode.contract.test.ts`
- `bun test src/typescript/react/src/domain/notebook/useNetcodeSession.test.ts`
- `API: smoke (v3)` task
- `UI: smoke (v3)` task
