### PR TITLE
fix(native-tests): address PR #1153 Copilot review comments

### DIFF
--- a/tests/native/runtime/runtime/controller/controller_runtime_test.c
+++ b/tests/native/runtime/runtime/controller/controller_runtime_test.c
@@ -75,6 +75,8 @@ static void test_runtime_controller_helpers(void **state)
                             "signal-by-id must dispatch to matched controller");
     BANANA_TEST_ASSERT_INT_EQ(g_signal_calls, 1,
                               "signal-by-id must trigger controller callback");
+    BANANA_TEST_ASSERT_INT_EQ(g_last_signal_value, 7,
+                              "signal-by-id must forward payload through callback");
 
     BANANA_TEST_ASSERT_TRUE(runtime_controller_assign_team_by_id(controllers, 2, 2, CONTROLLER_TEAM_NEUTRAL),
                             "assign-team-by-id must update team membership");

--- a/tests/native/runtime/support/copy_runtime_dlls.cmake
+++ b/tests/native/runtime/support/copy_runtime_dlls.cmake
@@ -1,3 +1,7 @@
+if(NOT DEFINED banana_target_dir OR banana_target_dir STREQUAL "")
+	message(FATAL_ERROR "banana_target_dir must be set when invoking copy_runtime_dlls.cmake")
+endif()
+
 if(NOT DEFINED banana_runtime_dlls OR banana_runtime_dlls STREQUAL "")
 	return()
 endif()

--- a/tests/native/runtime/support/test_support.h
+++ b/tests/native/runtime/support/test_support.h
@@ -63,6 +63,17 @@ typedef int (*banana_native_test_teardown_fn)(void **state);
             fail_msg("%s", (message));                                                             \
     } while (0)
 
+/* For helpers that return a value: asserts condition and returns ret on failure. */
+#define BANANA_TEST_ASSERT_TRUE_RET(condition, message, ret)                                        \
+    do                                                                                              \
+    {                                                                                               \
+        if (!(condition))                                                                           \
+        {                                                                                           \
+            fail_msg("%s", (message));                                                             \
+            return (ret);                                                                           \
+        }                                                                                           \
+    } while (0)
+
 #define BANANA_TEST_ASSERT_INT_EQ(actual, expected, message)                                        \
     do                                                                                              \
     {                                                                                               \
@@ -182,6 +193,17 @@ static inline int banana_native_run_tests(const BananaNativeTestCase *tests,
         {                                                                                            \
             banana_native_record_failure((message), __FILE__, __LINE__);                            \
             return;                                                                                  \
+        }                                                                                            \
+    } while (0)
+
+/* For helpers that return a value: records failure and returns ret without aborting the process. */
+#define BANANA_TEST_ASSERT_TRUE_RET(condition, message, ret)                                         \
+    do                                                                                               \
+    {                                                                                                \
+        if (!(condition))                                                                            \
+        {                                                                                            \
+            banana_native_record_failure((message), __FILE__, __LINE__);                            \
+            return (ret);                                                                            \
         }                                                                                            \
     } while (0)
 


### PR DESCRIPTION
## Summary

Follow-up to #1153 addressing all Copilot review issues.

### Changes

**`tests/native/runtime/support/test_support.h`**
- Added `BANANA_TEST_ASSERT_TRUE_RET(condition, message, ret)` macro in both the CMocka path (wraps `fail_msg` + unreachable `return ret`) and the non-CMocka path (calls `banana_native_record_failure` + `return ret`). Int-returning helpers can now short-circuit cleanly without a bare `return;` diagnostic.

**`tests/native/runtime/runtime/controller/controller_runtime_test.c`**
- Added `BANANA_TEST_ASSERT_INT_EQ(g_last_signal_value, 7, ...)` after the `g_signal_calls` check. The float payload `{0.7f, 0.0f, 0.0f}` was already correct; this assertion proves the value made it through `fake_signal`.

**`tests/native/runtime/support/copy_runtime_dlls.cmake`**
- Added an explicit guard for missing or empty `banana_target_dir` at the top of the script. Misconfiguration now surfaces a clear `FATAL_ERROR` instead of a silent downstream cmake error.

### What was already correct (no change needed)
- `combat_controller_coverage_test.c`: Already defines a local `COMBAT_TEST_ASSERT_TRUE` that returns `1` (not `return;`) in the non-CMocka path and rebinds `BANANA_TEST_ASSERT_TRUE` to it — self-fixed.
- `CMakeLists.txt` duplicate-wiring concern: No `BANANA_RUNTIME_NATIVE_CMOCKA_TARGETS` foreach exists in the file; `banana_enable_cmocka_native(banana_runtime_controller_system_test)` is called exactly once.

## Validation
- `cmake --build out/v3-native`: clean
- Full ctest suite: **39/39 passed**