### PR TITLE
K3H4 authoritative training persistence + side-panel layout updates

### DIFF
--- a/src/typescript/api/src/routes/netcode.contract.test.ts
+++ b/src/typescript/api/src/routes/netcode.contract.test.ts
@@ -1173,6 +1173,16 @@ describe('K3H4 training integration routes', () => {
       }
       return {...CANONICAL_GEOMETRY, sessionId, epoch: epochIndex, mode};
     },
+    async recordEpochFromAnalytics(sessionId) {
+      if (sessionId === 'missing') {
+        throw new K3h4VizServiceError(
+            'session_not_found', `Session '${sessionId}' not found.`, 404);
+      }
+      return {
+        epochIndex: 2,
+        persistedAtUtc: '2026-06-17T00:02:00.000Z',
+      };
+    },
   });
 
   test('creates a training session with default power mode', async () => {
@@ -1237,6 +1247,66 @@ describe('K3H4 training integration routes', () => {
         peakEpoch: 1,
       },
     });
+
+    await app.close();
+  });
+
+  test('records a persisted training epoch snapshot', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/netcode/k3h4/training-session/sess-abc123/epoch',
+      payload: {
+        mode: 'power',
+        confidence: 0.61,
+        analytics: {
+          k3h4Projection: {
+            alignment: 62,
+            radialStability: 58,
+            nodes: [{x: 0.5, y: 0.2}],
+          },
+          k3h4: {
+            centers: [{clusterId: 0}],
+            radii: [{clusterId: 0, inscribedRadiusQ16: 32768}],
+            weightedVoronoiScores: [{clusterId: 0, weightedScoreQ16: 65536}],
+            spectralProxy: [{clusterId: 0, amplitudeProxyQ16: 4096}],
+          },
+          k3h4Runtime: {
+            spectralActivation: 'affinity-graph',
+          },
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({
+      contractVersion: 1,
+      sessionId: 'sess-abc123',
+      mode: 'power',
+      epochIndex: 2,
+    });
+
+    await app.close();
+  });
+
+  test('rejects invalid payload for persisted epoch recording', async () => {
+    const app = await createApp(createFakeNetcode({}), {
+      k3h4TrainingService: createTrainingService(),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/netcode/k3h4/training-session/sess-abc123/epoch',
+      payload: {
+        mode: 'power',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({error: 'invalid_epoch_payload'});
 
     await app.close();
   });

--- a/src/typescript/api/src/routes/netcode.ts
+++ b/src/typescript/api/src/routes/netcode.ts
@@ -51,6 +51,59 @@ function parseTrainingMode(rawMode: unknown): TrainingSessionMode|null {
   return null;
 }
 
+type RecordTrainingEpochPayload = {
+  mode?: TrainingSessionMode;
+  confidence?: number;
+  analytics?: {
+    k3h4Projection?: {
+      alignment?: number;
+      radialStability?: number;
+      nodes?: Array<{x?: number; y?: number}>;
+    };
+    k3h4?: {
+      centers?: Array<{clusterId?: number}>;
+      radii?: Array<{clusterId?: number; inscribedRadiusQ16?: number}>;
+      weightedVoronoiScores?:
+          Array<{clusterId?: number; weightedScoreQ16?: number}>;
+      spectralProxy?: Array<{clusterId?: number; amplitudeProxyQ16?: number}>;
+    };
+    k3h4Runtime?: {spectralActivation?: 'disabled' | 'affinity-graph';};
+  };
+};
+
+function isRecordTrainingEpochPayload(body: unknown):
+    body is Required<RecordTrainingEpochPayload> {
+  if (!body || typeof body !== 'object') {
+    return false;
+  }
+
+  const payload = body as RecordTrainingEpochPayload;
+  if (!isFiniteNumber(payload.confidence) || !payload.analytics) {
+    return false;
+  }
+
+  const projection = payload.analytics.k3h4Projection;
+  const k3h4 = payload.analytics.k3h4;
+  const runtime = payload.analytics.k3h4Runtime;
+
+  if (!projection || !k3h4 || !runtime) {
+    return false;
+  }
+
+  if (!isFiniteNumber(projection.alignment) ||
+      !isFiniteNumber(projection.radialStability) ||
+      !Array.isArray(projection.nodes) || !Array.isArray(k3h4.centers) ||
+      !Array.isArray(k3h4.radii) ||
+      !Array.isArray(k3h4.weightedVoronoiScores) ||
+      !Array.isArray(k3h4.spectralProxy) ||
+      (runtime.spectralActivation !== 'disabled' &&
+       runtime.spectralActivation !== 'affinity-graph')) {
+    return false;
+  }
+
+  return true;
+}
+
 function resolveNetcodeK3h4Rollout(): NetcodeK3h4Rollout {
   const enabledRaw =
       (process.env.BANANA_NETCODE_K3H4_ENABLED ?? 'true').trim().toLowerCase();
@@ -405,6 +458,113 @@ export async function registerNetcodeRoutes(
         const session = await trainingService.createTrainingSession(mode);
         return reply.status(201).send(session);
       });
+
+  app.post<{Params: {id: string}; Body: RecordTrainingEpochPayload}>(
+      '/api/netcode/k3h4/training-session/:id/epoch',
+      async (request, reply) => {
+        const mode = parseTrainingMode(request.body?.mode);
+        if (!mode) {
+          return reply.status(400).send({
+            error: 'invalid_mode',
+            message:
+                'mode must be either multiplicative or power when provided.',
+          });
+        }
+
+        if (!isRecordTrainingEpochPayload(request.body)) {
+          return reply.status(400).send({
+            error: 'invalid_epoch_payload',
+            message:
+                'Epoch payload must include confidence and analytics snapshot fields.',
+          });
+        }
+
+        if (!trainingService.recordEpochFromAnalytics) {
+          return reply.status(503).send({
+            error: 'training_unavailable',
+            message: 'Epoch recording is not available for current runtime.',
+          });
+        }
+
+        try {
+          const persisted = await trainingService.recordEpochFromAnalytics(
+              request.params.id,
+              mode,
+              request.body.confidence,
+              {
+                k3h4Projection: {
+                  alignment: request.body.analytics.k3h4Projection.alignment,
+                  radialStability:
+                      request.body.analytics.k3h4Projection.radialStability,
+                  nodes: request.body.analytics.k3h4Projection.nodes.map(
+                      (node) => ({
+                        x: isFiniteNumber(node.x) ? node.x : 0,
+                        y: isFiniteNumber(node.y) ? node.y : 0,
+                      })),
+                },
+                k3h4: {
+                  centers: request.body.analytics.k3h4.centers.map(
+                      (center) => ({
+                        clusterId: isFiniteNumber(center.clusterId) ?
+                            center.clusterId :
+                            0,
+                      })),
+                  radii: request.body.analytics.k3h4.radii.map(
+                      (radius) => ({
+                        clusterId: isFiniteNumber(radius.clusterId) ?
+                            radius.clusterId :
+                            0,
+                        inscribedRadiusQ16:
+                            isFiniteNumber(radius.inscribedRadiusQ16) ?
+                            radius.inscribedRadiusQ16 :
+                            0,
+                      })),
+                  weightedVoronoiScores:
+                      request.body.analytics.k3h4.weightedVoronoiScores.map(
+                          (score) => ({
+                            clusterId: isFiniteNumber(score.clusterId) ?
+                                score.clusterId :
+                                0,
+                            weightedScoreQ16:
+                                isFiniteNumber(score.weightedScoreQ16) ?
+                                score.weightedScoreQ16 :
+                                0,
+                          })),
+                  spectralProxy: request.body.analytics.k3h4.spectralProxy.map(
+                      (spectral) => ({
+                        clusterId: isFiniteNumber(spectral.clusterId) ?
+                            spectral.clusterId :
+                            0,
+                        amplitudeProxyQ16:
+                            isFiniteNumber(spectral.amplitudeProxyQ16) ?
+                            spectral.amplitudeProxyQ16 :
+                            0,
+                      })),
+                },
+                k3h4Runtime: {
+                  spectralActivation:
+                      request.body.analytics.k3h4Runtime.spectralActivation,
+                },
+              },
+          );
+          return reply.status(201).send({
+            contractVersion: 1,
+            sessionId: request.params.id,
+            mode,
+            epochIndex: persisted.epochIndex,
+            persistedAtUtc: persisted.persistedAtUtc,
+          });
+        } catch (error) {
+          if (error instanceof K3h4VizServiceError) {
+            return reply.status(error.statusCode).send({
+              error: error.code,
+              message: error.message,
+            });
+          }
+          throw error;
+        }
+      },
+  );
 
   app.get<{Params: {id: string}; Querystring: {mode?: string}}>(
       '/api/netcode/k3h4/training-session/:id/confidence',

--- a/src/typescript/api/src/services/k3h4TrainingService.ts
+++ b/src/typescript/api/src/services/k3h4TrainingService.ts
@@ -59,8 +59,44 @@ export type EpochGeometry = {
                                                                                                                                                                                                                                                                             ProjectionMetadata;
 };
 
+export type EpochPersistenceAnalyticsSnapshot = {
+  readonly k3h4Projection: {
+    readonly alignment: number;
+    readonly radialStability: number;
+    readonly nodes: ReadonlyArray<{readonly x: number; readonly y: number;}>;
+  };
+  readonly k3h4: {
+    readonly centers: ReadonlyArray<{readonly clusterId: number}>;
+    readonly radii: ReadonlyArray<{
+      readonly clusterId: number;
+      readonly inscribedRadiusQ16: number;
+    }>;
+    readonly weightedVoronoiScores: ReadonlyArray<{
+      readonly clusterId: number;
+      readonly weightedScoreQ16: number;
+    }>;
+    readonly spectralProxy: ReadonlyArray<{
+      readonly clusterId: number;
+      readonly amplitudeProxyQ16: number;
+    }>;
+  };
+  readonly k3h4Runtime: {
+    readonly spectralActivation: 'disabled'|'affinity-graph';
+  };
+};
+
+export type RecordedEpochResult = {
+  readonly epochIndex: number; readonly persistedAtUtc: string;
+};
+
 export interface K3h4TrainingService {
   createTrainingSession(mode: TrainingSessionMode): Promise<TrainingSession>;
+  recordEpochFromAnalytics?(
+      sessionId: string,
+      mode: TrainingSessionMode,
+      confidence: number,
+      analytics: EpochPersistenceAnalyticsSnapshot,
+      ): Promise<RecordedEpochResult>;
   readConfidenceTimeSeries(sessionId: string, mode: TrainingSessionMode):
       Promise<ConfidenceTimeSeries>;
   readEpochGeometry(
@@ -174,6 +210,17 @@ function computeRollingAverage3(values: readonly number[]): number|null {
   if (values.length < 3) return null;
   const slice = values.slice(values.length - 3);
   return Number((slice[0] + slice[1] + slice[2]) / 3);
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+function q16ToFloat(value: number): number {
+  return Number.isFinite(value) ? value / 65536 : 0;
 }
 
 /** Build a regular octagon centred at (cx, cy) with the given radius. */
@@ -412,6 +459,138 @@ function decodeArtifactGeometry(
   };
 }
 
+type PersistedEpochOverlay = {
+  readonly contractVersion: 1; readonly sessionId: string; readonly epochIndex: number; readonly mode: TrainingSessionMode; readonly confidence: number; readonly persistedAtUtc: string; readonly geometry: {
+    readonly spectralActive: boolean; readonly clusters: ReadonlyArray<ClusterGeometry2d>; readonly tokens: ReadonlyArray<TokenGeometry2d>; readonly projectionMetadata:
+                                                                                                                                                         ProjectionMetadata;
+  };
+};
+
+function buildGeometryFromSnapshot(
+    sessionId: string,
+    epochIndex: number,
+    mode: TrainingSessionMode,
+    analytics: EpochPersistenceAnalyticsSnapshot,
+    ): EpochGeometry {
+  const weightedByCluster = new Map < number, {
+    sum: number;
+    count: number
+  }
+  >();
+  for (const score of analytics.k3h4.weightedVoronoiScores) {
+    const current =
+        weightedByCluster.get(score.clusterId) ?? {sum: 0, count: 0};
+    weightedByCluster.set(score.clusterId, {
+      sum: current.sum + q16ToFloat(score.weightedScoreQ16),
+      count: current.count + 1,
+    });
+  }
+
+  const radiusByCluster = new Map<number, number>();
+  for (const radius of analytics.k3h4.radii) {
+    radiusByCluster.set(
+        radius.clusterId, q16ToFloat(radius.inscribedRadiusQ16));
+  }
+
+  const spectralByCluster = new Map<number, number>();
+  for (const spectral of analytics.k3h4.spectralProxy) {
+    spectralByCluster.set(
+        spectral.clusterId, q16ToFloat(spectral.amplitudeProxyQ16));
+  }
+
+  const clusters: ClusterGeometry2d[] = analytics.k3h4.centers.map((center) => {
+    const centroid =
+        analytics.k3h4Projection.nodes[center.clusterId] ?? {x: 0, y: 0};
+    const radius = radiusByCluster.get(center.clusterId) ?? 0;
+    const scoreStats = weightedByCluster.get(center.clusterId);
+    const weightedScore = scoreStats && scoreStats.count > 0 ?
+        scoreStats.sum / scoreStats.count :
+        0;
+    const spectralProxy = spectralByCluster.get(center.clusterId) ?? 0;
+
+    return {
+      clusterId: center.clusterId,
+      centroid,
+      inscribedRadius: radius,
+      weightedScore,
+      spectralProxy,
+      polygon: octagonPolygon(centroid.x, centroid.y, radius),
+    };
+  });
+
+  const tokens: TokenGeometry2d[] =
+      clusters.map((cluster) => ({
+                     tokenId: `cluster-${cluster.clusterId}`,
+                     x: cluster.centroid.x,
+                     y: cluster.centroid.y,
+                     clusterId: cluster.clusterId,
+                     weightedScore: cluster.weightedScore,
+                   }));
+
+  return {
+    contractVersion: 1,
+    sessionId,
+    epoch: epochIndex,
+    mode,
+    spectralActive: analytics.k3h4Runtime.spectralActivation !== 'disabled',
+    clusters,
+    tokens,
+    projectionMetadata: {
+      method: 'pca',
+      components: 2,
+      explainedVariance: clampUnit(analytics.k3h4Projection.alignment / 100),
+      dimensionality: 3,
+    },
+  };
+}
+
+async function readEpochOverlay(
+    sessionDir: string,
+    epochIndex: number,
+    ): Promise<PersistedEpochOverlay|null> {
+  const overlayPath = path.join(sessionDir, `epoch-${epochIndex}.overlay.json`);
+  try {
+    const raw = await fs.readFile(overlayPath, 'utf8');
+    return JSON.parse(raw) as PersistedEpochOverlay;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return null;
+    }
+    throw new K3h4VizServiceError(
+        'training_unavailable',
+        `Failed to read persisted epoch overlay: ${
+            error instanceof Error ? error.message : String(error)}`,
+        503,
+    );
+  }
+}
+
+async function listEpochOverlays(sessionDir: string):
+    Promise<PersistedEpochOverlay[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(sessionDir);
+  } catch {
+    return [];
+  }
+
+  const overlays: PersistedEpochOverlay[] = [];
+  for (const entry of entries) {
+    const match = /^epoch-(\d+)\.overlay\.json$/.exec(entry);
+    if (!match) {
+      continue;
+    }
+    const epochIndex = Number(match[1]);
+    const overlay = await readEpochOverlay(sessionDir, epochIndex);
+    if (overlay) {
+      overlays.push(overlay);
+    }
+  }
+  overlays.sort((a, b) => a.epochIndex - b.epochIndex);
+  return overlays;
+}
+
 export function createFileSystemK3h4TrainingService(): K3h4TrainingService {
   const artifactRoot = resolveTrainingArtifactRoot();
 
@@ -431,6 +610,55 @@ export function createFileSystemK3h4TrainingService(): K3h4TrainingService {
 
           return {sessionId, mode, createdAtUtc};
         },
+
+    async recordEpochFromAnalytics(
+        sessionId: string,
+        mode: TrainingSessionMode,
+        confidence: number,
+        analytics: EpochPersistenceAnalyticsSnapshot,
+        ): Promise<RecordedEpochResult> {
+      validateSessionId(sessionId);
+      const sessionDir = path.join(artifactRoot, sessionId);
+
+      try {
+        await fs.access(sessionDir);
+      } catch {
+        throw new K3h4VizServiceError(
+            'session_not_found',
+            `Training session '${sessionId}' was not found.`,
+            404,
+        );
+      }
+
+      const overlayRecords = await listEpochOverlays(sessionDir);
+      const nextEpochIndex = overlayRecords.length === 0 ?
+          0 :
+          overlayRecords[overlayRecords.length - 1]!.epochIndex + 1;
+
+      const geometry =
+          buildGeometryFromSnapshot(sessionId, nextEpochIndex, mode, analytics);
+      const persistedAtUtc = new Date().toISOString();
+      const record: PersistedEpochOverlay = {
+        contractVersion: 1,
+        sessionId,
+        epochIndex: nextEpochIndex,
+        mode,
+        confidence: clampUnit(confidence),
+        persistedAtUtc,
+        geometry: {
+          spectralActive: geometry.spectralActive,
+          clusters: geometry.clusters,
+          tokens: geometry.tokens,
+          projectionMetadata: geometry.projectionMetadata,
+        },
+      };
+
+      const outPath =
+          path.join(sessionDir, `epoch-${nextEpochIndex}.overlay.json`);
+      await fs.writeFile(outPath, JSON.stringify(record), 'utf8');
+
+      return {epochIndex: nextEpochIndex, persistedAtUtc};
+    },
 
     async readConfidenceTimeSeries(
         sessionId: string,
@@ -495,11 +723,27 @@ export function createFileSystemK3h4TrainingService(): K3h4TrainingService {
         }
       }
 
-      const status: SessionStatus = epochs.length === 0 ? 'pending' : 'active';
-      const confidences = epochs.map((epoch) => epoch.confidence);
-      const peakEpoch = epochs.length === 0 ?
+      const overlays = await listEpochOverlays(sessionDir);
+      for (const overlay of overlays) {
+        epochs.push({
+          epochIndex: overlay.epochIndex,
+          confidence: overlay.confidence,
+          mode,
+        });
+      }
+
+      const dedupedEpochs =
+          Array
+              .from(new Map(epochs.map((epoch) => [epoch.epochIndex, epoch]))
+                        .values())
+              .sort((a, b) => a.epochIndex - b.epochIndex);
+
+      const status: SessionStatus =
+          dedupedEpochs.length === 0 ? 'pending' : 'active';
+      const confidences = dedupedEpochs.map((epoch) => epoch.confidence);
+      const peakEpoch = dedupedEpochs.length === 0 ?
           null :
-          epochs
+          dedupedEpochs
               .reduce(
                   (best, current) =>
                       current.confidence > best.confidence ? current : best)
@@ -510,7 +754,7 @@ export function createFileSystemK3h4TrainingService(): K3h4TrainingService {
         sessionId,
         status,
         mode,
-        epochs,
+        epochs: dedupedEpochs,
         metadata: {
           peakEpoch,
           rollingAverage3: computeRollingAverage3(confidences),
@@ -549,6 +793,21 @@ export function createFileSystemK3h4TrainingService(): K3h4TrainingService {
                 'session_not_found',
                 `Training session '${sessionId}' was not found.`, 404);
           }
+
+          const overlay = await readEpochOverlay(sessionDir, epochIndex);
+          if (overlay) {
+            return {
+              contractVersion: 1,
+              sessionId,
+              epoch: overlay.epochIndex,
+              mode,
+              spectralActive: overlay.geometry.spectralActive,
+              clusters: overlay.geometry.clusters,
+              tokens: overlay.geometry.tokens,
+              projectionMetadata: overlay.geometry.projectionMetadata,
+            };
+          }
+
           throw new K3h4VizServiceError(
               'artifact_not_found',
               `Epoch ${epochIndex} artifact not found for session '${

--- a/src/typescript/react/src/components/notebook-client/NotebookGameplaySurface.tsx
+++ b/src/typescript/react/src/components/notebook-client/NotebookGameplaySurface.tsx
@@ -917,58 +917,6 @@ export function NotebookGameplaySurface({
                     </div>
                 ) : null}
 
-                {!analyticsAvailability.available ? (
-                    <div style={{
-                        position: 'absolute',
-                        top: 16,
-                        right: 16,
-                        zIndex: 5,
-                        borderRadius: 12,
-                        border: '1px solid rgba(244, 63, 94, 0.55)',
-                        background: 'linear-gradient(140deg, rgba(76, 5, 25, 0.92), rgba(67, 20, 7, 0.85))',
-                        color: '#fecdd3',
-                        padding: '10px 12px',
-                        fontSize: 11,
-                        letterSpacing: '0.05em',
-                        textTransform: 'uppercase',
-                        fontWeight: 700,
-                        boxShadow: '0 12px 24px rgba(76, 5, 25, 0.35)',
-                    }}>
-                        Analytics unavailable · {analyticsAvailability.reason} · cohort {analyticsAvailability.rollout.cohort}
-                    </div>
-                ) : null}
-
-                {analyticsAvailability.available ? (
-                    <div style={{
-                        position: 'absolute',
-                        top: 16,
-                        right: 16,
-                        zIndex: 5,
-                        borderRadius: 12,
-                        border: `1px solid ${abiLayerCoverage.complete ? 'rgba(16, 185, 129, 0.52)' : 'rgba(251, 191, 36, 0.55)'}`,
-                        background: abiLayerCoverage.complete
-                            ? 'linear-gradient(140deg, rgba(6, 78, 59, 0.9), rgba(6, 95, 70, 0.82))'
-                            : 'linear-gradient(140deg, rgba(120, 53, 15, 0.9), rgba(146, 64, 14, 0.82))',
-                        color: abiLayerCoverage.complete ? '#d1fae5' : '#fef3c7',
-                        padding: '10px 12px',
-                        fontSize: 11,
-                        letterSpacing: '0.05em',
-                        textTransform: 'uppercase',
-                        fontWeight: 700,
-                        boxShadow: abiLayerCoverage.complete
-                            ? '0 12px 24px rgba(6, 78, 59, 0.35)'
-                            : '0 12px 24px rgba(120, 53, 15, 0.35)',
-                        display: 'grid',
-                        gap: 4,
-                        maxWidth: 340,
-                    }}>
-                        <span>ABI coverage {abiCoverageSummary} · {abiCoveragePercent}% · {abiCoverageState}</span>
-                        <span style={{ fontSize: 10, color: abiLayerCoverage.complete ? 'rgba(187, 247, 208, 0.92)' : 'rgba(254, 240, 138, 0.92)' }}>
-                            missing: {abiCoverageMissing}
-                        </span>
-                    </div>
-                ) : null}
-
                 <GameplayTopHud
                     selectedFile={selectedFile}
                     missionCode={missionSector.code}

--- a/src/typescript/react/src/domain/notebook/viz/useK3h4TrainingSession.ts
+++ b/src/typescript/react/src/domain/notebook/viz/useK3h4TrainingSession.ts
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 
-import {createK3h4TrainingSession, fetchK3h4ConfidenceTimeSeries, fetchK3h4EpochGeometry, fetchNetcodeAnalytics, type K3h4ConfidenceTimeSeries, type K3h4TrainingMode, type K3h4TrainingSession, type NetcodeAnalyticsRequest, resolveApiBaseUrl,} from '../../../lib/api';
+import {createK3h4TrainingSession, fetchK3h4ConfidenceTimeSeries, fetchK3h4EpochGeometry, fetchNetcodeAnalytics, type K3h4ConfidenceTimeSeries, type K3h4EpochConfidence, type K3h4TrainingMode, type K3h4TrainingSession, NetcodeAnalyticsError, type NetcodeAnalyticsRequest, type NetcodeAnalyticsResponse, recordK3h4TrainingEpoch, resolveApiBaseUrl,} from '../../../lib/api';
 import type {K3h4EpochGeometryResponse} from '../../../lib/k3h4GeometryTypes';
 
 const STORAGE_KEY = 'banana-k3h4-training-session';
@@ -53,8 +53,223 @@ const WORKFLOW_PASS_COUNT: Record<K3h4TrainingWorkflow, number> = {
   churn: 96,
 };
 
+const RATE_LIMIT_MAX_RETRIES_PER_PASS = 6;
+const RATE_LIMIT_BACKOFF_BASE_MS = 1200;
+const RATE_LIMIT_BACKOFF_MAX_MS = 20000;
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseRetryAfterMs(message: string): number|null {
+  const retryAfterMatch =
+      /retry\s*after\s*(\d+(?:\.\d+)?)\s*(ms|s|sec|secs|second|seconds|m|min|mins|minute|minutes)?/i
+          .exec(message);
+  if (!retryAfterMatch) {
+    return null;
+  }
+
+  const value = Number(retryAfterMatch[1]);
+  if (!Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+
+  const unit = (retryAfterMatch[2] ?? 's').toLowerCase();
+  if (unit === 'ms') {
+    return Math.round(value);
+  }
+  if (unit.startsWith('m')) {
+    return Math.round(value * 60000);
+  }
+  return Math.round(value * 1000);
+}
+
+function computeRateLimitBackoffMs(attemptIndex: number): number {
+  const exponential = Math.min(
+      RATE_LIMIT_BACKOFF_MAX_MS,
+      RATE_LIMIT_BACKOFF_BASE_MS * (2 ** Math.max(0, attemptIndex)),
+  );
+  const jitter = Math.floor(Math.random() * 350);
+  return Math.min(RATE_LIMIT_BACKOFF_MAX_MS, exponential + jitter);
+}
+
+function resolveRateLimitWaitMs(
+    error: unknown,
+    attemptIndex: number,
+    ): number|null {
+  if (error instanceof NetcodeAnalyticsError) {
+    if (error.status !== 429) {
+      return null;
+    }
+
+    const payloadMessage = typeof error.payload.message === 'string' ?
+        error.payload.message :
+        typeof error.payload.error === 'string' ? error.payload.error :
+                                                  '';
+    const fromPayload = parseRetryAfterMs(payloadMessage);
+    if (fromPayload !== null) {
+      return fromPayload;
+    }
+    const fromMessage = parseRetryAfterMs(error.message);
+    if (fromMessage !== null) {
+      return fromMessage;
+    }
+
+    return computeRateLimitBackoffMs(attemptIndex);
+  }
+
+  const message = extractErrorMessage(error);
+  if (!/rate\s*limit|too\s*many\s*requests|throttl/i.test(message)) {
+    return null;
+  }
+
+  const hintedWait = parseRetryAfterMs(message);
+  if (hintedWait !== null) {
+    return hintedWait;
+  }
+
+  return computeRateLimitBackoffMs(attemptIndex);
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+function clampSigned(value: number, magnitude: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(magnitude, Math.max(-magnitude, value));
+}
+
+type K3h4FeatureVector = {
+  readonly scoreSignal: number; readonly stabilitySignal: number; readonly spectralSignal: number; readonly convergenceSignal: number; readonly clusterCount:
+                                                                                                                                                    number;
+};
+
+type K3h4AdaptiveState = {
+  readonly modelConfidenceBias: number; readonly policyMomentumBias: number; readonly callDensityBias: number; readonly dependencyPulseBias: number; readonly interactionSignalBias: number; readonly stagnantPasses: number; readonly previousFeature:
+                                                                                                                                                                                                                                           K3h4FeatureVector |
+      null;
+};
+
+function createInitialAdaptiveState(): K3h4AdaptiveState {
+  return {
+    modelConfidenceBias: 0,
+    policyMomentumBias: 0,
+    callDensityBias: 0,
+    dependencyPulseBias: 0,
+    interactionSignalBias: 0,
+    stagnantPasses: 0,
+    previousFeature: null,
+  };
+}
+
+function extractK3h4FeatureVector(analytics: NetcodeAnalyticsResponse):
+    K3h4FeatureVector {
+  const weighted = analytics.k3h4.weightedVoronoiScores;
+  const radii = analytics.k3h4.radii;
+  const spectral = analytics.k3h4.spectralProxy;
+
+  const validScoreCount =
+      weighted.filter((score) => score.scoreValidity === 'valid').length;
+  const validScoreRatio =
+      weighted.length > 0 ? validScoreCount / weighted.length : 0;
+
+  const stableRadiusCount =
+      radii.filter((radius) => radius.radiusState === 'ok').length;
+  const stableRadiusRatio =
+      radii.length > 0 ? stableRadiusCount / radii.length : 0;
+
+  const spectralStrength = spectral.length > 0 ?
+      spectral.reduce(
+          (sum, entry) => sum + Math.abs(entry.frequencyProxyQ16) +
+              Math.abs(entry.amplitudeProxyQ16),
+          0,
+          ) /
+          (spectral.length * 131072) :
+      0;
+
+  const alignmentSignal = clampUnit(analytics.k3h4Projection.alignment / 100);
+  const radialStabilitySignal =
+      clampUnit(analytics.k3h4Projection.radialStability / 100);
+  const scoreSignal =
+      clampUnit(validScoreRatio * 0.55 + alignmentSignal * 0.45);
+  const stabilitySignal =
+      clampUnit(stableRadiusRatio * 0.5 + radialStabilitySignal * 0.5);
+
+  const convergenceSignal =
+      analytics.k3h4.observability.convergenceStatus === 'converged' ? 1 :
+      analytics.k3h4.observability.convergenceStatus === 'max-iterations' ?
+                                                                       0.5 :
+                                                                       0;
+
+  return {
+    scoreSignal,
+    stabilitySignal,
+    spectralSignal: clampUnit(spectralStrength),
+    convergenceSignal,
+    clusterCount: analytics.k3h4.centers.length,
+  };
+}
+
+function evolveAdaptiveState(
+    previous: K3h4AdaptiveState,
+    nextFeature: K3h4FeatureVector,
+    ): K3h4AdaptiveState {
+  const previousComposite = previous.previousFeature ?
+      previous.previousFeature.scoreSignal * 0.45 +
+          previous.previousFeature.stabilitySignal * 0.35 +
+          previous.previousFeature.convergenceSignal * 0.20 :
+      nextFeature.scoreSignal * 0.45 + nextFeature.stabilitySignal * 0.35 +
+          nextFeature.convergenceSignal * 0.20;
+  const nextComposite = nextFeature.scoreSignal * 0.45 +
+      nextFeature.stabilitySignal * 0.35 + nextFeature.convergenceSignal * 0.20;
+  const delta = nextComposite - previousComposite;
+
+  const stagnantPasses =
+      Math.abs(delta) < 0.01 ? previous.stagnantPasses + 1 : 0;
+  const plateauBoost = Math.min(1, stagnantPasses / 4) * 0.03;
+
+  const directionalAdjust = clampSigned(delta * 0.35, 0.04);
+  const scoreTargetBias =
+      clampSigned((nextFeature.scoreSignal - 0.62) * 0.20, 0.05);
+  const stabilityTargetBias =
+      clampSigned((nextFeature.stabilitySignal - 0.58) * 0.18, 0.05);
+  const spectralTargetBias =
+      clampSigned((nextFeature.spectralSignal - 0.52) * 0.12, 0.04);
+
+  return {
+    modelConfidenceBias: clampSigned(
+        previous.modelConfidenceBias + directionalAdjust + scoreTargetBias -
+            plateauBoost,
+        0.12,
+        ),
+    policyMomentumBias: clampSigned(
+        previous.policyMomentumBias + directionalAdjust * 0.75 +
+            stabilityTargetBias,
+        0.12,
+        ),
+    callDensityBias: clampSigned(
+        previous.callDensityBias + plateauBoost + spectralTargetBias,
+        0.10,
+        ),
+    dependencyPulseBias: clampSigned(
+        previous.dependencyPulseBias + plateauBoost * 0.7 +
+            (nextFeature.clusterCount >= 4 ? 0.01 : -0.005),
+        0.10,
+        ),
+    interactionSignalBias: clampSigned(
+        previous.interactionSignalBias + directionalAdjust * 0.5 +
+            spectralTargetBias,
+        0.08,
+        ),
+    stagnantPasses,
+    previousFeature: nextFeature,
+  };
 }
 
 function extractErrorMessage(error: unknown): string {
@@ -111,10 +326,51 @@ function extractErrorMessage(error: unknown): string {
   return 'Unknown error';
 }
 
+function isSessionNotFoundMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return normalized.includes('session_not_found') ||
+      normalized.includes('training session not found') ||
+      normalized.includes('session not found');
+}
+
+function computeEpochConfidenceFromFeature(feature: K3h4FeatureVector): number {
+  const blended = feature.scoreSignal * 0.46 + feature.stabilitySignal * 0.34 +
+      feature.convergenceSignal * 0.20;
+  return clampUnit(blended);
+}
+
+function deriveMetadataFromEpochs(epochs: readonly K3h4EpochConfidence[]): {
+  readonly peakEpoch: number|null; readonly rollingAverage3: number | null; readonly defaultMode:
+                                                                                         'power';
+} {
+  if (epochs.length === 0) {
+    return {peakEpoch: null, rollingAverage3: null, defaultMode: 'power'};
+  }
+
+  const peak = epochs.reduce(
+      (best, current) => current.confidence > best.confidence ? current : best,
+      epochs[0]!,
+  );
+  const rollingAverage3 = epochs.length >= 3 ?
+      Number(
+          (epochs[epochs.length - 1]!.confidence +
+           epochs[epochs.length - 2]!.confidence +
+           epochs[epochs.length - 3]!.confidence) /
+          3) :
+      null;
+
+  return {
+    peakEpoch: peak.epochIndex,
+    rollingAverage3,
+    defaultMode: 'power',
+  };
+}
+
 function buildAnalyticsPayload(params: {
   workflow: K3h4TrainingWorkflow; mode: K3h4TrainingMode; passIndex: number;
+  adaptive: K3h4AdaptiveState;
 }): NetcodeAnalyticsRequest {
-  const {workflow, mode, passIndex} = params;
+  const {workflow, mode, passIndex, adaptive} = params;
   const wave = Math.sin(passIndex / 3);
   const sweep = Math.cos(passIndex / 5);
   const workflowDepth = workflow === 'bootstrap' ? 1 :
@@ -122,17 +378,22 @@ function buildAnalyticsPayload(params: {
                                                    3;
 
   return {
-    callDensity: 0.42 + (wave + 1) * 0.14,
+    callDensity: clampUnit(0.42 + (wave + 1) * 0.14 + adaptive.callDensityBias),
     questPercent: 0.38 + (sweep + 1) * 0.18,
     playerLevel: 7 + (passIndex % 18),
     comboStreak: 2 + (passIndex % 9),
     branchPressure: 0.32 + (Math.abs(wave) * 0.36),
-    dependencyPulse: 0.34 + (Math.abs(sweep) * 0.34),
+    dependencyPulse: clampUnit(
+        0.34 + (Math.abs(sweep) * 0.34) + adaptive.dependencyPulseBias),
     workflowDepth,
     networkDimensions: workflow === 'churn' ? 4 : 3,
-    modelConfidence: 0.35 + (Math.abs(wave) * 0.55),
-    policyMomentum: 0.33 + (Math.abs(sweep) * 0.58),
-    interactionSignal: 0.44 + ((wave + sweep + 2) / 4) * 0.45,
+    modelConfidence: clampUnit(
+        0.35 + (Math.abs(wave) * 0.55) + adaptive.modelConfidenceBias),
+    policyMomentum: clampUnit(
+        0.33 + (Math.abs(sweep) * 0.58) + adaptive.policyMomentumBias),
+    interactionSignal: clampUnit(
+        0.44 + ((wave + sweep + 2) / 4) * 0.45 +
+        adaptive.interactionSignalBias),
     k3h4Mode: mode,
     spectralMode: workflow === 'relations' || workflow === 'churn' ?
         'affinity-graph' :
@@ -355,6 +616,8 @@ export function useK3h4TrainingSession(): UseK3h4TrainingSessionResult {
     }
 
     void (async () => {
+      let adaptiveState = createInitialAdaptiveState();
+
       for (let passIndex = 0; passIndex < totalPasses; passIndex += 1) {
         if (workflowRunIdRef.current !== runId) {
           return;
@@ -364,37 +627,178 @@ export function useK3h4TrainingSession(): UseK3h4TrainingSessionResult {
           workflow,
           mode: session.mode,
           passIndex,
+          adaptive: adaptiveState,
         });
 
-        try {
-          const analytics = await fetchNetcodeAnalytics(baseUrl, payload);
-          appendWorkflowLog({
-            level: 'info',
-            message: `Pass ${passIndex + 1}/${totalPasses} complete`,
-            details: `depth=${payload.workflowDepth} density=${
-                payload.callDensity.toFixed(3)} confidence=${
-                payload.modelConfidence.toFixed(
-                    3)} clusters=${analytics.k3h4.centers.length} convergence=${
-                analytics.k3h4.observability.convergenceStatus}`,
-          });
-        } catch (error) {
+        let completedPass = false;
+        let rateLimitRetries = 0;
+
+        while (!completedPass) {
           if (workflowRunIdRef.current !== runId) {
             return;
           }
-          const message = extractErrorMessage(error);
-          setWorkflowState({
-            status: 'error',
-            workflow,
-            totalPasses,
-            completedPasses: passIndex,
-            errorMessage: message,
-          });
-          appendWorkflowLog({
-            level: 'error',
-            message: `Workflow error at pass ${passIndex + 1}/${totalPasses}`,
-            details: message,
-          });
-          return;
+
+          try {
+            const analytics = await fetchNetcodeAnalytics(baseUrl, payload);
+            const featureVector = extractK3h4FeatureVector(analytics);
+            adaptiveState = evolveAdaptiveState(adaptiveState, featureVector);
+
+            appendWorkflowLog({
+              level: 'info',
+              message: `Pass ${passIndex + 1}/${totalPasses} complete`,
+              details: `depth=${payload.workflowDepth} density=${
+                  payload.callDensity.toFixed(3)} confidence=${
+                  payload.modelConfidence.toFixed(3)} clusters=${
+                  analytics.k3h4.centers.length} convergence=${
+                  analytics.k3h4.observability
+                      .convergenceStatus} featureScore=${
+                  featureVector.scoreSignal.toFixed(3)} stability=${
+                  featureVector.stabilitySignal.toFixed(3)}`,
+            });
+
+            const derivedConfidence =
+                computeEpochConfidenceFromFeature(featureVector);
+
+            const persisted = await recordK3h4TrainingEpoch(
+                baseUrl,
+                session.sessionId,
+                {
+                  mode: session.mode,
+                  confidence: derivedConfidence,
+                  analytics: {
+                    k3h4Projection: {
+                      alignment: analytics.k3h4Projection.alignment,
+                      radialStability: analytics.k3h4Projection.radialStability,
+                      nodes: analytics.k3h4Projection.nodes.map((node) => ({
+                                                                  x: node.x,
+                                                                  y: node.y,
+                                                                })),
+                    },
+                    k3h4: {
+                      centers: analytics.k3h4.centers.map(
+                          (center) => ({
+                            clusterId: center.clusterId,
+                          })),
+                      radii: analytics.k3h4.radii.map(
+                          (radius) => ({
+                            clusterId: radius.clusterId,
+                            inscribedRadiusQ16: radius.inscribedRadiusQ16,
+                          })),
+                      weightedVoronoiScores:
+                          analytics.k3h4.weightedVoronoiScores.map(
+                              (score) => ({
+                                clusterId: score.clusterId,
+                                weightedScoreQ16: score.weightedScoreQ16,
+                              })),
+                      spectralProxy: analytics.k3h4.spectralProxy.map(
+                          (spectral) => ({
+                            clusterId: spectral.clusterId,
+                            amplitudeProxyQ16: spectral.amplitudeProxyQ16,
+                          })),
+                    },
+                    k3h4Runtime: {
+                      spectralActivation:
+                          analytics.k3h4Runtime.spectralActivation,
+                    },
+                  },
+                },
+            );
+
+            setConfidence((existing) => {
+              const baseSeries: K3h4ConfidenceTimeSeries = existing ?? {
+                contractVersion: 1,
+                sessionId: session.sessionId,
+                status: 'pending',
+                mode: session.mode,
+                epochs: [],
+                metadata: {
+                  peakEpoch: null,
+                  rollingAverage3: null,
+                  defaultMode: 'power',
+                },
+              };
+              const mergedByEpoch = new Map<number, K3h4EpochConfidence>();
+              for (const epoch of baseSeries.epochs) {
+                mergedByEpoch.set(epoch.epochIndex, epoch);
+              }
+              mergedByEpoch.set(persisted.epochIndex, {
+                epochIndex: persisted.epochIndex,
+                confidence: derivedConfidence,
+                mode: session.mode,
+              });
+              const mergedEpochs =
+                  Array.from(mergedByEpoch.values())
+                      .sort((a, b) => a.epochIndex - b.epochIndex);
+              return {
+                ...baseSeries,
+                status: mergedEpochs.length > 0 ? 'active' : baseSeries.status,
+                epochs: mergedEpochs,
+                metadata: deriveMetadataFromEpochs(mergedEpochs),
+              };
+            });
+
+            completedPass = true;
+          } catch (error) {
+            if (workflowRunIdRef.current !== runId) {
+              return;
+            }
+
+            const message = extractErrorMessage(error);
+            if (isSessionNotFoundMessage(message)) {
+              writeStoredSession(null);
+              setSession(null);
+              setConfidence(null);
+              setLatestGeometry(null);
+              setPhase('idle');
+              setErrorMessage(
+                  'Training session expired on server. Start a new session and rerun workflow.',
+              );
+              setWorkflowState({
+                status: 'error',
+                workflow,
+                totalPasses,
+                completedPasses: passIndex,
+                errorMessage:
+                    'Training session expired on server. Start a new session and rerun workflow.',
+              });
+              appendWorkflowLog({
+                level: 'warn',
+                message:
+                    'Workflow stopped: server session was not found; local session has been reset',
+                details: message,
+              });
+              return;
+            }
+
+            const waitMs = resolveRateLimitWaitMs(error, rateLimitRetries);
+            if (waitMs !== null &&
+                rateLimitRetries < RATE_LIMIT_MAX_RETRIES_PER_PASS) {
+              rateLimitRetries += 1;
+              appendWorkflowLog({
+                level: 'warn',
+                message: `Rate limit detected at pass ${passIndex + 1}/${
+                    totalPasses}; waiting before retry`,
+                details: `retry=${rateLimitRetries}/${
+                    RATE_LIMIT_MAX_RETRIES_PER_PASS} waitMs=${waitMs}`,
+              });
+              await delay(waitMs);
+              continue;
+            }
+
+            setWorkflowState({
+              status: 'error',
+              workflow,
+              totalPasses,
+              completedPasses: passIndex,
+              errorMessage: message,
+            });
+            appendWorkflowLog({
+              level: 'error',
+              message: `Workflow error at pass ${passIndex + 1}/${totalPasses}`,
+              details: message,
+            });
+            return;
+          }
         }
 
         if (workflowRunIdRef.current !== runId) {

--- a/src/typescript/react/src/lib/api.ts
+++ b/src/typescript/react/src/lib/api.ts
@@ -1,5 +1,6 @@
 type ErrorPayload = {
-  error?: {message?: string};
+  error?: {message?: string}|string;
+  message?: string;
 };
 
 import type {LaunchGateReasonCode, LaunchGateStatusResponse, LaunchGateVerifyResponse} from './launchGateTypes';
@@ -487,7 +488,19 @@ export function resolveGameSessionWebSocketUrl(
 async function parseApiError(response: Response): Promise<string> {
   try {
     const payload = (await response.json()) as ErrorPayload;
-    return payload.error?.message ?? `request failed (${response.status})`;
+    if (typeof payload.message === 'string' &&
+        payload.message.trim().length > 0) {
+      return payload.message;
+    }
+    if (typeof payload.error === 'string' && payload.error.trim().length > 0) {
+      return payload.error;
+    }
+    if (payload.error && typeof payload.error === 'object' &&
+        typeof payload.error.message === 'string' &&
+        payload.error.message.trim().length > 0) {
+      return payload.error.message;
+    }
+    return `request failed (${response.status})`;
   } catch {
     return `request failed (${response.status})`;
   }
@@ -1140,6 +1153,41 @@ export type K3h4ConfidenceTimeSeries = {
   };
 };
 
+export type K3h4RecordEpochRequest = {
+  readonly mode: K3h4TrainingMode;
+  readonly confidence: number;
+  readonly analytics: {
+    readonly k3h4Projection: {
+      readonly alignment: number;
+      readonly radialStability: number;
+      readonly nodes: ReadonlyArray<{readonly x: number; readonly y: number}>;
+    };
+    readonly k3h4: {
+      readonly centers: ReadonlyArray<{readonly clusterId: number}>;
+      readonly radii: ReadonlyArray<{
+        readonly clusterId: number;
+        readonly inscribedRadiusQ16: number;
+      }>;
+      readonly weightedVoronoiScores: ReadonlyArray<{
+        readonly clusterId: number;
+        readonly weightedScoreQ16: number;
+      }>;
+      readonly spectralProxy: ReadonlyArray<{
+        readonly clusterId: number;
+        readonly amplitudeProxyQ16: number;
+      }>;
+    };
+    readonly k3h4Runtime: {
+      readonly spectralActivation: 'disabled'|'affinity-graph';
+    };
+  };
+};
+
+export type K3h4RecordEpochResponse = {
+  readonly contractVersion: 1; readonly sessionId: string; readonly mode: K3h4TrainingMode; readonly epochIndex: number; readonly persistedAtUtc:
+                                                                                                                                      string;
+};
+
 export async function createK3h4TrainingSession(
     baseUrl: string,
     mode: K3h4TrainingMode = 'power',
@@ -1165,5 +1213,22 @@ export async function fetchK3h4ConfidenceTimeSeries(
       baseUrl,
       `/api/netcode/k3h4/training-session/${
           encodeURIComponent(sessionId)}/confidence?${query}`,
+  );
+}
+
+export async function recordK3h4TrainingEpoch(
+    baseUrl: string,
+    sessionId: string,
+    payload: K3h4RecordEpochRequest,
+    ): Promise<K3h4RecordEpochResponse> {
+  return fetchApiJson<K3h4RecordEpochResponse>(
+      baseUrl,
+      `/api/netcode/k3h4/training-session/${
+          encodeURIComponent(sessionId)}/epoch`,
+      {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify(payload),
+      },
   );
 }

--- a/src/typescript/react/src/pages/DataSciencePlaygroundPage.tsx
+++ b/src/typescript/react/src/pages/DataSciencePlaygroundPage.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'r
 import { useLocation } from 'react-router-dom';
 
 import { MainMenuPanel } from '../components/notebook-client/MainMenuPanel';
-import { ModeRegistryPanel } from '../components/notebook-client/ModeRegistryPanel';
 import { ObjectivesDockPanel } from '../components/notebook-client/NotebookDockPanels';
 import { NotebookExplorerPanel } from '../components/notebook-client/NotebookExplorerPanel';
 import { NotebookGameplaySurface } from '../components/notebook-client/NotebookGameplaySurface';
@@ -75,8 +74,8 @@ const panelResetDefaults: Record<NotebookHudPanelId, number> = {
     menu: 0,
     status: 0,
     operations: 0,
-    visualizations: 0,
-    training: 0,
+    visualizations: 1,
+    training: 1,
     intelNode: 0,
     objectiveNode: 0,
     playerNode: 0,
@@ -94,8 +93,8 @@ const panelDefaultSizes: Record<NotebookHudPanelId, { width: number; height: num
     objectiveNode: { width: 360, height: 260 },
     nodeOps: { width: 360, height: 220 },
     operations: { width: 360, height: 240 },
-    visualizations: { width: 460, height: 380 },
-    training: { width: 440, height: 420 },
+    visualizations: { width: 460, height: 680 },
+    training: { width: 440, height: 680 },
 };
 
 type NotebookAnalyticsTelemetry = {
@@ -198,7 +197,6 @@ export function DataSciencePlaygroundPage() {
     const setObjectivePanel = useNotebookLayoutStore((state) => state.setObjectivePanel);
     const [modeDeckAnimating, setModeDeckAnimating] = useState(false);
     const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-    const [transitionHistory, setTransitionHistory] = useState<Array<{ pathname: string; mode: NotebookRouteMode; time: string; }>>([]);
     const [capturedFiles, setCapturedFiles] = useState<string[]>([]);
     const [totalXp, setTotalXp] = useState(0);
     const [comboStreak, setComboStreak] = useState(0);
@@ -291,20 +289,6 @@ export function DataSciencePlaygroundPage() {
             window.clearTimeout(timer);
         };
     }, [routeHudPreset.mode]);
-
-    useEffect(() => {
-        const timestamp = new Date().toLocaleTimeString();
-        setTransitionHistory((previous) => {
-            const nextEntry = {
-                pathname: location.pathname,
-                mode: routeHudPreset.mode,
-                time: timestamp,
-            };
-
-            const deduped = previous.filter((entry) => !(entry.pathname === nextEntry.pathname && entry.mode === nextEntry.mode));
-            return [nextEntry, ...deduped].slice(0, 3);
-        });
-    }, [location.pathname, routeHudPreset.mode]);
 
     useEffect(() => {
         if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -664,13 +648,13 @@ export function DataSciencePlaygroundPage() {
     } as const;
 
     const dockLayout: Array<{ id: keyof typeof dockRenderers; corner: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'; title: string; }> = [
+        { id: 'visualizations', corner: 'top-left', title: 'VISUALIZATIONS' },
         { id: 'menu', corner: 'top-left', title: 'MAIN MENU' },
         { id: 'playerNode', corner: 'top-left', title: 'PLAYER NODE' },
+        { id: 'training', corner: 'top-right', title: 'TRAINING' },
         { id: 'explorer', corner: 'top-right', title: 'FILE EXPLORER' },
         { id: 'intelNode', corner: 'top-right', title: 'INTEL NODE' },
         { id: 'status', corner: 'bottom-left', title: 'ROUTE REGISTRY' },
-        { id: 'visualizations', corner: 'bottom-left', title: 'VISUALIZATIONS' },
-        { id: 'training', corner: 'bottom-left', title: 'TRAINING' },
         { id: 'questLog', corner: 'bottom-left', title: 'QUEST LOG' },
         { id: 'objectiveNode', corner: 'bottom-right', title: 'OBJECTIVE NODE' },
         { id: 'nodeOps', corner: 'bottom-right', title: 'NODE OPS' },
@@ -679,7 +663,7 @@ export function DataSciencePlaygroundPage() {
     const dockEntries = dockLayout.map((dock) => ({
         id: dock.id,
         corner: dock.corner,
-        visible: panelVisibility[dock.id],
+        visible: dock.id === 'visualizations' || dock.id === 'training' ? true : panelVisibility[dock.id],
         content: dockRenderers[dock.id],
         title: dock.title,
         defaultWidth: panelDefaultSizes[dock.id].width,
@@ -690,20 +674,6 @@ export function DataSciencePlaygroundPage() {
     return (
         <main style={shellStyle}>
             <section style={stageStyle}>
-                {import.meta.env.DEV ? (
-                    <ModeRegistryPanel
-                        pathname={location.pathname}
-                        mode={routeHudPreset.mode}
-                        label={routeHudPreset.label}
-                        explorer={showExplorer}
-                        menu={showMenu}
-                        status={showStatus}
-                        operations={showOperations}
-                        prefersReducedMotion={prefersReducedMotion}
-                        transitions={transitionHistory}
-                    />
-                ) : null}
-
                 <RouteTopBar
                     routeLabel={routeHudPreset.label}
                     showExplorer={showExplorer}


### PR DESCRIPTION
## Summary
- make K3H4 training workflow authoritative-only by requiring persisted epoch writes
- add persisted epoch API route wiring and service behavior used by training workflow
- improve frontend 404/error parsing and stale-session recovery messaging
- move Visualizations to left side panel and Training to right side panel (top-anchored)
- remove outdated Mode Registry panel and top-right off-screen gameplay notification cards

## Validation
- bun test src/routes/netcode.contract.test.ts --bail (28 passed)
- local live API route probe confirmed epoch endpoint registration after service rebuild

## Notes
- local runtime previously returned route-not-found for POST /api/netcode/k3h4/training-session/:id/epoch until api-overworld was rebuilt/restarted
- production may require API redeploy to pick up the new epoch route before the updated UI can trigger workflows end-to-end