### PR TITLE
chore: shelve prod k3h4 follow-up deltas

### DIFF
--- a/src/typescript/api/src/routes/notebooks.ts
+++ b/src/typescript/api/src/routes/notebooks.ts
@@ -1,7 +1,7 @@
 // Notebooks route — serves a live-scanned catalog-index manifest of all
 // native C/H sources so the file explorer always reflects the current tree.
 import type {FastifyInstance} from 'fastify';
-import {readFileSync, readdirSync, statSync} from 'node:fs';
+import {readdirSync, readFileSync, statSync} from 'node:fs';
 import {join, relative} from 'node:path';
 
 function discoverNativeSources(sourceRoot: string): string[] {
@@ -35,9 +35,7 @@ function discoverNativeSources(sourceRoot: string): string[] {
 }
 
 type NotebookManifestPayload = {
-  generated_at_utc: string;
-  source_root: string;
-  notebook_path: string;
+  generated_at_utc: string; source_root: string; notebook_path: string;
   file_count: number;
   max_lines_per_file: number;
   files: string[];
@@ -55,9 +53,8 @@ function loadBundledNotebookManifest(workspaceRoot: string):
 
     return {
       generated_at_utc: new Date().toISOString(),
-      source_root: typeof parsed.source_root === 'string' ?
-          parsed.source_root :
-          'src/native',
+      source_root: typeof parsed.source_root === 'string' ? parsed.source_root :
+                                                            'src/native',
       notebook_path: typeof parsed.notebook_path === 'string' ?
           parsed.notebook_path :
           'notebooks/native-c-catalog.ipynb',
@@ -116,7 +113,8 @@ export async function registerNotebooksRoutes(app: FastifyInstance):
       return reply.send(payload);
     } catch {
       return reply.status(404).send({
-        message: 'Notebook payload is unavailable from API. Check API runtime and notebook endpoint.',
+        message:
+            'Notebook payload is unavailable from API. Check API runtime and notebook endpoint.',
       });
     }
   });

--- a/src/typescript/react/src/domain/notebook/k3h4AnalyticsOrchestrationLayer.ts
+++ b/src/typescript/react/src/domain/notebook/k3h4AnalyticsOrchestrationLayer.ts
@@ -113,12 +113,12 @@ export function mapK3h4AnalyticsToPresentationState(
       rewardTier === 'Relevant'                    ? RELEVANT_BAND :
                                                      LABELING_BAND;
 
-  const contractVectors = NODE_ORDER.map(
-      (id, index) => ({
-        id,
-        dimensions: [...(safeNodeVectors[index] ?? [])],
-        contractStrength: safeContractStrength[index] ?? 0,
-      }));
+  const contractVectors =
+      NODE_ORDER.map((id, index) => ({
+                       id,
+                       dimensions: [...(safeNodeVectors[index] ?? [])],
+                       contractStrength: safeContractStrength[index] ?? 0,
+                     }));
 
   const k3h4Projection = {
     dimensions: analytics.k3h4Projection?.dimensions ?? 0,
@@ -131,8 +131,7 @@ export function mapK3h4AnalyticsToPresentationState(
           coherence: safeProjectionNodes[index]?.coherence ?? 0,
           inradius: safeProjectionNodes[index]?.inradius ?? 0,
           nearestNeighborDistance:
-              safeProjectionNodes[index]?.nearestNeighborDistance ??
-              0,
+              safeProjectionNodes[index]?.nearestNeighborDistance ?? 0,
         })),
     alignment: analytics.k3h4Projection?.alignment ?? 0,
     radialStability: analytics.k3h4Projection?.radialStability ?? 0,
@@ -153,40 +152,42 @@ export function mapK3h4AnalyticsToPresentationState(
         memberCount: center.memberCount,
       };
     }),
-    radii: (safeK3h4.radii ?? []).map(
-        (radius) => ({
-          clusterId: radius.clusterId,
-          nearestNeighborDistanceQ16: radius.nearestNeighborDistanceQ16,
-          inscribedRadiusQ16: radius.inscribedRadiusQ16,
-          radiusState: radius.radiusState,
-        })),
-    weightedVoronoiScores: (safeK3h4.weightedVoronoiScores ?? []).map(
-        (score) => ({
-          vectorId: score.vectorId,
-          clusterId: score.clusterId,
-          distanceToCenterQ16: score.distanceToCenterQ16,
-          weightedScoreQ16: score.weightedScoreQ16,
-          scoreValidity: score.scoreValidity,
-        })),
-    spectralProxy: (safeK3h4.spectralProxy ?? []).map(
-        (entry) => ({
-          clusterId: entry.clusterId,
-          frequencyProxyQ16: entry.frequencyProxyQ16,
-          amplitudeProxyQ16: entry.amplitudeProxyQ16,
-          spectralState: entry.spectralState,
-        })),
+    radii: (safeK3h4.radii ??
+            []).map((radius) => ({
+                      clusterId: radius.clusterId,
+                      nearestNeighborDistanceQ16:
+                          radius.nearestNeighborDistanceQ16,
+                      inscribedRadiusQ16: radius.inscribedRadiusQ16,
+                      radiusState: radius.radiusState,
+                    })),
+    weightedVoronoiScores:
+        (safeK3h4.weightedVoronoiScores ??
+         []).map((score) => ({
+                   vectorId: score.vectorId,
+                   clusterId: score.clusterId,
+                   distanceToCenterQ16: score.distanceToCenterQ16,
+                   weightedScoreQ16: score.weightedScoreQ16,
+                   scoreValidity: score.scoreValidity,
+                 })),
+    spectralProxy: (safeK3h4.spectralProxy ??
+                    []).map((entry) => ({
+                              clusterId: entry.clusterId,
+                              frequencyProxyQ16: entry.frequencyProxyQ16,
+                              amplitudeProxyQ16: entry.amplitudeProxyQ16,
+                              spectralState: entry.spectralState,
+                            })),
     observability: {
-      convergenceStatus: normalizeConvergenceStatus(
-          safeK3h4.observability?.convergenceStatus),
+      convergenceStatus:
+          normalizeConvergenceStatus(safeK3h4.observability?.convergenceStatus),
       iterationCount: safeK3h4.observability?.iterationCount ?? 0,
       assignmentChangesLastIteration:
           safeK3h4.observability?.assignmentChangesLastIteration ?? 0,
-      scoringValidity:
-          normalizeScoringValidity((safeK3h4.observability as {
-                                     readonly scoringValidity?: unknown;
-                                   }).scoringValidity),
-      deterministicHash: normalizeDeterministicHash(
-          safeK3h4.observability?.deterministicHash),
+      scoringValidity: normalizeScoringValidity((safeK3h4.observability as {
+                                                  readonly scoringValidity?:
+                                                      unknown;
+                                                }).scoringValidity),
+      deterministicHash:
+          normalizeDeterministicHash(safeK3h4.observability?.deterministicHash),
     },
     runtime: {
       mode: analytics.k3h4Runtime?.mode ?? 'multiplicative',


### PR DESCRIPTION
## Summary\n- capture pending notebooks route formatting deltas\n- capture pending k3h4 analytics presentation mapping formatting deltas\n- keep this as a shelved follow-up branch while prod rollout settles\n\n## Notes\n- no behavioral contract changes intended\n- excludes generated tsbuildinfo noise