### PR TITLE
Add K3H4 training routes and notebook workflow UI

### DIFF
--- a/src/typescript/api/src/routes/netcode.contract.test.ts
+++ b/src/typescript/api/src/routes/netcode.contract.test.ts
@@ -3,8 +3,10 @@ import Fastify from 'fastify';
 
 import {registerFastifyErrorMapper} from '../lib/errors/fastifyErrorMapper.ts';
 import {registerRequestContextMiddleware} from '../middleware/requestContext.ts';
-import type {K3h4ScalingBenchmarkStatus} from '../services/k3h4ScalingBenchmark.ts';
 import type {K3h4ApplicationOrchestrationLayer} from '../services/k3h4ApplicationOrchestrationLayer.ts';
+import type {K3h4ScalingBenchmarkStatus} from '../services/k3h4ScalingBenchmark.ts';
+import {K3h4VizServiceError} from '../services/k3h4TrainingService.ts';
+import type {EpochGeometry, K3h4TrainingService} from '../services/k3h4TrainingService.ts';
 import type {NativeNetcodeService} from '../services/nativeNetcode.ts';
 import {type NetcodeAnalyticsAuthoritativeResult, NetcodeAnalyticsOrchestrationError,} from '../services/netcodeAuthoritativeComputeOrchestrator.ts';
 
@@ -395,11 +397,21 @@ function createFakeNetcode(captured: CapturedArgs): NativeNetcodeService {
   };
 }
 
-async function createApp(netcodeService: NativeNetcodeService) {
+async function createApp(
+    netcodeService: NativeNetcodeService,
+    options: {
+      scalingBenchmarkLoader?: () => K3h4ScalingBenchmarkStatus;
+      k3h4TrainingService?: K3h4TrainingService;
+    } = {},
+) {
   const app = Fastify({logger: false});
   await registerRequestContextMiddleware(app);
   registerFastifyErrorMapper(app);
-  await registerNetcodeRoutes(app, {netcodeService});
+  await registerNetcodeRoutes(app, {
+    netcodeService,
+    scalingBenchmarkLoader: options.scalingBenchmarkLoader,
+    k3h4TrainingService: options.k3h4TrainingService,
+  });
   await app.ready();
   return app;
 }
@@ -964,73 +976,77 @@ describe('netcode analytics contract', () => {
 
 async function buildScalingBenchmarkApp(
     benchmarkStatus: K3h4ScalingBenchmarkStatus,
-        ) {
-          const app = Fastify();
-          registerFastifyErrorMapper(app);
-          await registerRequestContextMiddleware(app);
-          await registerNetcodeRoutes(app, {
-            netcodeAuthoritativeComputeOrchestrator: undefined,
-            k3h4ApplicationOrchestrationLayer: undefined,
-            netcodeService: undefined,
-            scalingBenchmarkLoader: () => benchmarkStatus,
-          });
-          return app;
-        }
+) {
+  const app = Fastify();
+  registerFastifyErrorMapper(app);
+  await registerRequestContextMiddleware(app);
+  await registerNetcodeRoutes(app, {
+    netcodeAuthoritativeComputeOrchestrator: undefined,
+    k3h4ApplicationOrchestrationLayer: undefined,
+    netcodeService: undefined,
+    scalingBenchmarkLoader: () => benchmarkStatus,
+  });
+  return app;
+}
 
-        const CANONICAL_BENCHMARK_RESULT = {
-          contractVersion: 1 as const,
-          schemaVersion: 1,
-          series: [
-            {n: 64, k3h4Ns: 1000, attentionNs: 4000},
-            {n: 256, k3h4Ns: 4000, attentionNs: 65000},
-            {n: 1024, k3h4Ns: 16000, attentionNs: 1048000},
-            {n: 4096, k3h4Ns: 64000, attentionNs: 16777000},
-            {n: 16384, k3h4Ns: 256000, attentionNs: 268435000},
-          ],
-          metadata: {
-            calibratedSizes: [64, 256, 1024, 4096, 16384],
-            extrapolatedAbove: null,
-          },
-        } as const;
+const CANONICAL_BENCHMARK_RESULT = {
+  contractVersion: 1 as const,
+  schemaVersion: 1,
+  series: [
+    {n: 64, k3h4Ns: 1000, attentionNs: 4000},
+    {n: 256, k3h4Ns: 4000, attentionNs: 65000},
+    {n: 1024, k3h4Ns: 16000, attentionNs: 1048000},
+    {n: 4096, k3h4Ns: 64000, attentionNs: 16777000},
+    {n: 16384, k3h4Ns: 256000, attentionNs: 268435000},
+  ],
+  metadata: {
+    calibratedSizes: [64, 256, 1024, 4096, 16384],
+    extrapolatedAbove: null,
+  },
+} as const;
 
 describe('GET /api/netcode/k3h4/scaling-benchmark', () => {
-  test('returns 200 with scaling series when artifact is available', async () => {
-    const app = await buildScalingBenchmarkApp({
-      kind: 'ok',
-      result: CANONICAL_BENCHMARK_RESULT,
-    });
+  test(
+      'returns 200 with scaling series when artifact is available',
+      async () => {
+        const app = await buildScalingBenchmarkApp({
+          kind: 'ok',
+          result: CANONICAL_BENCHMARK_RESULT,
+        });
 
-    const response = await app.inject({
-      method: 'GET',
-      url: '/api/netcode/k3h4/scaling-benchmark',
-    });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/netcode/k3h4/scaling-benchmark',
+        });
 
-    expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body.contractVersion).toBe(1);
-    expect(Array.isArray(body.series)).toBe(true);
-    expect(body.series).toHaveLength(5);
-    expect(body.series[0]).toMatchObject({n: 64});
-    expect(body.series[4]).toMatchObject({n: 16384});
-    expect(body.metadata.calibratedSizes).toHaveLength(5);
-    expect(body.metadata.extrapolatedAbove).toBeNull();
+        expect(response.statusCode).toBe(200);
+        const body = response.json();
+        expect(body.contractVersion).toBe(1);
+        expect(Array.isArray(body.series)).toBe(true);
+        expect(body.series).toHaveLength(5);
+        expect(body.series[0]).toMatchObject({n: 64});
+        expect(body.series[4]).toMatchObject({n: 16384});
+        expect(body.metadata.calibratedSizes).toHaveLength(5);
+        expect(body.metadata.extrapolatedAbove).toBeNull();
 
-    await app.close();
-  });
+        await app.close();
+      });
 
-  test('returns 404 with benchmark_not_found when artifact is missing', async () => {
-    const app = await buildScalingBenchmarkApp({kind: 'not_found'});
+  test(
+      'returns 404 with benchmark_not_found when artifact is missing',
+      async () => {
+        const app = await buildScalingBenchmarkApp({kind: 'not_found'});
 
-    const response = await app.inject({
-      method: 'GET',
-      url: '/api/netcode/k3h4/scaling-benchmark',
-    });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/netcode/k3h4/scaling-benchmark',
+        });
 
-    expect(response.statusCode).toBe(404);
-    expect(response.json()).toMatchObject({error: 'benchmark_not_found'});
+        expect(response.statusCode).toBe(404);
+        expect(response.json()).toMatchObject({error: 'benchmark_not_found'});
 
-    await app.close();
-  });
+        await app.close();
+      });
 
   test('returns 503 with benchmark_unavailable when I/O fails', async () => {
     const app = await buildScalingBenchmarkApp({
@@ -1075,3 +1091,307 @@ describe('GET /api/netcode/k3h4/scaling-benchmark', () => {
   });
 });
 
+describe('K3H4 training integration routes', () => {
+  const CANONICAL_GEOMETRY: EpochGeometry = {
+    contractVersion: 1,
+    sessionId: 'sess-abc123',
+    epoch: 0,
+    mode: 'power',
+    spectralActive: false,
+    clusters: [
+      {
+        clusterId: 0,
+        centroid: {x: 0.5, y: 0.3},
+        inscribedRadius: 0.25,
+        weightedScore: 1.2,
+        spectralProxy: 0,
+        polygon: [
+          {x: 0.75, y: 0.3},
+          {x: 0.677, y: 0.477},
+          {x: 0.5, y: 0.55},
+          {x: 0.323, y: 0.477},
+          {x: 0.25, y: 0.3},
+          {x: 0.323, y: 0.123},
+          {x: 0.5, y: 0.05},
+          {x: 0.677, y: 0.123},
+        ],
+      },
+    ],
+    tokens: [
+      {tokenId: 'cluster-0', x: 0.5, y: 0.3, clusterId: 0, weightedScore: 1.2},
+    ],
+    projectionMetadata: {
+      method: 'pca',
+      components: 2,
+      explainedVariance: 0.9,
+      dimensionality: 3,
+    },
+  };
+
+  const createTrainingService = (): K3h4TrainingService => ({
+    async createTrainingSession(mode) {
+      return {
+        sessionId: 'sess-abc123',
+        mode,
+        createdAtUtc: '2026-06-17T00:00:00.000Z',
+      };
+    },
+    async readConfidenceTimeSeries(sessionId, mode) {
+      if (sessionId === 'missing') {
+        throw new K3h4VizServiceError(
+            'session_not_found', 'missing session', 404);
+      }
+
+      return {
+        contractVersion: 1 as const,
+        sessionId,
+        status: 'active' as const,
+        mode,
+        epochs: [
+          {epochIndex: 0, confidence: 0.41, mode},
+          {epochIndex: 1, confidence: 0.57, mode},
+        ],
+        metadata: {
+          peakEpoch: 1,
+          rollingAverage3: null,
+          defaultMode: 'power' as const,
+        },
+      };
+    },
+    async readEpochGeometry(sessionId, epochIndex, mode) {
+      if (sessionId === 'missing') {
+        throw new K3h4VizServiceError(
+            'session_not_found', `Session '${sessionId}' not found.`, 404);
+      }
+      if (epochIndex === 99) {
+        throw new K3h4VizServiceError(
+            'artifact_not_found', `Epoch ${epochIndex} not found.`, 404);
+      }
+      if (epochIndex === 42) {
+        throw new K3h4VizServiceError(
+            'artifact_incomplete', 'Artifact truncated.', 422);
+      }
+      return {...CANONICAL_GEOMETRY, sessionId, epoch: epochIndex, mode};
+    },
+  });
+
+  test('creates a training session with default power mode', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/netcode/k3h4/training-session',
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({
+      sessionId: 'sess-abc123',
+      mode: 'power',
+    });
+
+    await app.close();
+  });
+
+  test('rejects invalid training mode for session creation', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/netcode/k3h4/training-session',
+      payload: {mode: 'invalid'},
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({error: 'invalid_mode'});
+
+    await app.close();
+  });
+
+  test('returns confidence time-series for a session', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url:
+          '/api/netcode/k3h4/training-session/sess-abc123/confidence?mode=multiplicative',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      contractVersion: 1,
+      sessionId: 'sess-abc123',
+      mode: 'multiplicative',
+      status: 'active',
+      epochs: [
+        {epochIndex: 0, confidence: 0.41, mode: 'multiplicative'},
+        {epochIndex: 1, confidence: 0.57, mode: 'multiplicative'},
+      ],
+      metadata: {
+        peakEpoch: 1,
+      },
+    });
+
+    await app.close();
+  });
+
+  test('maps training service errors on confidence endpoint', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/netcode/k3h4/training-session/missing/confidence',
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({error: 'session_not_found'});
+
+    await app.close();
+  });
+
+  test('returns epoch geometry with PCA projection metadata', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url:
+          '/api/netcode/k3h4/training-session/sess-abc123/epoch/0/geometry?mode=power',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toMatchObject({
+      contractVersion: 1,
+      sessionId: 'sess-abc123',
+      epoch: 0,
+      mode: 'power',
+    });
+    expect(Array.isArray(body.clusters)).toBe(true);
+    expect(body.clusters.length).toBeGreaterThan(0);
+    expect(body.clusters[0]).toMatchObject({
+      clusterId: 0,
+      centroid: expect.objectContaining(
+          {x: expect.any(Number), y: expect.any(Number)}),
+      inscribedRadius: expect.any(Number),
+      weightedScore: expect.any(Number),
+    });
+    expect(Array.isArray(body.clusters[0].polygon)).toBe(true);
+    expect(body.clusters[0].polygon.length).toBe(8);
+    expect(body.projectionMetadata).toMatchObject({
+      method: 'pca',
+      components: 2,
+      explainedVariance: expect.any(Number),
+      dimensionality: expect.any(Number),
+    });
+    expect(Array.isArray(body.tokens)).toBe(true);
+
+    await app.close();
+  });
+
+  test('defaults geometry mode to power when omitted', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/netcode/k3h4/training-session/sess-abc123/epoch/0/geometry',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({mode: 'power'});
+
+    await app.close();
+  });
+
+  test('rejects invalid mode on geometry endpoint', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url:
+          '/api/netcode/k3h4/training-session/sess-abc123/epoch/0/geometry?mode=badmode',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({error: 'invalid_mode'});
+
+    await app.close();
+  });
+
+  test('rejects non-integer epoch index on geometry endpoint', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/netcode/k3h4/training-session/sess-abc123/epoch/foo/geometry',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({error: 'invalid_epoch'});
+
+    await app.close();
+  });
+
+  test('maps session_not_found error from geometry endpoint', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/netcode/k3h4/training-session/missing/epoch/0/geometry',
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({error: 'session_not_found'});
+
+    await app.close();
+  });
+
+  test('maps artifact_not_found error from geometry endpoint', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/netcode/k3h4/training-session/sess-abc123/epoch/99/geometry',
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({error: 'artifact_not_found'});
+
+    await app.close();
+  });
+
+  test('maps artifact_incomplete error from geometry endpoint', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/netcode/k3h4/training-session/sess-abc123/epoch/42/geometry',
+    });
+
+    expect(response.statusCode).toBe(422);
+    expect(response.json()).toMatchObject({error: 'artifact_incomplete'});
+
+    await app.close();
+  });
+});

--- a/src/typescript/api/src/routes/netcode.ts
+++ b/src/typescript/api/src/routes/netcode.ts
@@ -3,6 +3,7 @@ import type {FastifyInstance, FastifyReply} from 'fastify';
 import {createK3h4ApplicationOrchestrationLayer, type K3h4ApplicationOrchestrationLayer,} from '../services/k3h4ApplicationOrchestrationLayer.ts';
 import {loadK3h4ScalingBenchmark} from '../services/k3h4ScalingBenchmark.ts';
 import type {K3h4ScalingBenchmarkStatus} from '../services/k3h4ScalingBenchmark.ts';
+import {createFileSystemK3h4TrainingService, type K3h4TrainingService, K3h4VizServiceError, type TrainingSessionMode,} from '../services/k3h4TrainingService.ts';
 import {getNativeNetcodeService, type NativeNetcodeService,} from '../services/nativeNetcode.ts';
 import {createNetcodeAnalyticsAuthoritativeComputeOrchestrator, type NetcodeAnalyticsAuthoritativeComputeOrchestrator, NetcodeAnalyticsOrchestrationError, type NetcodeK3h4Rollout,} from '../services/netcodeAuthoritativeComputeOrchestrator.ts';
 
@@ -15,6 +16,7 @@ type NetcodeRouteOptions = {
 
 type NetcodeRouteOptionsExtended = NetcodeRouteOptions&{
   scalingBenchmarkLoader?: () => K3h4ScalingBenchmarkStatus;
+  k3h4TrainingService?: K3h4TrainingService;
 };
 
 function isFiniteNumber(value: unknown): value is number {
@@ -37,6 +39,16 @@ function isValidK3h4Mode(value: unknown): value is 'multiplicative'|'power' {
 function isValidSpectralMode(value: unknown): value is
     'disabled'|'affinity-graph' {
   return value === 'disabled' || value === 'affinity-graph';
+}
+
+function parseTrainingMode(rawMode: unknown): TrainingSessionMode|null {
+  if (rawMode === undefined || rawMode === null || rawMode === '') {
+    return 'power';
+  }
+  if (rawMode === 'multiplicative' || rawMode === 'power') {
+    return rawMode;
+  }
+  return null;
 }
 
 function resolveNetcodeK3h4Rollout(): NetcodeK3h4Rollout {
@@ -117,6 +129,8 @@ export async function registerNetcodeRoutes(
 
   const benchmarkLoader =
       options.scalingBenchmarkLoader ?? loadK3h4ScalingBenchmark;
+  const trainingService =
+      options.k3h4TrainingService ?? createFileSystemK3h4TrainingService();
 
   type OrchestratedNetcodeResult =
       Awaited<ReturnType<K3h4ApplicationOrchestrationLayer['compute']>>;
@@ -376,4 +390,84 @@ export async function registerNetcodeRoutes(
     }
     return status.result;
   });
+
+  app.post<{Body: {mode?: TrainingSessionMode}}>(
+      '/api/netcode/k3h4/training-session', async (request, reply) => {
+        const mode = parseTrainingMode(request.body?.mode);
+        if (!mode) {
+          return reply.status(400).send({
+            error: 'invalid_mode',
+            message:
+                'mode must be either multiplicative or power when provided.',
+          });
+        }
+
+        const session = await trainingService.createTrainingSession(mode);
+        return reply.status(201).send(session);
+      });
+
+  app.get<{Params: {id: string}; Querystring: {mode?: string}}>(
+      '/api/netcode/k3h4/training-session/:id/confidence',
+      async (request, reply) => {
+        const mode = parseTrainingMode(request.query.mode);
+        if (!mode) {
+          return reply.status(400).send({
+            error: 'invalid_mode',
+            message:
+                'mode must be either multiplicative or power when provided.',
+          });
+        }
+
+        try {
+          const confidence = await trainingService.readConfidenceTimeSeries(
+              request.params.id, mode);
+          return reply.send(confidence);
+        } catch (error) {
+          if (error instanceof K3h4VizServiceError) {
+            return reply.status(error.statusCode).send({
+              error: error.code,
+              message: error.message,
+            });
+          }
+          throw error;
+        }
+      },
+  );
+
+  app.get<{Params: {id: string; n: string}; Querystring: {mode?: string}}>(
+      '/api/netcode/k3h4/training-session/:id/epoch/:n/geometry',
+      async (request, reply) => {
+        const mode = parseTrainingMode(request.query.mode);
+        if (!mode) {
+          return reply.status(400).send({
+            error: 'invalid_mode',
+            message:
+                'mode must be either multiplicative or power when provided.',
+          });
+        }
+
+        const epochIndex = Number(request.params.n);
+        if (!Number.isInteger(epochIndex) || epochIndex < 0 ||
+            !Number.isFinite(epochIndex)) {
+          return reply.status(400).send({
+            error: 'invalid_epoch',
+            message: 'Epoch index must be a non-negative integer.',
+          });
+        }
+
+        try {
+          const geometry = await trainingService.readEpochGeometry(
+              request.params.id, epochIndex, mode);
+          return reply.send(geometry);
+        } catch (error) {
+          if (error instanceof K3h4VizServiceError) {
+            return reply.status(error.statusCode).send({
+              error: error.code,
+              message: error.message,
+            });
+          }
+          throw error;
+        }
+      },
+  );
 }

--- a/src/typescript/api/src/services/k3h4TrainingService.ts
+++ b/src/typescript/api/src/services/k3h4TrainingService.ts
@@ -1,0 +1,570 @@
+import nodeFs from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export type TrainingSessionMode = 'multiplicative'|'power';
+
+export type SessionStatus = 'pending'|'active'|'completed';
+
+export type TrainingSession = {
+  readonly sessionId: string; readonly mode: TrainingSessionMode; readonly createdAtUtc:
+                                                                               string;
+};
+
+export type EpochConfidence = {
+  readonly epochIndex: number; readonly confidence: number; readonly mode:
+                                                                         TrainingSessionMode;
+};
+
+export type ConfidenceTimeSeries = {
+  readonly contractVersion: 1; readonly sessionId: string; readonly status: SessionStatus; readonly mode: TrainingSessionMode; readonly epochs: readonly EpochConfidence[]; readonly metadata: {
+    readonly peakEpoch: number | null; readonly rollingAverage3: number | null; readonly defaultMode:
+                                                                                             'power';
+  };
+};
+
+export class K3h4VizServiceError extends Error {
+  public readonly code: string;
+  public readonly statusCode: number;
+
+  constructor(code: string, message: string, statusCode: number) {
+    super(message);
+    this.name = 'K3h4VizServiceError';
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+export type Point2d = {
+  readonly x: number; readonly y: number
+};
+
+export type ClusterGeometry2d = {
+  readonly clusterId: number; readonly centroid: Point2d; readonly inscribedRadius: number; readonly weightedScore: number; readonly spectralProxy: number; readonly polygon: ReadonlyArray<
+                                                                                                                                                                         Point2d>;
+};
+
+export type TokenGeometry2d = {
+  readonly tokenId: string; readonly x: number; readonly y: number; readonly clusterId: number; readonly weightedScore:
+                                                                                                             number;
+};
+
+export type ProjectionMetadata = {
+  readonly method: 'pca'; readonly components: 2; readonly explainedVariance: number; readonly dimensionality:
+                                                                                                   number;
+};
+
+export type EpochGeometry = {
+  readonly contractVersion: 1; readonly sessionId: string; readonly epoch: number; readonly mode: TrainingSessionMode; readonly spectralActive: boolean; readonly clusters: ReadonlyArray<ClusterGeometry2d>; readonly tokens: ReadonlyArray<TokenGeometry2d>; readonly projectionMetadata:
+                                                                                                                                                                                                                                                                            ProjectionMetadata;
+};
+
+export interface K3h4TrainingService {
+  createTrainingSession(mode: TrainingSessionMode): Promise<TrainingSession>;
+  readConfidenceTimeSeries(sessionId: string, mode: TrainingSessionMode):
+      Promise<ConfidenceTimeSeries>;
+  readEpochGeometry(
+      sessionId: string, epochIndex: number,
+      mode: TrainingSessionMode): Promise<EpochGeometry>;
+}
+
+const ARTIFACT_RELATIVE_PATH =
+    path.join('artifacts', 'native', 'k3h4-training');
+const TRAINING_ARTIFACT_MAGIC = 0x01;
+const TRAINING_ARTIFACT_VERSION = 1;
+const INTEGRITY_MARKER = 0xDEADBEEF;
+
+const SEARCH_ROOTS = [
+  process.cwd(),
+  path.resolve(process.cwd(), '..'),
+  path.resolve(process.cwd(), '../..'),
+  path.resolve(process.cwd(), '../../..'),
+  '/workspace',
+];
+
+function resolveTrainingArtifactRoot(): string {
+  for (const root of SEARCH_ROOTS) {
+    const candidate = path.join(root, ARTIFACT_RELATIVE_PATH);
+    if (nodeFs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return path.join(process.cwd(), ARTIFACT_RELATIVE_PATH);
+}
+
+function validateSessionId(sessionId: string): void {
+  if (!/^[A-Za-z0-9_-]{1,15}$/.test(sessionId)) {
+    throw new K3h4VizServiceError(
+        'invalid_session_id',
+        'Session ID must be 1-15 characters using letters, digits, hyphen, or underscore.',
+        400,
+    );
+  }
+}
+
+function createSessionId(): string {
+  const suffix = Math.floor(Math.random() * 100000).toString().padStart(5, '0');
+  return `s${Date.now().toString(36).slice(-6)}${suffix.slice(0, 2)}`;
+}
+
+function readInt32LE(buffer: Buffer, offset: number): number {
+  return buffer.readInt32LE(offset);
+}
+
+function readUInt32LE(buffer: Buffer, offset: number): number {
+  return buffer.readUInt32LE(offset);
+}
+
+function decodeArtifactConfidence(
+    buffer: Buffer, mode: TrainingSessionMode): number {
+  if (buffer.length < 51) {
+    throw new K3h4VizServiceError(
+        'artifact_incomplete', 'Training artifact is truncated.', 422);
+  }
+
+  const magic = buffer.readUInt8(0);
+  const version = buffer.readUInt16LE(1);
+  const clusterCount = readInt32LE(buffer, 35);
+  const dimension = readInt32LE(buffer, 39);
+
+  if (magic !== TRAINING_ARTIFACT_MAGIC ||
+      version !== TRAINING_ARTIFACT_VERSION) {
+    throw new K3h4VizServiceError(
+        'version_unsupported', 'Unsupported training artifact version.', 422);
+  }
+
+  if (clusterCount < 1 || dimension < 1) {
+    throw new K3h4VizServiceError(
+        'artifact_incomplete', 'Training artifact has invalid dimensions.',
+        422);
+  }
+
+  const clusterRecordBytes = dimension * 4 + 16;
+  const trailerOffset = 43 + clusterRecordBytes * clusterCount;
+  const crcOffset = trailerOffset + 4;
+
+  if (buffer.length < crcOffset + 4) {
+    throw new K3h4VizServiceError(
+        'artifact_incomplete', 'Training artifact trailer is missing.', 422);
+  }
+
+  const marker = readUInt32LE(buffer, trailerOffset);
+  if (marker !== INTEGRITY_MARKER) {
+    throw new K3h4VizServiceError(
+        'artifact_incomplete', 'Training artifact integrity marker missing.',
+        422);
+  }
+
+  const scoreOffsetWithinCluster =
+      dimension * 4 + 4 + (mode === 'power' ? 4 : 0);
+
+  let sum = 0;
+  for (let cluster = 0; cluster < clusterCount; cluster += 1) {
+    const clusterBase = 43 + cluster * clusterRecordBytes;
+    const scoreQ16 =
+        readInt32LE(buffer, clusterBase + scoreOffsetWithinCluster);
+    sum += scoreQ16 / 65536;
+  }
+
+  return sum / clusterCount;
+}
+
+function computeRollingAverage3(values: readonly number[]): number|null {
+  if (values.length < 3) return null;
+  const slice = values.slice(values.length - 3);
+  return Number((slice[0] + slice[1] + slice[2]) / 3);
+}
+
+/** Build a regular octagon centred at (cx, cy) with the given radius. */
+function octagonPolygon(cx: number, cy: number, r: number): Point2d[] {
+  return Array.from({length: 8}, (_, i) => {
+    const angle = (i / 8) * Math.PI * 2;
+    return {x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle)};
+  });
+}
+
+/**
+ * Minimal 2-component PCA via power iteration.
+ *
+ * Works for small d (≤ 16) and small n (≤ 4 clusters). Returns the
+ * 2D projections of each point plus the explained-variance ratio of the
+ * first two principal components.
+ */
+function pca2d(points: readonly(readonly number[])[]): {
+  projected: Array<Point2d>; explainedVariance: number; dimensionality: number;
+} {
+  const n = points.length;
+  const d = n > 0 ? points[0].length : 0;
+  const dimensionality = d;
+
+  if (n === 0 || d === 0) {
+    return {projected: [], explainedVariance: 1, dimensionality};
+  }
+  if (d === 1) {
+    return {
+      projected: points.map(p => ({x: p[0] ?? 0, y: 0})),
+      explainedVariance: 1,
+      dimensionality,
+    };
+  }
+
+  // Compute mean then centre.
+  const mean = Array.from(
+      {length: d}, (_, j) => points.reduce((s, p) => s + (p[j] ?? 0), 0) / n);
+  const centred = points.map(
+      p => Array.from({length: d}, (_, j) => (p[j] ?? 0) - (mean[j] ?? 0)));
+
+  // d×d covariance matrix.
+  const cov: number[][] = Array.from(
+      {length: d},
+      (_, i) => Array.from(
+          {length: d},
+          (_, j) => centred.reduce((s, p) => s + (p[i] ?? 0) * (p[j] ?? 0), 0) /
+              Math.max(n - 1, 1),
+          ),
+  );
+
+  // Power iteration to find the top eigenvector, then deflate for the second.
+  function powerIter(
+      matrix: number[][], dim: number, deflate?: readonly number[]): number[] {
+    let v: number[] = Array.from({length: dim}, (_, i) => i === 0 ? 1 : 0);
+    for (let iter = 0; iter < 120; iter++) {
+      let w = Array.from(
+          {length: dim},
+          (_, i) =>
+              (matrix[i] ?? []).reduce((s, mij, j) => s + mij * (v[j] ?? 0), 0),
+      );
+      if (deflate) {
+        const proj = w.reduce((s, wi, i) => s + wi * (deflate[i] ?? 0), 0);
+        w = w.map((wi, i) => wi - proj * (deflate[i] ?? 0));
+      }
+      const norm = Math.sqrt(w.reduce((s, wi) => s + wi * wi, 0));
+      if (norm < 1e-12) break;
+      v = w.map(wi => wi / norm);
+    }
+    return v;
+  }
+
+  const pc1 = powerIter(cov, d);
+  const pc2 = powerIter(cov, d, pc1);
+
+  // Variance captured by each PC.
+  const varOf = (pc: readonly number[]) => centred.reduce((s, p) => {
+    const proj = p.reduce((sum, pi, i) => sum + pi * (pc[i] ?? 0), 0);
+    return s + proj * proj;
+  }, 0) / Math.max(n - 1, 1);
+
+  const totalVar = cov.reduce((s, row, i) => s + (row[i] ?? 0), 0);
+  const capturedVar = varOf(pc1) + varOf(pc2);
+  const explainedVariance = totalVar > 1e-12 ? capturedVar / totalVar : 1;
+
+  const projected =
+      centred.map(p => ({
+                    x: p.reduce((s, pi, i) => s + pi * (pc1[i] ?? 0), 0),
+                    y: p.reduce((s, pi, i) => s + pi * (pc2[i] ?? 0), 0),
+                  }));
+
+  return {
+    projected,
+    explainedVariance: Math.min(1, Math.max(0, explainedVariance)),
+    dimensionality
+  };
+}
+
+/**
+ * Decode a training artifact binary into an EpochGeometry response.
+ *
+ * Binary layout (from native-k3h4-export-abi.md):
+ *   Offset  0: artifact_type (uint8)
+ *   Offset  1: contract_version (uint16 LE)
+ *   Offset  3: byte_order_tag (uint32 LE)
+ *   Offset  7: session_id (char[16])
+ *   Offset 23: epoch_index (int32 LE)
+ *   Offset 27: mode_flag (int32 LE)
+ *   Offset 31: spectral_active (int32 LE)
+ *   Offset 35: cluster_count (int32 LE)
+ *   Offset 39: dimension (int32 LE)
+ *   Offset 43: clusters[] — cluster_count × (d*4 + 16) bytes
+ *     Per cluster: center[d] float32, inscribed_radius float32,
+ *                  multiplicative_score int32 Q16, power_score int32 Q16,
+ *                  spectral_proxy int32 Q16
+ *   Trailer: integrity_marker (uint32), crc32 (uint32)
+ */
+function decodeArtifactGeometry(
+    buffer: Buffer,
+    sessionId: string,
+    epochIndex: number,
+    mode: TrainingSessionMode,
+    ): EpochGeometry {
+  if (buffer.length < 51) {
+    throw new K3h4VizServiceError(
+        'artifact_incomplete', 'Training artifact is truncated.', 422);
+  }
+
+  const magic = buffer.readUInt8(0);
+  const version = buffer.readUInt16LE(1);
+
+  if (magic !== TRAINING_ARTIFACT_MAGIC ||
+      version !== TRAINING_ARTIFACT_VERSION) {
+    throw new K3h4VizServiceError(
+        'version_unsupported', 'Unsupported training artifact version.', 422);
+  }
+
+  const clusterCount = readInt32LE(buffer, 35);
+  const dimension = readInt32LE(buffer, 39);
+  const modeFlagRaw = readInt32LE(buffer, 27);
+  const spectralActiveRaw = readInt32LE(buffer, 31);
+
+  if (clusterCount < 1 || clusterCount > 16 || dimension < 1 ||
+      dimension > 16) {
+    throw new K3h4VizServiceError(
+        'artifact_incomplete',
+        'Training artifact has invalid cluster/dimension counts.', 422);
+  }
+
+  const clusterRecordBytes = dimension * 4 + 16;
+  const trailerOffset = 43 + clusterRecordBytes * clusterCount;
+
+  if (buffer.length < trailerOffset + 8) {
+    throw new K3h4VizServiceError(
+        'artifact_incomplete', 'Training artifact trailer is missing.', 422);
+  }
+
+  const marker = readUInt32LE(buffer, trailerOffset);
+  if (marker !== INTEGRITY_MARKER) {
+    throw new K3h4VizServiceError(
+        'artifact_incomplete',
+        'Training artifact integrity marker is absent or corrupt.', 422);
+  }
+
+  // Decode cluster centers (float32) and scores.
+  const centersRaw: number[][] = [];
+  const inscribedRadii: number[] = [];
+  const weightedScores: number[] = [];
+  const spectralProxies: number[] = [];
+
+  for (let c = 0; c < clusterCount; c++) {
+    const base = 43 + c * clusterRecordBytes;
+    const center: number[] = [];
+    for (let dim = 0; dim < dimension; dim++) {
+      center.push(buffer.readFloatLE(base + dim * 4));
+    }
+    centersRaw.push(center);
+    inscribedRadii.push(buffer.readFloatLE(base + dimension * 4));
+
+    const multScore = readInt32LE(buffer, base + dimension * 4 + 4);
+    const powScore = readInt32LE(buffer, base + dimension * 4 + 8);
+    const specProxy = readInt32LE(buffer, base + dimension * 4 + 12);
+
+    weightedScores.push((mode === 'power' ? powScore : multScore) / 65536);
+    spectralProxies.push(specProxy / 65536);
+  }
+
+  // Project to 2D via PCA.
+  const {projected, explainedVariance, dimensionality} = pca2d(centersRaw);
+
+  // Build cluster geometry (polygon = octagon at inscribed radius).
+  const clusters: ClusterGeometry2d[] = centersRaw.map((_, i) => {
+    const pt = projected[i] ?? {x: 0, y: 0};
+    const r = inscribedRadii[i] ?? 0;
+    return {
+      clusterId: i,
+      centroid: pt,
+      inscribedRadius: r,
+      weightedScore: weightedScores[i] ?? 0,
+      spectralProxy: spectralProxies[i] ?? 0,
+      polygon: octagonPolygon(pt.x, pt.y, r),
+    };
+  });
+
+  // One representative token per cluster (artifact stores cluster summaries,
+  // not per-vector positions).
+  const tokens: TokenGeometry2d[] =
+      clusters.map(cl => ({
+                     tokenId: `cluster-${cl.clusterId}`,
+                     x: cl.centroid.x,
+                     y: cl.centroid.y,
+                     clusterId: cl.clusterId,
+                     weightedScore: cl.weightedScore,
+                   }));
+
+  // Artifact mode_flag: 0 = multiplicative, 1 = power. Use caller mode for
+  // response since the caller selects which score to surface.
+  const artifactMode: TrainingSessionMode =
+      modeFlagRaw === 1 ? 'power' : 'multiplicative';
+  void artifactMode;  // recorded above for future ABI cross-check
+
+  return {
+    contractVersion: 1,
+    sessionId,
+    epoch: epochIndex,
+    mode,
+    spectralActive: spectralActiveRaw !== 0,
+    clusters,
+    tokens,
+    projectionMetadata: {
+      method: 'pca',
+      components: 2,
+      explainedVariance,
+      dimensionality,
+    },
+  };
+}
+
+export function createFileSystemK3h4TrainingService(): K3h4TrainingService {
+  const artifactRoot = resolveTrainingArtifactRoot();
+
+  return {
+    async createTrainingSession(mode: TrainingSessionMode):
+        Promise<TrainingSession> {
+          const createdAtUtc = new Date().toISOString();
+          const sessionId = createSessionId();
+          const sessionDir = path.join(artifactRoot, sessionId);
+
+          await fs.mkdir(sessionDir, {recursive: true});
+          await fs.writeFile(
+              path.join(sessionDir, 'session.json'),
+              JSON.stringify({sessionId, mode, createdAtUtc}, null, 2),
+              'utf8',
+          );
+
+          return {sessionId, mode, createdAtUtc};
+        },
+
+    async readConfidenceTimeSeries(
+        sessionId: string,
+        mode: TrainingSessionMode,
+        ): Promise<ConfidenceTimeSeries> {
+      validateSessionId(sessionId);
+      const sessionDir = path.join(artifactRoot, sessionId);
+
+      let entries: string[];
+      try {
+        entries = await fs.readdir(sessionDir);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new K3h4VizServiceError(
+              'session_not_found',
+              `Training session '${sessionId}' was not found.`, 404);
+        }
+        throw new K3h4VizServiceError(
+            'training_unavailable',
+            `Failed to list training session artifacts: ${
+                error instanceof Error ? error.message : String(error)}`,
+            503,
+        );
+      }
+
+      const epochFiles = entries
+                             .map((entry) => {
+                               const match = /^epoch-(\d+)\.bin$/.exec(entry);
+                               if (!match) return null;
+                               return {
+                                 epochIndex: Number(match[1]),
+                                 fileName: entry,
+                               };
+                             })
+                             .filter(
+                                 (entry):
+                                     entry is {
+                                       epochIndex: number;
+                                       fileName: string;
+                                     } => entry !== null)
+                             .sort((a, b) => a.epochIndex - b.epochIndex);
+
+      const epochs: EpochConfidence[] = [];
+
+      for (const epoch of epochFiles) {
+        const artifactPath = path.join(sessionDir, epoch.fileName);
+        try {
+          const artifact = Buffer.from(await fs.readFile(artifactPath));
+          const confidence = decodeArtifactConfidence(artifact, mode);
+          epochs.push({
+            epochIndex: epoch.epochIndex,
+            confidence,
+            mode,
+          });
+        } catch (error) {
+          if (error instanceof K3h4VizServiceError &&
+              error.code === 'artifact_incomplete') {
+            // Partial artifacts are omitted from the confidence series.
+            continue;
+          }
+          throw error;
+        }
+      }
+
+      const status: SessionStatus = epochs.length === 0 ? 'pending' : 'active';
+      const confidences = epochs.map((epoch) => epoch.confidence);
+      const peakEpoch = epochs.length === 0 ?
+          null :
+          epochs
+              .reduce(
+                  (best, current) =>
+                      current.confidence > best.confidence ? current : best)
+              .epochIndex;
+
+      return {
+        contractVersion: 1,
+        sessionId,
+        status,
+        mode,
+        epochs,
+        metadata: {
+          peakEpoch,
+          rollingAverage3: computeRollingAverage3(confidences),
+          defaultMode: 'power',
+        },
+      };
+    },
+
+    async readEpochGeometry(
+        sessionId: string,
+        epochIndex: number,
+        mode: TrainingSessionMode,
+        ): Promise<EpochGeometry> {
+      validateSessionId(sessionId);
+      if (!Number.isInteger(epochIndex) || epochIndex < 0) {
+        throw new K3h4VizServiceError(
+            'invalid_epoch', 'Epoch index must be a non-negative integer.',
+            400);
+      }
+
+      const sessionDir = path.join(artifactRoot, sessionId);
+      const artifactPath = path.join(sessionDir, `epoch-${epochIndex}.bin`);
+
+      let rawBuffer: Buffer;
+      try {
+        rawBuffer = Buffer.from(await fs.readFile(artifactPath));
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === 'ENOENT') {
+          // Check whether the session directory itself exists to distinguish
+          // "session not found" from "epoch not yet written".
+          try {
+            await fs.access(sessionDir);
+          } catch {
+            throw new K3h4VizServiceError(
+                'session_not_found',
+                `Training session '${sessionId}' was not found.`, 404);
+          }
+          throw new K3h4VizServiceError(
+              'artifact_not_found',
+              `Epoch ${epochIndex} artifact not found for session '${
+                  sessionId}'.`,
+              404,
+          );
+        }
+        throw new K3h4VizServiceError(
+            'training_unavailable',
+            `Failed to read epoch artifact: ${
+                error instanceof Error ? error.message : String(error)}`,
+            503,
+        );
+      }
+
+      return decodeArtifactGeometry(rawBuffer, sessionId, epochIndex, mode);
+    },
+  };
+}

--- a/src/typescript/react/src/domain/notebook/viz/NotebookTrainingPanel.tsx
+++ b/src/typescript/react/src/domain/notebook/viz/NotebookTrainingPanel.tsx
@@ -1,0 +1,525 @@
+import { RoutePill as Pill } from '@banana/ui';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import type { K3h4TrainingMode } from '../../../lib/api';
+import type { K3h4ClusterGeometry2d } from '../../../lib/k3h4GeometryTypes';
+import { useK3h4TrainingSession } from './useK3h4TrainingSession';
+
+// ---------------------------------------------------------------------------
+// Small inline primitives (no new dependency)
+// ---------------------------------------------------------------------------
+
+const CARD_STYLE: React.CSSProperties = {
+    borderRadius: 10,
+    border: '1px solid rgba(45, 212, 191, 0.24)',
+    background: 'rgba(3, 14, 25, 0.32)',
+    padding: 12,
+    display: 'grid',
+    gap: 8,
+};
+
+const SECTION_LABEL: React.CSSProperties = {
+    fontSize: 11,
+    letterSpacing: '0.06em',
+    textTransform: 'uppercase',
+    color: '#67e8f9',
+};
+
+const MUTED: React.CSSProperties = { fontSize: 12, color: '#94a3b8' };
+
+const ERROR_TEXT: React.CSSProperties = { fontSize: 12, color: '#fda4af' };
+
+function Btn({
+    onClick,
+    disabled,
+    children,
+    variant = 'default',
+}: {
+    onClick: () => void;
+    disabled?: boolean;
+    children: React.ReactNode;
+    variant?: 'default' | 'danger';
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            style={{
+                borderRadius: 8,
+                border: `1px solid ${variant === 'danger' ? 'rgba(244, 63, 94, 0.4)' : 'rgba(45, 212, 191, 0.4)'}`,
+                background: variant === 'danger' ? 'rgba(15, 23, 42, 0.55)' : 'rgba(3, 14, 25, 0.55)',
+                color: variant === 'danger' ? '#fda4af' : '#a7f3d0',
+                padding: '6px 14px',
+                cursor: disabled ? 'not-allowed' : 'pointer',
+                fontSize: 11,
+                letterSpacing: '0.04em',
+                opacity: disabled ? 0.5 : 1,
+                transition: 'opacity 0.15s',
+            }}
+        >
+            {children}
+        </button>
+    );
+}
+
+function ModeSelector({
+    value,
+    onChange,
+    disabled,
+}: {
+    value: K3h4TrainingMode;
+    onChange: (m: K3h4TrainingMode) => void;
+    disabled?: boolean;
+}) {
+    return (
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            {(['power', 'multiplicative'] as K3h4TrainingMode[]).map((m) => (
+                <button
+                    key={m}
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => onChange(m)}
+                    style={{
+                        borderRadius: 8,
+                        border: `1px solid ${value === m ? 'rgba(45, 212, 191, 0.55)' : 'rgba(148, 163, 184, 0.25)'}`,
+                        background: value === m ? 'rgba(45, 212, 191, 0.12)' : 'rgba(15, 23, 42, 0.4)',
+                        color: value === m ? '#a7f3d0' : '#64748b',
+                        padding: '4px 10px',
+                        cursor: disabled ? 'not-allowed' : 'pointer',
+                        fontSize: 11,
+                        opacity: disabled ? 0.5 : 1,
+                    }}
+                >
+                    {m}
+                </button>
+            ))}
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Confidence chart (sparkline via SVG — no charting library)
+// ---------------------------------------------------------------------------
+
+function ConfidenceSparkline({
+    values,
+    width = 340,
+    height = 80,
+}: {
+    values: readonly number[];
+    width?: number;
+    height?: number;
+}) {
+    const points = useMemo(() => {
+        if (values.length < 2) return null;
+        const minV = Math.min(...values);
+        const maxV = Math.max(...values);
+        const range = maxV - minV || 1;
+        return values.map((v, i) => {
+            const x = (i / (values.length - 1)) * (width - 20) + 10;
+            const y = height - 10 - ((v - minV) / range) * (height - 20);
+            return { x, y, v };
+        });
+    }, [values, width, height]);
+
+    if (!points) {
+        return (
+            <div style={{ ...MUTED, textAlign: 'center', paddingTop: 8 }}>
+                Waiting for first epoch…
+            </div>
+        );
+    }
+
+    const pathD = points
+        .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`)
+        .join(' ');
+
+    const peakPt = points.reduce((best, p) => (p.v > best.v ? p : best));
+    const lastPt = points[points.length - 1]!;
+
+    return (
+        <svg width={width} height={height} style={{ overflow: 'visible' }}>
+            <defs>
+                <linearGradient id="conf-grad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#2dd4bf" stopOpacity="0.3" />
+                    <stop offset="100%" stopColor="#2dd4bf" stopOpacity="0" />
+                </linearGradient>
+            </defs>
+            {/* area fill */}
+            <path
+                d={`${pathD} L ${lastPt.x.toFixed(1)} ${height - 10} L ${points[0]!.x.toFixed(1)} ${height - 10} Z`}
+                fill="url(#conf-grad)"
+            />
+            {/* line */}
+            <path d={pathD} fill="none" stroke="#2dd4bf" strokeWidth={1.5} strokeLinejoin="round" />
+            {/* peak dot */}
+            <circle cx={peakPt.x} cy={peakPt.y} r={3} fill="#a7f3d0" />
+            <text x={peakPt.x + 5} y={peakPt.y - 4} fill="#a7f3d0" fontSize={9}>
+                peak {peakPt.v.toFixed(3)}
+            </text>
+            {/* latest dot */}
+            <circle cx={lastPt.x} cy={lastPt.y} r={3} fill="#67e8f9" />
+        </svg>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
+
+export function NotebookTrainingPanel() {
+    const {
+        phase,
+        session,
+        confidence,
+        latestGeometry,
+        errorMessage,
+        workflowState,
+        workflowLogs,
+        startSession,
+        runWorkflow,
+        stopWorkflow,
+        clearWorkflowLogs,
+        clearSession,
+    } = useK3h4TrainingSession();
+
+    const [pendingMode, setPendingMode] = useState<K3h4TrainingMode>('power');
+
+    const isActive = phase === 'active';
+    const isCreating = phase === 'creating';
+
+    const confidenceValues = confidence?.epochs.map((e) => e.confidence) ?? [];
+    const rollingAvg = confidence?.metadata.rollingAverage3;
+    const peakEpoch = confidence?.metadata.peakEpoch;
+    const sessionStatus = confidence?.status ?? (session ? 'pending' : null);
+    const workflowBusy = workflowState.status === 'running';
+    const workflowProgressPct =
+        workflowState.totalPasses > 0 ?
+            Math.round((workflowState.completedPasses / workflowState.totalPasses) * 100) :
+            0;
+    const geometryClusters = (latestGeometry?.clusters ?? []) as readonly K3h4ClusterGeometry2d[];
+    const workflowLogViewportRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (!workflowLogViewportRef.current) {
+            return;
+        }
+        workflowLogViewportRef.current.scrollTop = workflowLogViewportRef.current.scrollHeight;
+    }, [workflowLogs]);
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: 10, overflow: 'auto' }}>
+
+            {/* ── Session header ─────────────────────────────────────────────── */}
+            <div style={CARD_STYLE}>
+                <div style={SECTION_LABEL}>Training Session</div>
+
+                {!session ? (
+                    <>
+                        <div style={MUTED}>
+                            Start a shared training session. Sessions persist in the browser
+                            and are visible to all researchers (no auth required).
+                        </div>
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                            <div style={{ ...MUTED, fontSize: 11 }}>Scoring mode</div>
+                            <ModeSelector
+                                value={pendingMode}
+                                onChange={setPendingMode}
+                                disabled={isCreating}
+                            />
+                            <Btn
+                                onClick={() => startSession(pendingMode)}
+                                disabled={isCreating}
+                            >
+                                {isCreating ? 'Creating…' : 'Start Training Session'}
+                            </Btn>
+                        </div>
+                    </>
+                ) : (
+                    <div style={{ display: 'grid', gap: 8 }}>
+                        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                            <Pill color="#a7f3d0" borderColor="rgba(16, 185, 129, 0.28)">
+                                Session {session.sessionId}
+                            </Pill>
+                            <Pill color="#bae6fd" borderColor="rgba(56, 189, 248, 0.3)">
+                                Mode: {session.mode}
+                            </Pill>
+                            {sessionStatus ? (
+                                <Pill
+                                    color={sessionStatus === 'completed' ? '#86efac' : sessionStatus === 'active' ? '#a7f3d0' : '#e9d5ff'}
+                                    borderColor={sessionStatus === 'completed' ? 'rgba(34, 197, 94, 0.28)' : 'rgba(168, 85, 247, 0.26)'}
+                                >
+                                    {sessionStatus}
+                                </Pill>
+                            ) : null}
+                            {confidence ? (
+                                <Pill color="#bae6fd" borderColor="rgba(56, 189, 248, 0.3)">
+                                    {confidence.epochs.length} epoch{confidence.epochs.length !== 1 ? 's' : ''}
+                                </Pill>
+                            ) : null}
+                        </div>
+                        <div style={{ ...MUTED, fontSize: 10 }}>
+                            Created {new Date(session.createdAtUtc).toLocaleString()}
+                        </div>
+                        <Btn onClick={clearSession} variant="danger">
+                            Clear Session
+                        </Btn>
+                    </div>
+                )}
+
+                {errorMessage ? (
+                    <div style={ERROR_TEXT}>{errorMessage}</div>
+                ) : null}
+            </div>
+
+            {/* ── Confidence time-series ─────────────────────────────────────── */}
+            {isActive && session ? (
+                <div style={CARD_STYLE}>
+                    <div style={SECTION_LABEL}>Confidence Time-Series</div>
+
+                    {confidence === null ? (
+                        <div style={MUTED}>Polling for epoch data…</div>
+                    ) : null}
+
+                    {confidence !== null && confidence.epochs.length === 0 ? (
+                        <div style={MUTED}>
+                            Session is pending — no epochs recorded yet. Kick off a training
+                            workflow to generate artifact data.
+                        </div>
+                    ) : null}
+
+                    {confidenceValues.length > 0 ? (
+                        <div style={{ display: 'grid', gap: 6 }}>
+                            <div style={{ overflowX: 'auto' }}>
+                                <ConfidenceSparkline values={confidenceValues} />
+                            </div>
+                            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                                {peakEpoch !== null && peakEpoch !== undefined ? (
+                                    <Pill color="#a7f3d0" borderColor="rgba(16, 185, 129, 0.28)">
+                                        Peak epoch: {peakEpoch}
+                                    </Pill>
+                                ) : null}
+                                {rollingAvg !== null && rollingAvg !== undefined ? (
+                                    <Pill color="#bae6fd" borderColor="rgba(56, 189, 248, 0.3)">
+                                        3-epoch avg: {rollingAvg.toFixed(4)}
+                                    </Pill>
+                                ) : null}
+                                <Pill
+                                    color={confidenceValues[confidenceValues.length - 1]! > 0 ? '#86efac' : '#e9d5ff'}
+                                    borderColor="rgba(34, 197, 94, 0.28)"
+                                >
+                                    Latest: {confidenceValues[confidenceValues.length - 1]!.toFixed(4)}
+                                </Pill>
+                            </div>
+                        </div>
+                    ) : null}
+                </div>
+            ) : null}
+
+            {/* ── Latest epoch geometry summary ─────────────────────────────── */}
+            {isActive && latestGeometry ? (
+                <div style={CARD_STYLE}>
+                    <div style={SECTION_LABEL}>
+                        Epoch {latestGeometry.epoch} Geometry — {latestGeometry.mode}
+                    </div>
+                    <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                        <Pill color="#a7f3d0" borderColor="rgba(16, 185, 129, 0.28)">
+                            {latestGeometry.clusters.length} cluster{latestGeometry.clusters.length !== 1 ? 's' : ''}
+                        </Pill>
+                        <Pill color="#bae6fd" borderColor="rgba(56, 189, 248, 0.3)">
+                            PCA {latestGeometry.projectionMetadata.components}D ·{' '}
+                            {(latestGeometry.projectionMetadata.explainedVariance * 100).toFixed(1)}% var
+                        </Pill>
+                        <Pill color="#e9d5ff" borderColor="rgba(168, 85, 247, 0.26)">
+                            Tokens: {latestGeometry.tokens.length}
+                        </Pill>
+                    </div>
+                    <div style={{ display: 'grid', gap: 4 }}>
+                        {geometryClusters.map((cluster: K3h4ClusterGeometry2d) => (
+                            <div
+                                key={cluster.clusterId}
+                                style={{
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    fontSize: 11,
+                                    padding: '4px 8px',
+                                    borderRadius: 6,
+                                    background: 'rgba(45, 212, 191, 0.06)',
+                                    border: '1px solid rgba(45, 212, 191, 0.12)',
+                                }}
+                            >
+                                <span style={{ color: '#94a3b8' }}>Cluster {cluster.clusterId}</span>
+                                <span style={{ color: '#a7f3d0' }}>
+                                    r={cluster.inscribedRadius.toFixed(4)} · centroid=({cluster.centroid.x.toFixed(3)}, {cluster.centroid.y.toFixed(3)})
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                    <div style={{ ...MUTED, fontSize: 10 }}>
+                        Centroid ({latestGeometry.clusters[0]?.centroid.x.toFixed(3) ?? '—'},
+                        {' '}{latestGeometry.clusters[0]?.centroid.y.toFixed(3) ?? '—'}) ·
+                        Projection: {latestGeometry.projectionMetadata.method.toUpperCase()},
+                        dim={latestGeometry.projectionMetadata.components}
+                    </div>
+                </div>
+            ) : null}
+
+            {/* ── Workflow controls ─────────────────────────────────────────── */}
+            {isActive && session ? (
+                <div style={{
+                    ...CARD_STYLE,
+                    border: '1px solid rgba(148, 163, 184, 0.18)',
+                    background: 'rgba(15, 23, 42, 0.32)',
+                }}>
+                    <div style={SECTION_LABEL}>Training Workflows</div>
+
+                    <div style={MUTED}>
+                        Run click-ops workflows to churn codebase topology signals and relation vectors.
+                        This triggers repeated analytics passes so humans do not need to handcraft starter training runs.
+                    </div>
+
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                        <Btn
+                            onClick={() => runWorkflow('bootstrap')}
+                            disabled={workflowBusy}
+                        >
+                            Bootstrap Data (12)
+                        </Btn>
+                        <Btn
+                            onClick={() => runWorkflow('relations')}
+                            disabled={workflowBusy}
+                        >
+                            Relation Sweep (36)
+                        </Btn>
+                        <Btn
+                            onClick={() => runWorkflow('churn')}
+                            disabled={workflowBusy}
+                        >
+                            Full Churn (96)
+                        </Btn>
+                        <Btn
+                            onClick={stopWorkflow}
+                            disabled={!workflowBusy}
+                            variant="danger"
+                        >
+                            Stop Run
+                        </Btn>
+                    </div>
+
+                    {workflowState.workflow ? (
+                        <div style={{ display: 'grid', gap: 6 }}>
+                            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                                <Pill color="#bae6fd" borderColor="rgba(56, 189, 248, 0.3)">
+                                    Workflow: {workflowState.workflow}
+                                </Pill>
+                                <Pill color="#a7f3d0" borderColor="rgba(16, 185, 129, 0.28)">
+                                    Passes: {workflowState.completedPasses}/{workflowState.totalPasses}
+                                </Pill>
+                                <Pill color="#e9d5ff" borderColor="rgba(168, 85, 247, 0.26)">
+                                    Progress: {workflowProgressPct}%
+                                </Pill>
+                                <Pill
+                                    color={workflowState.status === 'error' ? '#fda4af' : workflowState.status === 'completed' ? '#86efac' : '#bae6fd'}
+                                    borderColor={workflowState.status === 'error' ? 'rgba(244, 63, 94, 0.3)' : 'rgba(56, 189, 248, 0.3)'}
+                                >
+                                    {workflowState.status}
+                                </Pill>
+                            </div>
+                            <div style={{
+                                height: 8,
+                                borderRadius: 999,
+                                background: 'rgba(15, 23, 42, 0.7)',
+                                border: '1px solid rgba(45, 212, 191, 0.2)',
+                                overflow: 'hidden',
+                            }}>
+                                <div style={{
+                                    width: `${workflowProgressPct}%`,
+                                    height: '100%',
+                                    background: 'linear-gradient(90deg, rgba(20, 184, 166, 0.8), rgba(14, 165, 233, 0.85))',
+                                    transition: 'width 0.2s ease',
+                                }} />
+                            </div>
+                        </div>
+                    ) : null}
+
+                    {workflowState.errorMessage ? (
+                        <div style={ERROR_TEXT}>{workflowState.errorMessage}</div>
+                    ) : null}
+
+                    <div style={{ ...MUTED, fontSize: 10 }}>
+                        Session {session.sessionId} is used for live polling. As epochs land, confidence and geometry refresh automatically.
+                    </div>
+                </div>
+            ) : null}
+
+            {/* ── Live workflow logs ───────────────────────────────────────── */}
+            {isActive && session ? (
+                <div style={{
+                    ...CARD_STYLE,
+                    border: '1px solid rgba(56, 189, 248, 0.2)',
+                    background: 'rgba(7, 19, 34, 0.45)',
+                }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
+                        <div style={SECTION_LABEL}>Live Training Logs</div>
+                        <Btn
+                            onClick={clearWorkflowLogs}
+                            disabled={workflowLogs.length === 0 || workflowBusy}
+                            variant="danger"
+                        >
+                            Clear Logs
+                        </Btn>
+                    </div>
+
+                    <div style={{ ...MUTED, fontSize: 11 }}>
+                        Watch each pass as churn executes so you can inspect what is being trained in real time.
+                    </div>
+
+                    <div
+                        ref={workflowLogViewportRef}
+                        style={{
+                            maxHeight: 220,
+                            overflowY: 'auto',
+                            borderRadius: 8,
+                            border: '1px solid rgba(148, 163, 184, 0.2)',
+                            background: 'rgba(2, 6, 23, 0.75)',
+                            padding: 8,
+                            display: 'grid',
+                            gap: 6,
+                        }}
+                    >
+                        {workflowLogs.length === 0 ? (
+                            <div style={{ ...MUTED, fontSize: 11 }}>
+                                No training logs yet. Start a workflow to stream pass-level output.
+                            </div>
+                        ) : workflowLogs.map((entry) => (
+                            <div
+                                key={entry.id}
+                                style={{
+                                    borderRadius: 6,
+                                    border: `1px solid ${entry.level === 'error' ? 'rgba(244, 63, 94, 0.35)' : entry.level === 'warn' ? 'rgba(251, 191, 36, 0.35)' : entry.level === 'success' ? 'rgba(34, 197, 94, 0.35)' : 'rgba(56, 189, 248, 0.26)'}`,
+                                    background: 'rgba(15, 23, 42, 0.55)',
+                                    padding: '6px 8px',
+                                    display: 'grid',
+                                    gap: 2,
+                                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                                    fontSize: 11,
+                                }}
+                            >
+                                <div style={{ color: '#cbd5e1' }}>
+                                    [{new Date(entry.timestamp).toLocaleTimeString()}] {entry.message}
+                                </div>
+                                {entry.details ? (
+                                    <div style={{ color: '#94a3b8', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                                        {entry.details}
+                                    </div>
+                                ) : null}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            ) : null}
+
+        </div>
+    );
+}

--- a/src/typescript/react/src/domain/notebook/viz/useK3h4TrainingSession.ts
+++ b/src/typescript/react/src/domain/notebook/viz/useK3h4TrainingSession.ts
@@ -1,0 +1,473 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {createK3h4TrainingSession, fetchK3h4ConfidenceTimeSeries, fetchK3h4EpochGeometry, fetchNetcodeAnalytics, type K3h4ConfidenceTimeSeries, type K3h4TrainingMode, type K3h4TrainingSession, type NetcodeAnalyticsRequest, resolveApiBaseUrl,} from '../../../lib/api';
+import type {K3h4EpochGeometryResponse} from '../../../lib/k3h4GeometryTypes';
+
+const STORAGE_KEY = 'banana-k3h4-training-session';
+const POLL_INTERVAL_MS = typeof import.meta.env !== 'undefined' &&
+        import.meta.env.VITE_K3H4_CONFIDENCE_POLL_MS ?
+    Number(import.meta.env.VITE_K3H4_CONFIDENCE_POLL_MS) :
+    4000;
+
+function readStoredSession(): K3h4TrainingSession|null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as K3h4TrainingSession;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredSession(session: K3h4TrainingSession|null): void {
+  try {
+    if (session) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // localStorage may be unavailable (SSR / privacy mode).
+  }
+}
+
+export type TrainingSessionPhase = 'idle'|'creating'|'active'|'error';
+export type K3h4TrainingWorkflow = 'bootstrap'|'relations'|'churn';
+export type TrainingWorkflowLogLevel = 'info'|'success'|'warn'|'error';
+
+export type TrainingWorkflowLogEntry = {
+  readonly id: string; readonly timestamp: string; readonly level: TrainingWorkflowLogLevel; readonly message:
+                                                                                                          string;
+  readonly details?: string;
+};
+
+export type TrainingWorkflowState = {
+  readonly status: 'idle'|'running'|'completed'|'error'; readonly workflow: K3h4TrainingWorkflow | null; readonly totalPasses: number; readonly completedPasses: number; readonly errorMessage:
+                                                                                                                                                                                      string |
+      null;
+};
+
+const WORKFLOW_PASS_COUNT: Record<K3h4TrainingWorkflow, number> = {
+  bootstrap: 12,
+  relations: 36,
+  churn: 96,
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    const record = error as Record<string, unknown>;
+    const nestedCandidates = [
+      record.payload,
+      record.cause,
+      record.response,
+      record.data,
+      record.body,
+      record.message,
+      record.error,
+      record.detail,
+      record.details,
+      record.reason,
+    ];
+
+    for (const candidate of nestedCandidates) {
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        if (candidate === '[object Object]') {
+          continue;
+        }
+        return candidate;
+      }
+      if (typeof candidate === 'object' && candidate !== null) {
+        const nested = extractErrorMessage(candidate);
+        if (nested !== 'Unknown error' && nested !== '[object Object]') {
+          return nested;
+        }
+      }
+    }
+
+    if (error instanceof Error && error.message.trim().length > 0 &&
+        error.message !== '[object Object]') {
+      return error.message;
+    }
+
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return 'Unknown error';
+    }
+  }
+
+  if (typeof error === 'string' && error.trim().length > 0) {
+    return error;
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return 'Unknown error';
+}
+
+function buildAnalyticsPayload(params: {
+  workflow: K3h4TrainingWorkflow; mode: K3h4TrainingMode; passIndex: number;
+}): NetcodeAnalyticsRequest {
+  const {workflow, mode, passIndex} = params;
+  const wave = Math.sin(passIndex / 3);
+  const sweep = Math.cos(passIndex / 5);
+  const workflowDepth = workflow === 'bootstrap' ? 1 :
+      workflow === 'relations'                   ? 2 :
+                                                   3;
+
+  return {
+    callDensity: 0.42 + (wave + 1) * 0.14,
+    questPercent: 0.38 + (sweep + 1) * 0.18,
+    playerLevel: 7 + (passIndex % 18),
+    comboStreak: 2 + (passIndex % 9),
+    branchPressure: 0.32 + (Math.abs(wave) * 0.36),
+    dependencyPulse: 0.34 + (Math.abs(sweep) * 0.34),
+    workflowDepth,
+    networkDimensions: workflow === 'churn' ? 4 : 3,
+    modelConfidence: 0.35 + (Math.abs(wave) * 0.55),
+    policyMomentum: 0.33 + (Math.abs(sweep) * 0.58),
+    interactionSignal: 0.44 + ((wave + sweep + 2) / 4) * 0.45,
+    k3h4Mode: mode,
+    spectralMode: workflow === 'relations' || workflow === 'churn' ?
+        'affinity-graph' :
+        'disabled',
+  };
+}
+
+export type UseK3h4TrainingSessionResult = {
+  phase: TrainingSessionPhase; session: K3h4TrainingSession | null;
+  confidence: K3h4ConfidenceTimeSeries | null;
+  latestGeometry: K3h4EpochGeometryResponse | null;
+  errorMessage: string | null;
+  workflowState: TrainingWorkflowState;
+  workflowLogs: readonly TrainingWorkflowLogEntry[];
+  startSession: (mode: K3h4TrainingMode) => void;
+  runWorkflow: (workflow: K3h4TrainingWorkflow) => void;
+  stopWorkflow: () => void;
+  clearWorkflowLogs: () => void;
+  clearSession: () => void;
+};
+
+export function useK3h4TrainingSession(): UseK3h4TrainingSessionResult {
+  const [phase, setPhase] = useState<TrainingSessionPhase>('idle');
+  const [session, setSession] =
+      useState<K3h4TrainingSession|null>(() => readStoredSession());
+  const [confidence, setConfidence] =
+      useState<K3h4ConfidenceTimeSeries|null>(null);
+  const [latestGeometry, setLatestGeometry] =
+      useState<K3h4EpochGeometryResponse|null>(null);
+  const [errorMessage, setErrorMessage] = useState<string|null>(null);
+  const [workflowState, setWorkflowState] = useState<TrainingWorkflowState>({
+    status: 'idle',
+    workflow: null,
+    totalPasses: 0,
+    completedPasses: 0,
+    errorMessage: null,
+  });
+  const [workflowLogs, setWorkflowLogs] =
+      useState<TrainingWorkflowLogEntry[]>([]);
+
+  const pollRef = useRef<ReturnType<typeof setInterval>|null>(null);
+  const workflowRunIdRef = useRef(0);
+
+  const appendWorkflowLog = useCallback(
+      (entry: {
+        level: TrainingWorkflowLogLevel; message: string;
+        details?: string;
+      }) => {
+        setWorkflowLogs((current) => {
+          const next: TrainingWorkflowLogEntry = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+            timestamp: new Date().toISOString(),
+            level: entry.level,
+            message: entry.message,
+            details: entry.details,
+          };
+          const updated = [...current, next];
+          return updated.length > 400 ? updated.slice(updated.length - 400) :
+                                        updated;
+        });
+      },
+      []);
+
+  // When a session is already in storage, resume polling immediately.
+  useEffect(() => {
+    if (session) setPhase('active');
+  }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const pollConfidence = useCallback(
+      async (activeSession: K3h4TrainingSession) => {
+        const baseUrl = resolveApiBaseUrl();
+        try {
+          const series = await fetchK3h4ConfidenceTimeSeries(
+              baseUrl, activeSession.sessionId, activeSession.mode);
+          setConfidence(series);
+
+          if (series.status === 'completed') stopPolling();
+
+          // Load geometry for the latest epoch when available.
+          if (series.epochs.length > 0) {
+            const lastEpoch =
+                series.epochs[series.epochs.length - 1]!.epochIndex;
+            try {
+              const geo = await fetchK3h4EpochGeometry(
+                  baseUrl, activeSession.sessionId, lastEpoch,
+                  activeSession.mode);
+              setLatestGeometry(geo);
+            } catch {
+              // Geometry is best-effort; don't break the confidence poll.
+            }
+          }
+        } catch (err) {
+          // 404 means session was pruned server-side — surface but keep going.
+          const msg = extractErrorMessage(err);
+          if (msg.includes('session_not_found') || msg.includes('404')) {
+            setErrorMessage('Training session not found on server.');
+            stopPolling();
+          }
+          // Other transient errors are swallowed; next tick will retry.
+        }
+      },
+      [stopPolling],
+  );
+
+  const startPolling = useCallback(
+      (activeSession: K3h4TrainingSession) => {
+        stopPolling();
+        void pollConfidence(activeSession);
+        pollRef.current = setInterval(
+            () => void pollConfidence(activeSession), POLL_INTERVAL_MS);
+      },
+      [pollConfidence, stopPolling],
+  );
+
+  // Resume polling whenever phase becomes active.
+  useEffect(() => {
+    if (phase === 'active' && session) startPolling(session);
+    return stopPolling;
+  }, [phase, session, startPolling, stopPolling]);
+
+  const startSession = useCallback((mode: K3h4TrainingMode) => {
+    setPhase('creating');
+    setErrorMessage(null);
+    const baseUrl = resolveApiBaseUrl();
+    createK3h4TrainingSession(baseUrl, mode)
+        .then((created) => {
+          writeStoredSession(created);
+          setSession(created);
+          setConfidence(null);
+          setLatestGeometry(null);
+          setPhase('active');
+          appendWorkflowLog({
+            level: 'success',
+            message: `Session ${created.sessionId} created (${created.mode})`,
+          });
+        })
+        .catch((err) => {
+          const msg = extractErrorMessage(err);
+          setErrorMessage(msg);
+          setPhase('error');
+          appendWorkflowLog({
+            level: 'error',
+            message: 'Failed to create training session',
+            details: msg,
+          });
+        });
+  }, [appendWorkflowLog]);
+
+  const stopWorkflow = useCallback(() => {
+    workflowRunIdRef.current += 1;
+    setWorkflowState(
+        (current) => ({
+          status: current.status === 'running' ? 'idle' : current.status,
+          workflow: current.status === 'running' ? null : current.workflow,
+          totalPasses: current.status === 'running' ? 0 : current.totalPasses,
+          completedPasses:
+              current.status === 'running' ? 0 : current.completedPasses,
+          errorMessage: null,
+        }));
+    appendWorkflowLog({
+      level: 'warn',
+      message: 'Workflow run stopped by user',
+    });
+  }, [appendWorkflowLog]);
+
+  const runWorkflow = useCallback((workflow: K3h4TrainingWorkflow) => {
+    if (!session) {
+      setWorkflowState({
+        status: 'error',
+        workflow: null,
+        totalPasses: 0,
+        completedPasses: 0,
+        errorMessage: 'Start a session before running workflow actions.',
+      });
+      appendWorkflowLog({
+        level: 'error',
+        message: 'Workflow start rejected: no active session',
+      });
+      return;
+    }
+
+    const runId = workflowRunIdRef.current + 1;
+    workflowRunIdRef.current = runId;
+
+    const totalPasses = WORKFLOW_PASS_COUNT[workflow];
+    setWorkflowState({
+      status: 'running',
+      workflow,
+      totalPasses,
+      completedPasses: 0,
+      errorMessage: null,
+    });
+    appendWorkflowLog({
+      level: 'info',
+      message: `Starting ${workflow} workflow (${totalPasses} passes)`,
+      details: `mode=${session.mode} session=${session.sessionId}`,
+    });
+
+    const baseUrl = resolveApiBaseUrl();
+    if (!baseUrl) {
+      setWorkflowState({
+        status: 'error',
+        workflow,
+        totalPasses,
+        completedPasses: 0,
+        errorMessage: 'API base URL is not configured.',
+      });
+      appendWorkflowLog({
+        level: 'error',
+        message: 'Workflow failed: API base URL is missing',
+      });
+      return;
+    }
+
+    void (async () => {
+      for (let passIndex = 0; passIndex < totalPasses; passIndex += 1) {
+        if (workflowRunIdRef.current !== runId) {
+          return;
+        }
+
+        const payload = buildAnalyticsPayload({
+          workflow,
+          mode: session.mode,
+          passIndex,
+        });
+
+        try {
+          const analytics = await fetchNetcodeAnalytics(baseUrl, payload);
+          appendWorkflowLog({
+            level: 'info',
+            message: `Pass ${passIndex + 1}/${totalPasses} complete`,
+            details: `depth=${payload.workflowDepth} density=${
+                payload.callDensity.toFixed(3)} confidence=${
+                payload.modelConfidence.toFixed(
+                    3)} clusters=${analytics.k3h4.centers.length} convergence=${
+                analytics.k3h4.observability.convergenceStatus}`,
+          });
+        } catch (error) {
+          if (workflowRunIdRef.current !== runId) {
+            return;
+          }
+          const message = extractErrorMessage(error);
+          setWorkflowState({
+            status: 'error',
+            workflow,
+            totalPasses,
+            completedPasses: passIndex,
+            errorMessage: message,
+          });
+          appendWorkflowLog({
+            level: 'error',
+            message: `Workflow error at pass ${passIndex + 1}/${totalPasses}`,
+            details: message,
+          });
+          return;
+        }
+
+        if (workflowRunIdRef.current !== runId) {
+          return;
+        }
+
+        setWorkflowState({
+          status: 'running',
+          workflow,
+          totalPasses,
+          completedPasses: passIndex + 1,
+          errorMessage: null,
+        });
+
+        await delay(120);
+      }
+
+      if (workflowRunIdRef.current !== runId) {
+        return;
+      }
+
+      setWorkflowState({
+        status: 'completed',
+        workflow,
+        totalPasses,
+        completedPasses: totalPasses,
+        errorMessage: null,
+      });
+      appendWorkflowLog({
+        level: 'success',
+        message: `Workflow ${workflow} completed`,
+        details: `passes=${totalPasses} session=${session.sessionId}`,
+      });
+
+      await pollConfidence(session);
+    })();
+  }, [appendWorkflowLog, pollConfidence, session]);
+
+  const clearWorkflowLogs = useCallback(() => {
+    setWorkflowLogs([]);
+  }, []);
+
+  const clearSession = useCallback(() => {
+    workflowRunIdRef.current += 1;
+    stopPolling();
+    writeStoredSession(null);
+    setSession(null);
+    setConfidence(null);
+    setLatestGeometry(null);
+    setErrorMessage(null);
+    setWorkflowState({
+      status: 'idle',
+      workflow: null,
+      totalPasses: 0,
+      completedPasses: 0,
+      errorMessage: null,
+    });
+    setWorkflowLogs([]);
+    setPhase('idle');
+  }, [stopPolling]);
+
+  return {
+    phase,
+    session,
+    confidence,
+    latestGeometry,
+    errorMessage,
+    workflowState,
+    workflowLogs,
+    startSession,
+    runWorkflow,
+    stopWorkflow,
+    clearWorkflowLogs,
+    clearSession,
+  };
+}

--- a/src/typescript/react/src/lib/api.ts
+++ b/src/typescript/react/src/lib/api.ts
@@ -1116,3 +1116,54 @@ export async function fetchK3h4EpochGeometry(
           encodeURIComponent(sessionId)}/epoch/${epoch}/geometry?${query}`,
   );
 }
+
+// ---------------------------------------------------------------------------
+// K3H4 training session API
+// ---------------------------------------------------------------------------
+
+export type K3h4TrainingMode = 'multiplicative'|'power';
+
+export type K3h4TrainingSession = {
+  readonly sessionId: string; readonly mode: K3h4TrainingMode; readonly createdAtUtc:
+                                                                            string;
+};
+
+export type K3h4EpochConfidence = {
+  readonly epochIndex: number; readonly confidence: number; readonly mode:
+                                                                         K3h4TrainingMode;
+};
+
+export type K3h4ConfidenceTimeSeries = {
+  readonly contractVersion: 1; readonly sessionId: string; readonly status: 'pending' | 'active' | 'completed'; readonly mode: K3h4TrainingMode; readonly epochs: readonly K3h4EpochConfidence[]; readonly metadata: {
+    readonly peakEpoch: number | null; readonly rollingAverage3: number | null; readonly defaultMode:
+                                                                                             'power';
+  };
+};
+
+export async function createK3h4TrainingSession(
+    baseUrl: string,
+    mode: K3h4TrainingMode = 'power',
+    ): Promise<K3h4TrainingSession> {
+  return fetchApiJson<K3h4TrainingSession>(
+      baseUrl,
+      '/api/netcode/k3h4/training-session',
+      {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({mode})
+      },
+  );
+}
+
+export async function fetchK3h4ConfidenceTimeSeries(
+    baseUrl: string,
+    sessionId: string,
+    mode: K3h4TrainingMode = 'power',
+    ): Promise<K3h4ConfidenceTimeSeries> {
+  const query = new URLSearchParams({mode}).toString();
+  return fetchApiJson<K3h4ConfidenceTimeSeries>(
+      baseUrl,
+      `/api/netcode/k3h4/training-session/${
+          encodeURIComponent(sessionId)}/confidence?${query}`,
+  );
+}

--- a/src/typescript/react/src/lib/notebook-client/layoutStore.ts
+++ b/src/typescript/react/src/lib/notebook-client/layoutStore.ts
@@ -12,7 +12,8 @@ const workflowOrder: WorkflowStepId[] = ['scan', 'shape', 'commit'];
 function pickHudPanelFromPreset(preset: {
   explorer: boolean; menu: boolean; status: boolean; operations: boolean;
   visualizations: boolean;
-}): 'explorer'|'menu'|'status'|'operations'|'visualizations'|null {
+  training: boolean;
+}): 'explorer'|'menu'|'status'|'operations'|'visualizations'|'training'|null {
   if (preset.explorer) {
     return 'explorer';
   }
@@ -27,6 +28,9 @@ function pickHudPanelFromPreset(preset: {
   }
   if (preset.visualizations) {
     return 'visualizations';
+  }
+  if (preset.training) {
+    return 'training';
   }
   return null;
 }
@@ -43,9 +47,11 @@ type NotebookLayoutState = {
   showStatus: boolean;
   showOperations: boolean;
   showVisualizations: boolean;
+  showTraining: boolean;
   lastHudSnapshot: {
     explorer: boolean; menu: boolean; status: boolean; operations: boolean;
     visualizations: boolean;
+    training: boolean;
   };
   showIntelNodeWindow: boolean;
   showObjectiveNodeWindow: boolean;
@@ -72,13 +78,15 @@ type NotebookLayoutState = {
   applyHudPreset: (preset: {
     explorer: boolean; menu: boolean; status: boolean; operations: boolean;
     visualizations: boolean;
+    training: boolean;
   }) => void;
   setHudPanelVisibility: (
-      panel: 'explorer'|'menu'|'status'|'operations'|'visualizations',
+      panel: 'explorer'|'menu'|'status'|'operations'|'visualizations'|
+      'training',
       visible: boolean,
       ) => void;
-  toggleHudPanel:
-      (panel: 'explorer'|'menu'|'status'|'operations'|'visualizations') => void;
+  toggleHudPanel: (panel: 'explorer'|'menu'|'status'|'operations'|
+                   'visualizations'|'training') => void;
   closeAllHudPanels: () => void;
   reopenHudPanels: () => void;
   setGameplayWindowVisibility: (
@@ -88,7 +96,7 @@ type NotebookLayoutState = {
   closeAllGameplayWindows: () => void;
   reopenGameplayWindows: () => void;
   focusHudPanel: (panel: 'explorer'|'menu'|'status'|'operations'|
-                  'visualizations'|null) => void;
+                  'visualizations'|'training'|null) => void;
   resetHudPanels: () => void;
   resetForSector: (hasSelection: boolean) => void;
 };
@@ -102,29 +110,31 @@ export const useNotebookLayoutStore = create<NotebookLayoutState>(
       activeWorkflowStep: 'scan',
       workflowDepth: 1,
       showFullSourceDump: false,
-      showExplorer: true,
-      showMenu: true,
-      showStatus: true,
-      showOperations: true,
+      showExplorer: false,
+      showMenu: false,
+      showStatus: false,
+      showOperations: false,
       showVisualizations: true,
+      showTraining: false,
       lastHudSnapshot: {
-        explorer: true,
-        menu: true,
-        status: true,
-        operations: true,
+        explorer: false,
+        menu: false,
+        status: false,
+        operations: false,
         visualizations: true,
+        training: false,
       },
-      showIntelNodeWindow: true,
-      showObjectiveNodeWindow: true,
-      showPlayerNodeWindow: true,
-      showQuestLogWindow: true,
-      showNodeOpsWindow: true,
+      showIntelNodeWindow: false,
+      showObjectiveNodeWindow: false,
+      showPlayerNodeWindow: false,
+      showQuestLogWindow: false,
+      showNodeOpsWindow: false,
       lastGameplayWindowSnapshot: {
-        intelNode: true,
-        objectiveNode: true,
-        playerNode: true,
-        questLog: true,
-        nodeOps: true,
+        intelNode: false,
+        objectiveNode: false,
+        playerNode: false,
+        questLog: false,
+        nodeOps: false,
       },
       lastGameplayDockSnapshot: 'intel',
       explorerDropupOpen: false,
@@ -155,6 +165,7 @@ export const useNotebookLayoutStore = create<NotebookLayoutState>(
         showStatus: pickHudPanelFromPreset(preset) === 'status',
         showOperations: pickHudPanelFromPreset(preset) === 'operations',
         showVisualizations: pickHudPanelFromPreset(preset) === 'visualizations',
+        showTraining: pickHudPanelFromPreset(preset) === 'training',
         explorerDropupOpen: false,
       }),
       setHudPanelVisibility: (panel, visible) => set(
@@ -166,6 +177,7 @@ export const useNotebookLayoutStore = create<NotebookLayoutState>(
                                                      state.showOperations,
             showVisualizations:
                 panel === 'visualizations' ? visible : state.showVisualizations,
+            showTraining: panel === 'training' ? visible : state.showTraining,
           })),
       toggleHudPanel: (panel) =>
           set((state) => ({
@@ -179,6 +191,8 @@ export const useNotebookLayoutStore = create<NotebookLayoutState>(
                 showVisualizations: panel === 'visualizations' ?
                     !state.showVisualizations :
                     state.showVisualizations,
+                showTraining: panel === 'training' ? !state.showTraining :
+                                                     state.showTraining,
                 explorerDropupOpen: false,
               })),
       closeAllHudPanels: () => set((state) => ({
@@ -188,12 +202,14 @@ export const useNotebookLayoutStore = create<NotebookLayoutState>(
                                        status: state.showStatus,
                                        operations: state.showOperations,
                                        visualizations: state.showVisualizations,
+                                       training: state.showTraining,
                                      },
                                      showExplorer: false,
                                      showMenu: false,
                                      showStatus: false,
                                      showOperations: false,
                                      showVisualizations: false,
+                                     showTraining: false,
                                      explorerDropupOpen: false,
                                    })),
       reopenHudPanels: () =>
@@ -203,6 +219,7 @@ export const useNotebookLayoutStore = create<NotebookLayoutState>(
                 showStatus: state.lastHudSnapshot.status,
                 showOperations: state.lastHudSnapshot.operations,
                 showVisualizations: state.lastHudSnapshot.visualizations,
+                showTraining: state.lastHudSnapshot.training,
                 explorerDropupOpen: false,
               })),
       setGameplayWindowVisibility: (window, visible) => set(
@@ -253,6 +270,7 @@ export const useNotebookLayoutStore = create<NotebookLayoutState>(
                 showStatus: panel === 'status',
                 showOperations: panel === 'operations',
                 showVisualizations: panel === 'visualizations',
+                showTraining: panel === 'training',
                 explorerDropupOpen: false,
               })),
       resetHudPanels: () => set({
@@ -261,6 +279,7 @@ export const useNotebookLayoutStore = create<NotebookLayoutState>(
         showStatus: false,
         showOperations: false,
         showVisualizations: false,
+        showTraining: false,
         explorerDropupOpen: false,
       }),
       resetForSector: (hasSelection) => set({

--- a/src/typescript/react/src/lib/notebook-client/useNotebookWindowOrchestrator.ts
+++ b/src/typescript/react/src/lib/notebook-client/useNotebookWindowOrchestrator.ts
@@ -3,8 +3,8 @@ import {useMemo, useState} from 'react';
 import {useNotebookLayoutStore} from './layoutStore';
 
 export type NotebookHudPanelId =
-    'explorer'|'menu'|'status'|'operations'|'visualizations'|'intelNode'|
-    'objectiveNode'|'playerNode'|'questLog'|'nodeOps';
+    'explorer'|'menu'|'status'|'operations'|'visualizations'|'training'|
+    'intelNode'|'objectiveNode'|'playerNode'|'questLog'|'nodeOps';
 
 type UseNotebookWindowOrchestratorOptions = {
   readonly initialPinnedPanels?: readonly NotebookHudPanelId[];
@@ -16,6 +16,7 @@ export function useNotebookWindowOrchestrator({
         'menu',
         'explorer',
         'visualizations',
+        'training',
         'intelNode',
         'objectiveNode',
         'playerNode',
@@ -30,6 +31,7 @@ export function useNotebookWindowOrchestrator({
       useNotebookLayoutStore((state) => state.showOperations);
   const showVisualizations =
       useNotebookLayoutStore((state) => state.showVisualizations);
+  const showTraining = useNotebookLayoutStore((state) => state.showTraining);
   const showObjectiveNode =
       useNotebookLayoutStore((state) => state.showObjectiveNodeWindow);
   const showIntelNode =
@@ -69,6 +71,7 @@ export function useNotebookWindowOrchestrator({
         status: showStatus,
         operations: showOperations,
         visualizations: showVisualizations,
+        training: showTraining,
         intelNode: showIntelNode,
         objectiveNode: showObjectiveNode,
         playerNode: showPlayerNode,
@@ -81,6 +84,7 @@ export function useNotebookWindowOrchestrator({
         showStatus,
         showOperations,
         showVisualizations,
+        showTraining,
         showIntelNode,
         showObjectiveNode,
         showPlayerNode,
@@ -100,7 +104,8 @@ export function useNotebookWindowOrchestrator({
 
   const closePanel = (panel: NotebookHudPanelId) => {
     if (panel === 'explorer' || panel === 'menu' || panel === 'status' ||
-        panel === 'visualizations' || panel === 'operations') {
+        panel === 'visualizations' || panel === 'operations' ||
+        panel === 'training') {
       setHudPanelVisibility(panel, false);
       return;
     }
@@ -129,7 +134,8 @@ export function useNotebookWindowOrchestrator({
 
   const togglePanel = (panel: NotebookHudPanelId) => {
     if (panel === 'explorer' || panel === 'menu' || panel === 'status' ||
-        panel === 'visualizations' || panel === 'operations') {
+        panel === 'visualizations' || panel === 'operations' ||
+        panel === 'training') {
       toggleHudPanel(panel);
       return;
     }
@@ -163,6 +169,7 @@ export function useNotebookWindowOrchestrator({
     setHudPanelVisibility('status', false);
     setHudPanelVisibility('operations', false);
     setHudPanelVisibility('visualizations', false);
+    setHudPanelVisibility('training', false);
   };
 
   const closeAllWindows = () => {
@@ -181,6 +188,7 @@ export function useNotebookWindowOrchestrator({
     showStatus,
     showOperations,
     showVisualizations,
+    showTraining,
     showIntelNode,
     showObjectiveNode,
     showPlayerNode,

--- a/src/typescript/react/src/pages/DataSciencePlaygroundPage.tsx
+++ b/src/typescript/react/src/pages/DataSciencePlaygroundPage.tsx
@@ -11,6 +11,7 @@ import { NotebookHealthPanel } from '../components/notebook-client/NotebookHealt
 import { NotebookOperationsPanel } from '../components/notebook-client/NotebookOperationsPanel';
 import { NotebookVisualizationsPanel } from '../components/notebook-client/NotebookVisualizationsPanel';
 import { RouteModePanel } from '../components/notebook-client/RouteModePanel';
+import { NotebookTrainingPanel } from '../domain/notebook/viz/NotebookTrainingPanel';
 import { withErrorBoundary } from '../components/errors/withErrorBoundary';
 import {
     buildQuestProgress,
@@ -48,6 +49,9 @@ const SafeNotebookOperationsPanel = withErrorBoundary(NotebookOperationsPanel, {
 const SafeNotebookVisualizationsPanel = withErrorBoundary(NotebookVisualizationsPanel, {
     componentName: 'NotebookVisualizationsPanel',
 });
+const SafeNotebookTrainingPanel = withErrorBoundary(NotebookTrainingPanel, {
+    componentName: 'NotebookTrainingPanel',
+});
 
 const shellStyle: CSSProperties = {
     height: '100dvh',
@@ -72,6 +76,7 @@ const panelResetDefaults: Record<NotebookHudPanelId, number> = {
     status: 0,
     operations: 0,
     visualizations: 0,
+    training: 0,
     intelNode: 0,
     objectiveNode: 0,
     playerNode: 0,
@@ -90,6 +95,7 @@ const panelDefaultSizes: Record<NotebookHudPanelId, { width: number; height: num
     nodeOps: { width: 360, height: 220 },
     operations: { width: 360, height: 240 },
     visualizations: { width: 460, height: 380 },
+    training: { width: 440, height: 420 },
 };
 
 type NotebookAnalyticsTelemetry = {
@@ -172,6 +178,7 @@ export function DataSciencePlaygroundPage() {
         showStatus,
         showOperations,
         showVisualizations,
+        showTraining,
         showIntelNode,
         showObjectiveNode,
         showPlayerNode,
@@ -254,6 +261,7 @@ export function DataSciencePlaygroundPage() {
             status: previous.status + 1,
             operations: previous.operations + 1,
             visualizations: previous.visualizations + 1,
+            training: previous.training + 1,
             intelNode: previous.intelNode + 1,
             objectiveNode: previous.objectiveNode + 1,
             playerNode: previous.playerNode + 1,
@@ -539,6 +547,18 @@ export function DataSciencePlaygroundPage() {
                 />
             </RouteDeckTransition>
         ),
+        training: (
+            <RouteDeckTransition
+                reducedMotion={prefersReducedMotion}
+                animating={modeDeckAnimating}
+                delayMs={120}
+                inactiveOpacity={0.84}
+                inactiveTransform="translateY(9px) scale(0.992)"
+                inactiveFilter="saturate(1.04)"
+            >
+                <SafeNotebookTrainingPanel />
+            </RouteDeckTransition>
+        ),
         objectiveNode: (
             <ObjectivesDockPanel
                 completedQuestCount={completedQuestCount}
@@ -650,6 +670,7 @@ export function DataSciencePlaygroundPage() {
         { id: 'intelNode', corner: 'top-right', title: 'INTEL NODE' },
         { id: 'status', corner: 'bottom-left', title: 'ROUTE REGISTRY' },
         { id: 'visualizations', corner: 'bottom-left', title: 'VISUALIZATIONS' },
+        { id: 'training', corner: 'bottom-left', title: 'TRAINING' },
         { id: 'questLog', corner: 'bottom-left', title: 'QUEST LOG' },
         { id: 'objectiveNode', corner: 'bottom-right', title: 'OBJECTIVE NODE' },
         { id: 'nodeOps', corner: 'bottom-right', title: 'NODE OPS' },
@@ -736,6 +757,7 @@ export function DataSciencePlaygroundPage() {
                     showOperations={showOperations}
                     showStatus={showStatus}
                     showVisualizations={showVisualizations}
+                    showTraining={showTraining}
                     showIntelNode={showIntelNode}
                     showObjectiveNode={showObjectiveNode}
                     showPlayerNode={showPlayerNode}
@@ -747,6 +769,7 @@ export function DataSciencePlaygroundPage() {
                     onToggleOperations={() => togglePanel('operations')}
                     onToggleStatus={() => togglePanel('status')}
                     onToggleVisualizations={() => togglePanel('visualizations')}
+                    onToggleTraining={() => togglePanel('training')}
                     onToggleIntelNode={() => togglePanel('intelNode')}
                     onToggleObjectiveNode={() => togglePanel('objectiveNode')}
                     onTogglePlayerNode={() => togglePanel('playerNode')}

--- a/src/typescript/react/tests/playwright/k3h4-training-viz.spec.ts
+++ b/src/typescript/react/tests/playwright/k3h4-training-viz.spec.ts
@@ -1,0 +1,216 @@
+import {expect, test} from '@playwright/test';
+
+/**
+ * K3H4 training integration smoke — covers the three new endpoints added in
+ * the 036-k3h4-transformer-viz training integration feature:
+ *
+ *   POST /api/netcode/k3h4/training-session
+ *   GET  /api/netcode/k3h4/training-session/:id/confidence
+ *   GET  /api/netcode/k3h4/training-session/:id/epoch/:n/geometry
+ *
+ * These tests run against the live compose stack (api-overworld on :8081)
+ * and the React shell (react-overworld on :5173).
+ */
+
+const API_BASE = process.env.PLAYWRIGHT_API_BASE_URL ?? 'http://localhost:8081';
+
+test.describe('K3H4 training integration API', () => {
+  test(
+      'POST training-session creates a session with default power mode',
+      async ({request}) => {
+        const res = await request.post(
+            `${API_BASE}/api/netcode/k3h4/training-session`, {
+              headers: {'content-type': 'application/json'},
+              data: {},
+            });
+
+        expect(res.status(), 'training-session must return 201').toBe(201);
+        const json = await res.json() as {
+          sessionId?: string;
+          mode?: string;
+          createdAtUtc?: string;
+        };
+        expect(json.sessionId).toBeTruthy();
+        expect(json.mode).toBe('power');
+        expect(typeof json.createdAtUtc).toBe('string');
+      });
+
+  test(
+      'POST training-session accepts explicit multiplicative mode',
+      async ({request}) => {
+        const res = await request.post(
+            `${API_BASE}/api/netcode/k3h4/training-session`, {
+              headers: {'content-type': 'application/json'},
+              data: {mode: 'multiplicative'},
+            });
+
+        expect(res.status()).toBe(201);
+        const json = await res.json() as {mode?: string};
+        expect(json.mode).toBe('multiplicative');
+      });
+
+  test('POST training-session rejects invalid mode', async ({request}) => {
+    const res =
+        await request.post(`${API_BASE}/api/netcode/k3h4/training-session`, {
+          headers: {'content-type': 'application/json'},
+          data: {mode: 'turbo'},
+        });
+    expect(res.status()).toBe(400);
+    const json = await res.json() as {error?: string};
+    expect(json.error).toBe('invalid_mode');
+  });
+
+  test(
+      'GET confidence returns pending status for fresh session',
+      async ({request}) => {
+        // Create a fresh session first.
+        const createRes = await request.post(
+            `${API_BASE}/api/netcode/k3h4/training-session`, {
+              headers: {'content-type': 'application/json'},
+              data: {mode: 'power'},
+            });
+        expect(createRes.status()).toBe(201);
+        const {sessionId} = await createRes.json() as {sessionId: string};
+
+        const confRes =
+            await request.get(`${API_BASE}/api/netcode/k3h4/training-session/${
+                sessionId}/confidence`);
+        expect(confRes.status()).toBe(200);
+        const conf = await confRes.json() as {
+          contractVersion?: number;
+          sessionId?: string;
+          status?: string;
+          mode?: string;
+          epochs?: unknown[];
+        };
+        expect(conf.contractVersion).toBe(1);
+        expect(conf.sessionId).toBe(sessionId);
+        expect(conf.status).toBe('pending');
+        expect(conf.mode).toBe('power');
+        expect(Array.isArray(conf.epochs)).toBe(true);
+        expect(conf.epochs).toHaveLength(0);
+      });
+
+  test('GET confidence returns 404 for unknown session', async ({request}) => {
+    // Session ID must be ≤ 15 chars and match [A-Za-z0-9_-]+
+    const res = await request.get(`${
+        API_BASE}/api/netcode/k3h4/training-session/no-sess-ghost/confidence`);
+    expect(res.status()).toBe(404);
+    const json = await res.json() as {error?: string};
+    expect(json.error).toBe('session_not_found');
+  });
+
+  test('GET confidence rejects invalid mode param', async ({request}) => {
+    const createRes =
+        await request.post(`${API_BASE}/api/netcode/k3h4/training-session`, {
+          headers: {'content-type': 'application/json'},
+          data: {},
+        });
+    const {sessionId} = await createRes.json() as {sessionId: string};
+
+    const res =
+        await request.get(`${API_BASE}/api/netcode/k3h4/training-session/${
+            sessionId}/confidence?mode=bad`);
+    expect(res.status()).toBe(400);
+    const json = await res.json() as {error?: string};
+    expect(json.error).toBe('invalid_mode');
+  });
+
+  test(
+      'GET epoch geometry returns 404 for missing artifact',
+      async ({request}) => {
+        const createRes = await request.post(
+            `${API_BASE}/api/netcode/k3h4/training-session`, {
+              headers: {'content-type': 'application/json'},
+              data: {},
+            });
+        const {sessionId} = await createRes.json() as {sessionId: string};
+
+        const res =
+            await request.get(`${API_BASE}/api/netcode/k3h4/training-session/${
+                sessionId}/epoch/0/geometry`);
+        expect(res.status()).toBe(404);
+        const json = await res.json() as {error?: string};
+        expect(json.error).toBe('artifact_not_found');
+      });
+
+  test('GET epoch geometry returns 404 for unknown session', async ({request}) => {
+    // Session ID must be ≤ 15 chars
+    const res = await request.get(`${
+        API_BASE}/api/netcode/k3h4/training-session/no-sess-geo99/epoch/0/geometry`);
+    expect(res.status()).toBe(404);
+    const json = await res.json() as {error?: string};
+    expect(json.error).toBe('session_not_found');
+  });
+
+  test('GET epoch geometry rejects invalid epoch index', async ({request}) => {
+    const res = await request.get(`${
+        API_BASE}/api/netcode/k3h4/training-session/sess01/epoch/nan/geometry`);
+    expect(res.status()).toBe(400);
+    const json = await res.json() as {error?: string};
+    expect(json.error).toBe('invalid_epoch');
+  });
+
+  test('GET scaling-benchmark returns series data', async ({request}) => {
+    const res =
+        await request.get(`${API_BASE}/api/netcode/k3h4/scaling-benchmark`);
+    // The CTest benchmark may not have run in a fresh compose stack, so both
+    // 200 (data available) and 404 (not yet generated) are acceptable.
+    expect([200, 404]).toContain(res.status());
+    if (res.status() === 200) {
+      const json = await res.json() as {
+        contractVersion?: number;
+        series?: unknown[];
+      };
+      expect(json.contractVersion).toBe(1);
+      expect(Array.isArray(json.series)).toBe(true);
+      expect((json.series ?? []).length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+test.describe('K3H4 training UI presence', () => {
+  test('React shell loads without transport errors', async ({page}) => {
+    await page.goto('/');
+
+    await expect
+        .poll(
+            async () => {
+              const bodyText = await page.locator('body').innerText();
+              return {
+                transportError: bodyText.includes('TRANSPORT-ERROR'),
+                analyticsUnavailable:
+                    bodyText.includes('ANALYTICS UNAVAILABLE'),
+              };
+            },
+            {timeout: 30_000, intervals: [1_000, 2_000, 3_000]},
+            )
+        .toMatchObject({
+          transportError: false,
+          analyticsUnavailable: false,
+        });
+  });
+
+  test(
+      'default pinned panels are minimal — shell renders without node panels',
+      async ({page}) => {
+        await page.goto('/');
+
+        // Wait for the shell to stabilise.
+        await page.waitForLoadState('networkidle', {timeout: 20_000})
+            .catch(() => {/* tolerate slow hydration */});
+
+        // All panels are pinned, but only the visualizations window is shown
+        // by default. Node sub-panels start hidden and are opened on demand.
+        // Verify no transport or unavailability errors surface.
+        const bodyText = await page.locator('body').innerText();
+        expect(
+            bodyText.includes('TRANSPORT-ERROR'),
+            'no transport error when node panels are closed by default')
+            .toBe(false);
+        expect(
+            bodyText.includes('ANALYTICS UNAVAILABLE'),
+            'analytics not unavailable when node panels are closed')
+            .toBe(false);
+      });
+});

--- a/src/typescript/shared/ui/src/components/RouteHudControlStrip.tsx
+++ b/src/typescript/shared/ui/src/components/RouteHudControlStrip.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 
-type PanelId = 'explorer' | 'menu' | 'operations' | 'status' | 'visualizations' | 'intelNode' | 'objectiveNode' | 'playerNode' | 'questLog' | 'nodeOps';
+type PanelId = 'explorer' | 'menu' | 'operations' | 'status' | 'visualizations' | 'training' | 'intelNode' | 'objectiveNode' | 'playerNode' | 'questLog' | 'nodeOps';
 
 type RouteHudControlStripProps = {
     readonly routeLabel: string;
@@ -10,6 +10,7 @@ type RouteHudControlStripProps = {
     readonly showOperations: boolean;
     readonly showStatus: boolean;
     readonly showVisualizations?: boolean;
+    readonly showTraining?: boolean;
     readonly showIntelNode?: boolean;
     readonly showObjectiveNode?: boolean;
     readonly showPlayerNode?: boolean;
@@ -20,6 +21,7 @@ type RouteHudControlStripProps = {
     readonly onToggleOperations: () => void;
     readonly onToggleStatus: () => void;
     readonly onToggleVisualizations?: () => void;
+    readonly onToggleTraining?: () => void;
     readonly onToggleIntelNode?: () => void;
     readonly onToggleObjectiveNode?: () => void;
     readonly onTogglePlayerNode?: () => void;
@@ -107,6 +109,14 @@ function PanelIcon({ id }: { readonly id: PanelId }) {
                     <path d="M2 13.5h12" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
                 </svg>
             );
+        case 'training':
+            return (
+                <svg viewBox="0 0 16 16" aria-hidden="true" style={svgStyle}>
+                    <path d="M3 12.5 6.4 8.8l2.1 1.8L13 4.5" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M11.1 4.5H13v1.9" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M2.5 13.5h11" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                </svg>
+            );
         case 'intelNode':
             return (
                 <svg viewBox="0 0 16 16" aria-hidden="true" style={svgStyle}>
@@ -177,6 +187,7 @@ export function RouteHudControlStrip({
     showOperations,
     showStatus,
     showVisualizations = false,
+    showTraining = false,
     showIntelNode = false,
     showObjectiveNode = false,
     showPlayerNode = false,
@@ -186,12 +197,13 @@ export function RouteHudControlStrip({
     onToggleOperations,
     onToggleStatus,
     onToggleVisualizations,
+    onToggleTraining,
     onToggleIntelNode,
     onToggleObjectiveNode,
     onTogglePlayerNode,
     onToggleQuestLog,
     onToggleNodeOps,
-    pinnedPanels = ['explorer', 'menu', 'operations', 'status', 'visualizations', 'intelNode', 'objectiveNode', 'playerNode', 'questLog', 'nodeOps'],
+    pinnedPanels = ['explorer', 'menu', 'operations', 'status', 'visualizations', 'training', 'intelNode', 'objectiveNode', 'playerNode', 'questLog', 'nodeOps'],
     onTogglePanelPin,
     onResetPanel,
     onFocusViewport,
@@ -236,6 +248,12 @@ export function RouteHudControlStrip({
                 label: 'Visualizations',
                 active: showVisualizations,
                 onClick: onToggleVisualizations ?? (() => { }),
+            },
+            {
+                id: 'training',
+                label: 'Training',
+                active: showTraining,
+                onClick: onToggleTraining ?? (() => { }),
             },
             {
                 id: 'intelNode',


### PR DESCRIPTION
## Summary
- add K3H4 training session API routes and file-backed service coverage
- add a dedicated notebook training panel with click-ops workflow controls and live logs
- extend HUD wiring and Playwright coverage for the new training flow

## Validation
- bun test src/routes/netcode.contract.test.ts
- PLAYWRIGHT_BASE_URL=http://localhost:5173 PLAYWRIGHT_API_BASE_URL=http://localhost:8081 bunx playwright test tests/playwright/k3h4-training-viz.spec.ts --reporter=list
