### PR TITLE
Add native source inventory coverage reporting

### DIFF
--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -222,29 +222,26 @@ jobs:
         if: always()
         shell: bash
         run: |
-          python - <<'PY'
-          from pathlib import Path
-          import os
-          import re
-          html_path = Path('artifacts/native/coverage-ci/coverage-files-summary.html')
-          md_path = Path('artifacts/native/coverage-ci/coverage-summary.md')
-          if not html_path.exists():
-              print('::warning::Native inventory coverage summary page was not generated.')
-              raise SystemExit(0)
-          text = html_path.read_text(encoding='utf-8', errors='ignore')
-          match = re.search(r'Overall coverage across the current inventory: <strong>([0-9.]+)%</strong>', text)
-          if match:
-              pct = match.group(1)
-              print(f"::notice::Native source inventory coverage: {pct}%")
-              with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as fh:
-                  fh.write(f"## Native source inventory coverage\n\n- Overall inventory coverage: {pct}%\n- Report: [coverage-files-summary.html](artifacts/native/coverage-ci/coverage-files-summary.html)\n- Detailed report: [index.html](artifacts/native/coverage-ci/index.html)\n")
-          else:
-              print('::warning::Native inventory coverage summary page did not contain an overall percentage.')
-          if md_path.exists():
-              with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as fh:
-                  fh.write('\n### Coverage run note\n\n')
-                  fh.write(md_path.read_text(encoding='utf-8'))
-          PY
+          set -euo pipefail
+          mkdir -p "$GITHUB_STEP_SUMMARY_DIR"
+          summary_path="artifacts/native/coverage-ci/coverage-summary.md"
+          html_path="artifacts/native/coverage-ci/coverage-files-summary.html"
+          if [[ -f "$summary_path" ]]; then
+            cat "$summary_path" >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat <<'EOF_SUMMARY' >> "$GITHUB_STEP_SUMMARY"
+          ## Native source inventory coverage
+
+          - Summary report was not generated; the coverage job still completed with warnings.
+          - Artifact path: [artifacts/native/coverage-ci](artifacts/native/coverage-ci)
+          EOF_SUMMARY
+          fi
+
+          if [[ -f "$html_path" ]]; then
+            echo "::notice::Native inventory summary report available at $html_path"
+          else
+            echo "::warning::Native inventory coverage summary page was not generated."
+          fi
 
       - name: Upload native coverage artifacts
         if: always()

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -239,18 +239,18 @@ jobs:
 
           if [[ -f "$html_path" ]]; then
             python - <<'PY'
-from pathlib import Path
-import os
-import re
-html_path = Path("artifacts/native/coverage-ci/coverage-files-summary.html")
-summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
-text = html_path.read_text(encoding="utf-8", errors="ignore") if html_path.exists() else ""
-style_match = re.search(r"<style>(.*?)</style>", text, re.S | re.I)
-body_match = re.search(r"<body>(.*?)</body>", text, re.S | re.I)
-body = body_match.group(1) if body_match else text
-style = f"<style>{style_match.group(1)}</style>" if style_match else ""
-existing = summary_path.read_text(encoding="utf-8", errors="ignore") if summary_path.exists() else ""
-summary_path.write_text(existing + "\n" + style + body, encoding="utf-8")
+            from pathlib import Path
+            import os
+            import re
+            html_path = Path("artifacts/native/coverage-ci/coverage-files-summary.html")
+            summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+            text = html_path.read_text(encoding="utf-8", errors="ignore") if html_path.exists() else ""
+            style_match = re.search(r"<style>(.*?)</style>", text, re.S | re.I)
+            body_match = re.search(r"<body>(.*?)</body>", text, re.S | re.I)
+            body = body_match.group(1) if body_match else text
+            style = f"<style>{style_match.group(1)}</style>" if style_match else ""
+            existing = summary_path.read_text(encoding="utf-8", errors="ignore") if summary_path.exists() else ""
+            summary_path.write_text(existing + "\n" + style + body, encoding="utf-8")
 PY
             echo "::notice::Native inventory summary report available at $html_path"
           else

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -232,11 +232,28 @@ jobs:
           ## Native source inventory coverage
 
           - Summary report was not generated; the coverage job still completed with warnings.
-          - Artifact path: [artifacts/native/coverage-ci](artifacts/native/coverage-ci)
+          - Artifact path: artifacts/native/coverage-ci
           EOF_SUMMARY
           fi
 
           if [[ -f "$html_path" ]]; then
+            python - <<'PY'
+            from pathlib import Path
+            import os
+            import re
+            html_path = Path('artifacts/native/coverage-ci/coverage-files-summary.html')
+            summary_path = Path(os.environ['GITHUB_STEP_SUMMARY'])
+            if html_path.exists():
+                text = html_path.read_text(encoding='utf-8', errors='ignore')
+                style_match = re.search(r'<style>(.*?)</style>', text, re.S | re.I)
+                body_match = re.search(r'<body>(.*?)</body>', text, re.S | re.I)
+                body = body_match.group(1) if body_match else text
+                style = f'<style>{style_match.group(1)}</style>' if style_match else ''
+                with summary_path.open('a', encoding='utf-8') as fh:
+                    fh.write('\n')
+                    fh.write(style)
+                    fh.write(body)
+            PY
             echo "::notice::Native inventory summary report available at $html_path"
           else
             echo "::warning::Native inventory coverage summary page was not generated."

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -238,10 +238,20 @@ jobs:
           fi
 
           if [[ -f "$html_path" ]]; then
-            python -c 'from pathlib import Path; import os, re; html_path = Path("artifacts/native/coverage-ci/coverage-files-summary.html"); summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"]); 
-            text = html_path.read_text(encoding="utf-8", errors="ignore") if html_path.exists() else ""; 
-            style_match = re.search(r"<style>(.*?)</style>", text, re.S | re.I); body_match = re.search(r"<body>(.*?)</body>", text, re.S | re.I); body = body_match.group(1) if body_match else text; style = f"<style>{style_match.group(1)}</style>" if style_match else ""; 
-            summary_path.write_text(summary_path.read_text(encoding="utf-8", errors="ignore") + "\n" + style + body, encoding="utf-8") if summary_path.exists() else None'
+            python - <<'PY'
+from pathlib import Path
+import os
+import re
+html_path = Path("artifacts/native/coverage-ci/coverage-files-summary.html")
+summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+text = html_path.read_text(encoding="utf-8", errors="ignore") if html_path.exists() else ""
+style_match = re.search(r"<style>(.*?)</style>", text, re.S | re.I)
+body_match = re.search(r"<body>(.*?)</body>", text, re.S | re.I)
+body = body_match.group(1) if body_match else text
+style = f"<style>{style_match.group(1)}</style>" if style_match else ""
+existing = summary_path.read_text(encoding="utf-8", errors="ignore") if summary_path.exists() else ""
+summary_path.write_text(existing + "\n" + style + body, encoding="utf-8")
+PY
             echo "::notice::Native inventory summary report available at $html_path"
           else
             echo "::warning::Native inventory coverage summary page was not generated."

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -224,17 +224,26 @@ jobs:
         run: |
           python - <<'PY'
           from pathlib import Path
+          import os
           import re
           html_path = Path('artifacts/native/coverage-ci/coverage-files-summary.html')
+          md_path = Path('artifacts/native/coverage-ci/coverage-summary.md')
           if not html_path.exists():
               print('::warning::Native inventory coverage summary page was not generated.')
               raise SystemExit(0)
           text = html_path.read_text(encoding='utf-8', errors='ignore')
           match = re.search(r'Overall coverage across the current inventory: <strong>([0-9.]+)%</strong>', text)
           if match:
-              print(f"::notice::Native source inventory coverage: {match.group(1)}%")
+              pct = match.group(1)
+              print(f"::notice::Native source inventory coverage: {pct}%")
+              with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as fh:
+                  fh.write(f"## Native source inventory coverage\n\n- Overall inventory coverage: {pct}%\n- Report: [coverage-files-summary.html](artifacts/native/coverage-ci/coverage-files-summary.html)\n- Detailed report: [index.html](artifacts/native/coverage-ci/index.html)\n")
           else:
               print('::warning::Native inventory coverage summary page did not contain an overall percentage.')
+          if md_path.exists():
+              with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as fh:
+                  fh.write('\n### Coverage run note\n\n')
+                  fh.write(md_path.read_text(encoding='utf-8'))
           PY
 
       - name: Upload native coverage artifacts

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -251,7 +251,7 @@ jobs:
             style = f"<style>{style_match.group(1)}</style>" if style_match else ""
             existing = summary_path.read_text(encoding="utf-8", errors="ignore") if summary_path.exists() else ""
             summary_path.write_text(existing + "\n" + style + body, encoding="utf-8")
-PY
+            PY
             echo "::notice::Native inventory summary report available at $html_path"
           else
             echo "::warning::Native inventory coverage summary page was not generated."

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -214,14 +214,36 @@ jobs:
             cmake ninja-build gcc g++ libomp-dev gcovr lcov
 
       - name: Run native coverage workflow
+        id: native_coverage
+        continue-on-error: true
         run: bash scripts/run-native-coverage.sh --build-dir out/native-coverage-ci --output-dir artifacts/native/coverage-ci
 
+      - name: Report native inventory coverage
+        if: always()
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import re
+          html_path = Path('artifacts/native/coverage-ci/coverage-files-summary.html')
+          if not html_path.exists():
+              print('::warning::Native inventory coverage summary page was not generated.')
+              raise SystemExit(0)
+          text = html_path.read_text(encoding='utf-8', errors='ignore')
+          match = re.search(r'Overall coverage across the current inventory: <strong>([0-9.]+)%</strong>', text)
+          if match:
+              print(f"::notice::Native source inventory coverage: {match.group(1)}%")
+          else:
+              print('::warning::Native inventory coverage summary page did not contain an overall percentage.')
+          PY
+
       - name: Upload native coverage artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: native-coverage-report
           path: artifacts/native/coverage-ci
-          if-no-files-found: error
+          if-no-files-found: warn
 
   native-neon-integration:
     name: Native / Neon integration

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -238,21 +238,12 @@ jobs:
           fi
 
           if [[ -f "$html_path" ]]; then
-            cat > /tmp/append-native-summary.py <<'PY'
-from pathlib import Path
-import os
-import re
-html_path = Path("artifacts/native/coverage-ci/coverage-files-summary.html")
-summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
-text = html_path.read_text(encoding="utf-8", errors="ignore") if html_path.exists() else ""
-style_match = re.search(r"<style>(.*?)</style>", text, re.S | re.I)
-body_match = re.search(r"<body>(.*?)</body>", text, re.S | re.I)
-body = body_match.group(1) if body_match else text
-style = f"<style>{style_match.group(1)}</style>" if style_match else ""
-existing = summary_path.read_text(encoding="utf-8", errors="ignore") if summary_path.exists() else ""
-summary_path.write_text(existing + "\n" + style + body, encoding="utf-8")
-PY
-            python /tmp/append-native-summary.py
+            {
+              echo
+              echo "## Native source inventory coverage report"
+              echo
+              sed -n '/<body>/,/<\/body>/p' "$html_path" | sed '1d;$d'
+            } >> "$GITHUB_STEP_SUMMARY"
             echo "::notice::Native inventory summary report available at $html_path"
           else
             echo "::warning::Native inventory coverage summary page was not generated."

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -223,7 +223,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "$GITHUB_STEP_SUMMARY_DIR"
           summary_path="artifacts/native/coverage-ci/coverage-summary.md"
           html_path="artifacts/native/coverage-ci/coverage-files-summary.html"
           if [[ -f "$summary_path" ]]; then

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -200,6 +200,29 @@ jobs:
       - name: Run native tests
         run: ctest --test-dir out/native-ci --output-on-failure
 
+  native-coverage:
+    name: Native / coverage
+    needs: pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install native coverage deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            cmake ninja-build gcc g++ libomp-dev gcovr lcov
+
+      - name: Run native coverage workflow
+        run: bash scripts/run-native-coverage.sh --build-dir out/native-coverage-ci --output-dir artifacts/native/coverage-ci
+
+      - name: Upload native coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-coverage-report
+          path: artifacts/native/coverage-ci
+          if-no-files-found: error
+
   native-neon-integration:
     name: Native / Neon integration
     needs:
@@ -248,6 +271,7 @@ jobs:
       - secret-scans
       - typescript-smoke
       - native-build
+      - native-coverage
       - native-neon-integration
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -237,23 +237,10 @@ jobs:
           fi
 
           if [[ -f "$html_path" ]]; then
-            python - <<'PY'
-            from pathlib import Path
-            import os
-            import re
-            html_path = Path('artifacts/native/coverage-ci/coverage-files-summary.html')
-            summary_path = Path(os.environ['GITHUB_STEP_SUMMARY'])
-            if html_path.exists():
-                text = html_path.read_text(encoding='utf-8', errors='ignore')
-                style_match = re.search(r'<style>(.*?)</style>', text, re.S | re.I)
-                body_match = re.search(r'<body>(.*?)</body>', text, re.S | re.I)
-                body = body_match.group(1) if body_match else text
-                style = f'<style>{style_match.group(1)}</style>' if style_match else ''
-                with summary_path.open('a', encoding='utf-8') as fh:
-                    fh.write('\n')
-                    fh.write(style)
-                    fh.write(body)
-            PY
+            python -c 'from pathlib import Path; import os, re; html_path = Path("artifacts/native/coverage-ci/coverage-files-summary.html"); summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"]); 
+            text = html_path.read_text(encoding="utf-8", errors="ignore") if html_path.exists() else ""; 
+            style_match = re.search(r"<style>(.*?)</style>", text, re.S | re.I); body_match = re.search(r"<body>(.*?)</body>", text, re.S | re.I); body = body_match.group(1) if body_match else text; style = f"<style>{style_match.group(1)}</style>" if style_match else ""; 
+            summary_path.write_text(summary_path.read_text(encoding="utf-8", errors="ignore") + "\n" + style + body, encoding="utf-8") if summary_path.exists() else None'
             echo "::notice::Native inventory summary report available at $html_path"
           else
             echo "::warning::Native inventory coverage summary page was not generated."

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -204,8 +204,8 @@ jobs:
     name: Native / coverage
     needs: pre-commit
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
 
       - name: Install native coverage deps
         run: |

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -206,6 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - uses: actions/checkout@v6
 
       - name: Install native coverage deps
         run: |

--- a/.github/workflows/banana.yml
+++ b/.github/workflows/banana.yml
@@ -238,20 +238,21 @@ jobs:
           fi
 
           if [[ -f "$html_path" ]]; then
-            python - <<'PY'
-            from pathlib import Path
-            import os
-            import re
-            html_path = Path("artifacts/native/coverage-ci/coverage-files-summary.html")
-            summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
-            text = html_path.read_text(encoding="utf-8", errors="ignore") if html_path.exists() else ""
-            style_match = re.search(r"<style>(.*?)</style>", text, re.S | re.I)
-            body_match = re.search(r"<body>(.*?)</body>", text, re.S | re.I)
-            body = body_match.group(1) if body_match else text
-            style = f"<style>{style_match.group(1)}</style>" if style_match else ""
-            existing = summary_path.read_text(encoding="utf-8", errors="ignore") if summary_path.exists() else ""
-            summary_path.write_text(existing + "\n" + style + body, encoding="utf-8")
-            PY
+            cat > /tmp/append-native-summary.py <<'PY'
+from pathlib import Path
+import os
+import re
+html_path = Path("artifacts/native/coverage-ci/coverage-files-summary.html")
+summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+text = html_path.read_text(encoding="utf-8", errors="ignore") if html_path.exists() else ""
+style_match = re.search(r"<style>(.*?)</style>", text, re.S | re.I)
+body_match = re.search(r"<body>(.*?)</body>", text, re.S | re.I)
+body = body_match.group(1) if body_match else text
+style = f"<style>{style_match.group(1)}</style>" if style_match else ""
+existing = summary_path.read_text(encoding="utf-8", errors="ignore") if summary_path.exists() else ""
+summary_path.write_text(existing + "\n" + style + body, encoding="utf-8")
+PY
+            python /tmp/append-native-summary.py
             echo "::notice::Native inventory summary report available at $html_path"
           else
             echo "::warning::Native inventory coverage summary page was not generated."

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ Thumbs.db
 /src/typescript/react/test-results
 *.stackdump
 /.tools/vcpkg
+/artifacts/native/coverage-report-msvc
+/artifacts/native/coverage-report
+/artifacts/native/coverage-report-cobertura
+nul

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Thumbs.db
 /artifacts/native/coverage-report
 /artifacts/native/coverage-report-cobertura
 nul
+/artifacts/native/coverage-ci

--- a/artifacts/native/k3h4-scaling-benchmark.json
+++ b/artifacts/native/k3h4-scaling-benchmark.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
   "series": [
-    { "n": 64, "k3h4_ns": 1380200, "attention_ns": 22583 },
-    { "n": 256, "k3h4_ns": 5362401, "attention_ns": 385393 },
-    { "n": 1024, "k3h4_ns": 23845700, "attention_ns": 6571900 },
-    { "n": 4096, "k3h4_ns": 96335900, "attention_ns": 100202800 },
-    { "n": 16384, "k3h4_ns": 418797000, "attention_ns": 1609032100 }
+    { "n": 64, "k3h4_ns": 2134900, "attention_ns": 25831 },
+    { "n": 256, "k3h4_ns": 5685600, "attention_ns": 369775 },
+    { "n": 1024, "k3h4_ns": 24381100, "attention_ns": 5760700 },
+    { "n": 4096, "k3h4_ns": 93334800, "attention_ns": 101432100 },
+    { "n": 16384, "k3h4_ns": 386468300, "attention_ns": 1605832700 }
   ]
 }

--- a/artifacts/native/k3h4-scaling-benchmark.json
+++ b/artifacts/native/k3h4-scaling-benchmark.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
   "series": [
-    { "n": 64, "k3h4_ns": 2134900, "attention_ns": 25831 },
-    { "n": 256, "k3h4_ns": 5685600, "attention_ns": 369775 },
-    { "n": 1024, "k3h4_ns": 24381100, "attention_ns": 5760700 },
-    { "n": 4096, "k3h4_ns": 93334800, "attention_ns": 101432100 },
-    { "n": 16384, "k3h4_ns": 386468300, "attention_ns": 1605832700 }
+    { "n": 64, "k3h4_ns": 2403500, "attention_ns": 22732 },
+    { "n": 256, "k3h4_ns": 5640400, "attention_ns": 368012 },
+    { "n": 1024, "k3h4_ns": 23135400, "attention_ns": 8709900 },
+    { "n": 4096, "k3h4_ns": 92382300, "attention_ns": 96239000 },
+    { "n": 16384, "k3h4_ns": 382189200, "attention_ns": 1566871500 }
   ]
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,9 +6,14 @@
 - `build-k3h4-standalone-release.sh`: packages a standalone K3H4 model release bundle (native library, ABI header, contracts, metadata, checksum) under `artifacts/native/k3h4/releases/<version>/`.
 - `run-native-feedback-loop.sh`: runs the native human-feedback loop factory in scenario mode or DX12 playloop script mode (`--script`), emitting operator-readable telemetry snapshots.
 - `run-war-test-suites.sh`: scenario-suite orchestrator for the feedback loop factory (`focused`, `evidence`, `soak`, `gameplay`, `legacy`, `mmo-only`) with optional scenario overrides (`warfront`, `negotiate`, `comeback`, `flank`, `pressure`, `truce`, `rally`) and optional `--script-dir` (`<scenario>.dx12play`) execution.
+- `run-native-coverage.sh`: configures a coverage-enabled native build, runs the native test suite, and exports HTML/text coverage artifacts that can be run locally or in CI.
 - `run-dx12-playtest-suites.sh`: launches the DX12 POC with polished demo-scene assets for interactive playtests or autotest sweeps (`playtest`, `showcase`, `metro`, `corridor`, `continent`, `all`, `features`) with optional `--feature <name>` overrides.
 - `refresh-coherent-world-evidence.sh`: refreshes 031 evidence artifacts by capturing feedback-loop suite output logs, optionally forwarding `BANANA_NATIVE_FEEDBACK_SCRIPT_DIR` into suite runs.
 - `refresh-coherent-world-api-baselines.sh`: refreshes 031 API unit/integration evidence artifacts.
+
+Coverage examples:
+- `bash scripts/run-native-coverage.sh`
+- `bash scripts/run-native-coverage.sh --build-dir out/native-coverage-ci --output-dir artifacts/native/coverage-ci`
 
 Playtest examples:
 - `bash scripts/run-dx12-playtest-suites.sh --suite playtest` (interactive playtest with telemetry + auto-target defaults)

--- a/scripts/run-native-coverage.sh
+++ b/scripts/run-native-coverage.sh
@@ -207,7 +207,7 @@ covered_total = 0
 uncovered_total = 0
 for path in all_sources:
     rel = path.relative_to(source_root).as_posix()
-    entry = coverage_by_file.get(path.name)
+    entry = coverage_by_file.get(rel) or coverage_by_file.get(path.name)
     if entry is None:
         line_count = sum(1 for _ in path.read_text(encoding='utf-8', errors='ignore').splitlines())
         covered = 0

--- a/scripts/run-native-coverage.sh
+++ b/scripts/run-native-coverage.sh
@@ -119,6 +119,7 @@ else
     if ! gcovr \
       --root "$ROOT_DIR" \
       --filter "$ROOT_DIR/src/native/" \
+      --json "$OUTPUT_DIR/gcovr.json" \
       --html-details "$OUTPUT_DIR/index.html" \
       --txt "$OUTPUT_DIR/coverage-summary.txt" \
       --json-summary "$OUTPUT_DIR/gcovr.json" \

--- a/scripts/run-native-coverage.sh
+++ b/scripts/run-native-coverage.sh
@@ -121,6 +121,7 @@ else
       --filter "$ROOT_DIR/src/native/" \
       --html-details "$OUTPUT_DIR/index.html" \
       --txt "$OUTPUT_DIR/coverage-summary.txt" \
+      --json-summary "$OUTPUT_DIR/gcovr.json" \
       --print-summary \
       --sort uncovered \
       --exclude '.*tests.*' \
@@ -148,6 +149,19 @@ root_dir = Path(os.environ.get('BANANA_NATIVE_COVERAGE_ROOT_DIR', os.getcwd())).
 source_root = (root_dir / 'src' / 'native').resolve()
 if not source_root.exists():
     raise SystemExit(f"native source root does not exist: {source_root}")
+
+
+def parse_overall_percentage(report_dir: Path):
+    summary_txt = report_dir / 'coverage-summary.txt'
+    if not summary_txt.exists():
+        return None
+    for line in summary_txt.read_text(encoding='utf-8', errors='ignore').splitlines():
+        if not line.strip().startswith('TOTAL'):
+            continue
+        match = re.search(r'([0-9.]+)%\s*$', line)
+        if match:
+            return float(match.group(1))
+    return None
 
 modules_candidates = [report_dir / 'Modules', report_dir / 'coverage-report-msvc' / 'Modules']
 coverage_by_file = {}
@@ -231,7 +245,9 @@ for path in all_sources:
 rows.sort(key=lambda item: (item[2] == 0, item[2], item[0]), reverse=False)
 
 summary_path = report_dir / 'coverage-files-summary.html'
-overall_pct = (100.0 * covered_total / (covered_total + uncovered_total)) if (covered_total + uncovered_total) else 0.0
+overall_pct = parse_overall_percentage(report_dir)
+if overall_pct is None:
+    overall_pct = (100.0 * covered_total / (covered_total + uncovered_total)) if (covered_total + uncovered_total) else 0.0
 summary_html = f'''<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -257,7 +273,13 @@ summary_html = f'''<!DOCTYPE html>
 '''
 summary_path.write_text(summary_html, encoding='utf-8')
 summary_md = report_dir / 'coverage-summary.md'
-summary_md.write_text(f"# Native source inventory coverage\n\n- Overall inventory coverage: {overall_pct:.1f}%\n- Source inventory summary: [coverage-files-summary.html](coverage-files-summary.html)\n- Detailed report: [index.html](index.html)\n", encoding='utf-8')
+summary_md.write_text(
+    f"# Native source inventory coverage\n\n"
+    f"- Overall inventory coverage: {overall_pct:.1f}%\n"
+    f"- Source inventory summary: artifacts/native/coverage-ci/coverage-files-summary.html\n"
+    f"- Detailed report: artifacts/native/coverage-ci/index.html\n",
+    encoding='utf-8'
+)
 
 print(f"[coverage] wrote source inventory summary to {summary_path}")
 print(f"[coverage] overall inventory coverage: {overall_pct:.1f}%")

--- a/scripts/run-native-coverage.sh
+++ b/scripts/run-native-coverage.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${BANANA_NATIVE_BUILD_DIR:-out/native-coverage}"
+OUTPUT_DIR="${BANANA_NATIVE_COVERAGE_OUTPUT_DIR:-artifacts/native/coverage}"
+SKIP_BUILD=0
+SKIP_TESTS=0
+
+usage() {
+  cat <<'EOF_USAGE'
+Usage:
+  bash scripts/run-native-coverage.sh [options]
+
+Options:
+  --build-dir <path>      CMake build directory (default: out/native-coverage)
+  --output-dir <path>     Coverage report output directory (default: artifacts/native/coverage)
+  --skip-build            Reuse the existing build tree without reconfiguring/building
+  --skip-tests            Skip ctest execution and only generate the coverage report
+  --help                  Show this help
+
+Examples:
+  bash scripts/run-native-coverage.sh
+  bash scripts/run-native-coverage.sh --build-dir out/native-coverage-ci --output-dir artifacts/native/coverage-ci
+EOF_USAGE
+}
+
+die() {
+  echo "[coverage] error: $*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build-dir)
+      [[ $# -ge 2 ]] || die "--build-dir requires a value"
+      BUILD_DIR="$2"
+      shift 2
+      ;;
+    --output-dir)
+      [[ $# -ge 2 ]] || die "--output-dir requires a value"
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --skip-build)
+      SKIP_BUILD=1
+      shift
+      ;;
+    --skip-tests)
+      SKIP_TESTS=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument '$1'"
+      ;;
+  esac
+done
+
+mkdir -p "$ROOT_DIR"
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+  if [[ -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+    echo "[coverage] reusing existing build tree at $BUILD_DIR"
+  else
+    echo "[coverage] configuring native coverage build in $BUILD_DIR"
+    cmake -S "$ROOT_DIR/src/native" -B "$BUILD_DIR" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBANANA_ENABLE_COVERAGE=ON
+  fi
+
+  echo "[coverage] building native targets"
+  cmake --build "$BUILD_DIR" --parallel
+else
+  echo "[coverage] reusing existing build tree at $BUILD_DIR"
+fi
+
+if [[ "$SKIP_TESTS" -eq 0 ]]; then
+  echo "[coverage] running native tests"
+  if [[ -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+    ctest --test-dir "$BUILD_DIR" -C Debug --output-on-failure
+  else
+    ctest --test-dir "$BUILD_DIR" --output-on-failure
+  fi
+else
+  echo "[coverage] skipping native tests"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* || "$OS" == "Windows_NT" ]]; then
+  if command -v OpenCppCoverage.exe >/dev/null 2>&1; then
+    SOURCE_ROOT_W="$(cygpath -w "$ROOT_DIR/src/native" 2>/dev/null || printf '%s' "$ROOT_DIR/src/native")"
+    OUTPUT_DIR_W="$(cygpath -w "$OUTPUT_DIR" 2>/dev/null || printf '%s' "$OUTPUT_DIR")"
+    echo "[coverage] generating Windows HTML report at $OUTPUT_DIR"
+    OpenCppCoverage.exe \
+      --working_dir "$ROOT_DIR" \
+      --sources "$SOURCE_ROOT_W" \
+      --export_type html:"$OUTPUT_DIR_W" \
+      --cover_children \
+      -- \
+      ctest --test-dir "$BUILD_DIR" -C Debug --output-on-failure
+  else
+    die "OpenCppCoverage.exe was not found. Install OpenCppCoverage or run this script on a Unix-like environment with gcovr installed."
+  fi
+else
+  if ! command -v gcovr >/dev/null 2>&1; then
+    die "gcovr is required. Install it with your package manager (for example: sudo apt-get install -y gcovr lcov)."
+  fi
+
+  echo "[coverage] generating gcovr report at $OUTPUT_DIR"
+  gcovr \
+    --root "$ROOT_DIR" \
+    --filter "$ROOT_DIR/src/native/" \
+    --html-details "$OUTPUT_DIR/index.html" \
+    --txt "$OUTPUT_DIR/coverage-summary.txt" \
+    --print-summary \
+    --sort uncovered \
+    --exclude '.*tests.*' \
+    --exclude '.*third_party.*'
+fi
+
+BANANA_NATIVE_COVERAGE_REPORT_DIR="$OUTPUT_DIR" python - <<'PY'
+import os
+import re
+import html
+from pathlib import Path
+
+report_dir = Path(os.environ.get('BANANA_NATIVE_COVERAGE_REPORT_DIR', ''))
+if not report_dir:
+    raise SystemExit('BANANA_NATIVE_COVERAGE_REPORT_DIR is empty')
+report_dir = report_dir.resolve() if report_dir.exists() else Path(report_dir)
+if not report_dir.exists():
+    raise SystemExit(f"coverage report directory does not exist: {report_dir}")
+
+source_root = (Path(os.getcwd()) / 'src' / 'native').resolve()
+if not source_root.exists():
+    raise SystemExit(f"native source root does not exist: {source_root}")
+
+modules_candidates = [report_dir / 'Modules', report_dir / 'coverage-report-msvc' / 'Modules']
+coverage_by_file = {}
+for modules_dir in modules_candidates:
+    if not modules_dir.exists():
+        continue
+    for module_dir in sorted(modules_dir.iterdir()):
+        if not module_dir.is_dir():
+            continue
+        for html_file in sorted(module_dir.glob('*.html')):
+            if html_file.name == 'index.html':
+                continue
+            text = html_file.read_text(encoding='utf-8', errors='ignore')
+            title_match = re.search(r'<title>(.*?)</title>', text, re.I | re.S)
+            title = title_match.group(1).strip() if title_match else html_file.stem
+            covered = len(re.findall(r'background-color:#dfd', text))
+            uncovered = len(re.findall(r'background-color:#fdd', text))
+            total = covered + uncovered
+            if total <= 0:
+                continue
+            coverage_by_file[title] = {
+                'covered': coverage_by_file.get(title, {}).get('covered', 0) + covered,
+                'uncovered': coverage_by_file.get(title, {}).get('uncovered', 0) + uncovered,
+                'total': coverage_by_file.get(title, {}).get('total', 0) + total,
+            }
+
+rows = []
+all_sources = []
+for path in sorted(source_root.rglob('*')):
+    if not path.is_file():
+        continue
+    if path.suffix.lower() not in {'.c', '.h', '.cpp', '.hpp'}:
+        continue
+    if 'third_party' in path.parts or '.git' in path.parts or 'out' in path.parts:
+        continue
+    all_sources.append(path)
+
+covered_total = 0
+uncovered_total = 0
+for path in all_sources:
+    rel = path.relative_to(source_root).as_posix()
+    entry = coverage_by_file.get(path.name)
+    if entry is None:
+        line_count = sum(1 for _ in path.read_text(encoding='utf-8', errors='ignore').splitlines())
+        covered = 0
+        uncovered = line_count
+        status = 'not observed'
+        observed = False
+    else:
+        line_count = entry['total'] if entry['total'] > 0 else sum(1 for _ in path.read_text(encoding='utf-8', errors='ignore').splitlines())
+        covered = entry['covered']
+        uncovered = entry['uncovered']
+        status = 'partial' if covered and uncovered else ('fully covered' if covered else 'no observed lines')
+        observed = True
+    if covered + uncovered > 0:
+        pct = 100.0 * covered / (covered + uncovered)
+    else:
+        pct = 0.0
+    covered_total += covered
+    uncovered_total += uncovered
+    rows.append((rel, covered, uncovered, covered + uncovered, pct, status, observed))
+
+rows.sort(key=lambda item: (item[2] == 0, item[2], item[0]), reverse=False)
+
+summary_path = report_dir / 'coverage-files-summary.html'
+overall_pct = (100.0 * covered_total / (covered_total + uncovered_total)) if (covered_total + uncovered_total) else 0.0
+summary_html = f'''<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Native source inventory coverage</title>
+<style>body{{font-family:Segoe UI,Arial,sans-serif;margin:24px;color:#222;}} table{{border-collapse:collapse;width:100%;max-width:1400px;}} th,td{{border:1px solid #d0d7de;padding:8px 10px;text-align:left;}} th{{background:#f6f8fa;}} tr:nth-child(even){{background:#fafbfc;}} a{{color:#0969da;text-decoration:none;}} .low{{color:#cf222e;font-weight:600;}} .good{{color:#1a7f37;font-weight:600;}} .meta{{color:#57606a;font-size:0.95em;}} .warn{{color:#8250df;font-weight:600;}}</style>
+</head>
+<body>
+<h1>Native source inventory coverage</h1>
+<p class="meta">This view enumerates every native source file under src/native. Files that were not observed in the current coverage run are shown as <strong>not observed</strong> and are treated as uncovered so the inventory is representative of the full native codebase.</p>
+<p class="meta">Overall coverage across the current inventory: <strong>{overall_pct:.1f}%</strong> ({covered_total} covered lines / {covered_total + uncovered_total} total lines).</p>
+<table>
+<thead><tr><th>Source file</th><th>Status</th><th>Covered</th><th>Uncovered</th><th>Total</th><th>Coverage</th></tr></thead>
+<tbody>
+{''.join(
+    f'<tr><td><strong>{html.escape(rel)}</strong></td><td>{status}</td><td>{covered}</td><td>{uncovered}</td><td>{total}</td><td class="{cls}">{pct:.1f}%</td></tr>'
+    for rel, covered, uncovered, total, pct, status, observed in rows
+    for cls in ['low' if pct < 60 else 'good']
+)}
+</tbody></table>
+<p class="meta">Open the detailed OpenCppCoverage report at <a href="index.html">index.html</a>.</p>
+</body></html>
+'''
+summary_path.write_text(summary_html, encoding='utf-8')
+
+print(f"[coverage] wrote source inventory summary to {summary_path}")
+print(f"[coverage] overall inventory coverage: {100.0 * covered_total / (covered_total + uncovered_total) if (covered_total + uncovered_total) else 0.0:.1f}%")
+PY
+
+echo "[coverage] report ready: $OUTPUT_DIR"
+if [[ -f "$OUTPUT_DIR/coverage-summary.txt" ]]; then
+  echo "[coverage] summary"
+  cat "$OUTPUT_DIR/coverage-summary.txt"
+fi

--- a/scripts/run-native-coverage.sh
+++ b/scripts/run-native-coverage.sh
@@ -60,7 +60,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-mkdir -p "$ROOT_DIR"
+cd "$ROOT_DIR"
 
 if [[ "$SKIP_BUILD" -eq 0 ]]; then
   if [[ -f "$BUILD_DIR/CMakeCache.txt" ]]; then

--- a/scripts/run-native-coverage.sh
+++ b/scripts/run-native-coverage.sh
@@ -88,37 +88,46 @@ else
 fi
 
 mkdir -p "$OUTPUT_DIR"
+coverage_status="ok"
 
 if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* || "$OS" == "Windows_NT" ]]; then
   if command -v OpenCppCoverage.exe >/dev/null 2>&1; then
     SOURCE_ROOT_W="$(cygpath -w "$ROOT_DIR/src/native" 2>/dev/null || printf '%s' "$ROOT_DIR/src/native")"
     OUTPUT_DIR_W="$(cygpath -w "$OUTPUT_DIR" 2>/dev/null || printf '%s' "$OUTPUT_DIR")"
     echo "[coverage] generating Windows HTML report at $OUTPUT_DIR"
-    OpenCppCoverage.exe \
+    if ! OpenCppCoverage.exe \
       --working_dir "$ROOT_DIR" \
       --sources "$SOURCE_ROOT_W" \
       --export_type html:"$OUTPUT_DIR_W" \
       --cover_children \
       -- \
-      ctest --test-dir "$BUILD_DIR" -C Debug --output-on-failure
+      ctest --test-dir "$BUILD_DIR" -C Debug --output-on-failure; then
+      coverage_status="warn"
+      echo "[coverage] warning: OpenCppCoverage failed; writing fallback inventory summary"
+    fi
   else
-    die "OpenCppCoverage.exe was not found. Install OpenCppCoverage or run this script on a Unix-like environment with gcovr installed."
+    coverage_status="warn"
+    echo "[coverage] warning: OpenCppCoverage.exe was not found; writing fallback inventory summary"
   fi
 else
   if ! command -v gcovr >/dev/null 2>&1; then
-    die "gcovr is required. Install it with your package manager (for example: sudo apt-get install -y gcovr lcov)."
+    coverage_status="warn"
+    echo "[coverage] warning: gcovr is required; writing fallback inventory summary"
+  else
+    echo "[coverage] generating gcovr report at $OUTPUT_DIR"
+    if ! gcovr \
+      --root "$ROOT_DIR" \
+      --filter "$ROOT_DIR/src/native/" \
+      --html-details "$OUTPUT_DIR/index.html" \
+      --txt "$OUTPUT_DIR/coverage-summary.txt" \
+      --print-summary \
+      --sort uncovered \
+      --exclude '.*tests.*' \
+      --exclude '.*third_party.*'; then
+      coverage_status="warn"
+      echo "[coverage] warning: gcovr failed; writing fallback inventory summary"
+    fi
   fi
-
-  echo "[coverage] generating gcovr report at $OUTPUT_DIR"
-  gcovr \
-    --root "$ROOT_DIR" \
-    --filter "$ROOT_DIR/src/native/" \
-    --html-details "$OUTPUT_DIR/index.html" \
-    --txt "$OUTPUT_DIR/coverage-summary.txt" \
-    --print-summary \
-    --sort uncovered \
-    --exclude '.*tests.*' \
-    --exclude '.*third_party.*'
 fi
 
 BANANA_NATIVE_COVERAGE_REPORT_DIR="$OUTPUT_DIR" python - <<'PY'
@@ -227,13 +236,17 @@ summary_html = f'''<!DOCTYPE html>
 </body></html>
 '''
 summary_path.write_text(summary_html, encoding='utf-8')
+summary_md = report_dir / 'coverage-summary.md'
+summary_md.write_text(f"# Native source inventory coverage\n\n- Overall inventory coverage: {overall_pct:.1f}%\n- Source inventory summary: [coverage-files-summary.html](coverage-files-summary.html)\n- Detailed report: [index.html](index.html)\n", encoding='utf-8')
 
 print(f"[coverage] wrote source inventory summary to {summary_path}")
-print(f"[coverage] overall inventory coverage: {100.0 * covered_total / (covered_total + uncovered_total) if (covered_total + uncovered_total) else 0.0:.1f}%")
+print(f"[coverage] overall inventory coverage: {overall_pct:.1f}%")
+if coverage_status != 'ok':
+    print(f"[coverage] warning: coverage tool reported a problem; fallback inventory summary was written")
 PY
 
 echo "[coverage] report ready: $OUTPUT_DIR"
-if [[ -f "$OUTPUT_DIR/coverage-summary.txt" ]]; then
+if [[ -f "$OUTPUT_DIR/coverage-summary.md" ]]; then
   echo "[coverage] summary"
-  cat "$OUTPUT_DIR/coverage-summary.txt"
+  cat "$OUTPUT_DIR/coverage-summary.md"
 fi

--- a/scripts/run-native-coverage.sh
+++ b/scripts/run-native-coverage.sh
@@ -151,29 +151,47 @@ if not source_root.exists():
 
 modules_candidates = [report_dir / 'Modules', report_dir / 'coverage-report-msvc' / 'Modules']
 coverage_by_file = {}
-for modules_dir in modules_candidates:
-    if not modules_dir.exists():
-        continue
-    for module_dir in sorted(modules_dir.iterdir()):
-        if not module_dir.is_dir():
-            continue
-        for html_file in sorted(module_dir.glob('*.html')):
-            if html_file.name == 'index.html':
-                continue
-            text = html_file.read_text(encoding='utf-8', errors='ignore')
-            title_match = re.search(r'<title>(.*?)</title>', text, re.I | re.S)
-            title = title_match.group(1).strip() if title_match else html_file.stem
-            covered = len(re.findall(r'background-color:#dfd', text))
-            uncovered = len(re.findall(r'background-color:#fdd', text))
-            total = covered + uncovered
-            if total <= 0:
-                continue
-            coverage_by_file[title] = {
-                'covered': coverage_by_file.get(title, {}).get('covered', 0) + covered,
-                'uncovered': coverage_by_file.get(title, {}).get('uncovered', 0) + uncovered,
-                'total': coverage_by_file.get(title, {}).get('total', 0) + total,
-            }
 
+gcovr_json_path = report_dir / 'gcovr.json'
+if gcovr_json_path.exists():
+    import json
+    gcovr_data = json.loads(gcovr_json_path.read_text(encoding='utf-8', errors='ignore') or '{}')
+    for entry in gcovr_data.get('files', []):
+        file_path = Path(entry.get('file', ''))
+        try:
+            key = file_path.resolve().relative_to(source_root).as_posix()
+        except Exception:
+            key = file_path.as_posix()
+        lines = (entry.get('summary') or {}).get('lines') or {}
+        coverage_by_file[key] = {
+            'covered': int(lines.get('covered', 0)),
+            'uncovered': int(lines.get('missing', 0)),
+            'total': int(lines.get('count', 0)),
+        }
+else:
+    for modules_dir in modules_candidates:
+        if not modules_dir.exists():
+            continue
+        for module_dir in sorted(modules_dir.iterdir()):
+            if not module_dir.is_dir():
+                continue
+            for html_file in sorted(module_dir.glob('*.html')):
+                if html_file.name == 'index.html':
+                    continue
+                text = html_file.read_text(encoding='utf-8', errors='ignore')
+                title_match = re.search(r'<title>(.*?)</title>', text, re.I | re.S)
+                title = title_match.group(1).strip() if title_match else html_file.stem
+                key = Path(title).name
+                covered = len(re.findall(r'background-color:#dfd', text))
+                uncovered = len(re.findall(r'background-color:#fdd', text))
+                total = covered + uncovered
+                if total <= 0:
+                    continue
+                coverage_by_file[key] = {
+                    'covered': coverage_by_file.get(key, {}).get('covered', 0) + covered,
+                    'uncovered': coverage_by_file.get(key, {}).get('uncovered', 0) + uncovered,
+                    'total': coverage_by_file.get(key, {}).get('total', 0) + total,
+                }
 rows = []
 all_sources = []
 for path in sorted(source_root.rglob('*')):

--- a/scripts/run-native-coverage.sh
+++ b/scripts/run-native-coverage.sh
@@ -90,7 +90,8 @@ fi
 mkdir -p "$OUTPUT_DIR"
 coverage_status="ok"
 
-if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* || "$OS" == "Windows_NT" ]]; then
+os_name="${OSTYPE:-}"
+if [[ "$os_name" == msys* || "$os_name" == cygwin* || "${OS:-}" == "Windows_NT" ]]; then
   if command -v OpenCppCoverage.exe >/dev/null 2>&1; then
     SOURCE_ROOT_W="$(cygpath -w "$ROOT_DIR/src/native" 2>/dev/null || printf '%s' "$ROOT_DIR/src/native")"
     OUTPUT_DIR_W="$(cygpath -w "$OUTPUT_DIR" 2>/dev/null || printf '%s' "$OUTPUT_DIR")"
@@ -130,7 +131,7 @@ else
   fi
 fi
 
-BANANA_NATIVE_COVERAGE_REPORT_DIR="$OUTPUT_DIR" python - <<'PY'
+BANANA_NATIVE_COVERAGE_ROOT_DIR="$ROOT_DIR" BANANA_NATIVE_COVERAGE_REPORT_DIR="$OUTPUT_DIR" BANANA_NATIVE_COVERAGE_STATUS="$coverage_status" python - <<'PY'
 import os
 import re
 import html
@@ -143,7 +144,8 @@ report_dir = report_dir.resolve() if report_dir.exists() else Path(report_dir)
 if not report_dir.exists():
     raise SystemExit(f"coverage report directory does not exist: {report_dir}")
 
-source_root = (Path(os.getcwd()) / 'src' / 'native').resolve()
+root_dir = Path(os.environ.get('BANANA_NATIVE_COVERAGE_ROOT_DIR', os.getcwd())).resolve()
+source_root = (root_dir / 'src' / 'native').resolve()
 if not source_root.exists():
     raise SystemExit(f"native source root does not exist: {source_root}")
 
@@ -241,7 +243,7 @@ summary_md.write_text(f"# Native source inventory coverage\n\n- Overall inventor
 
 print(f"[coverage] wrote source inventory summary to {summary_path}")
 print(f"[coverage] overall inventory coverage: {overall_pct:.1f}%")
-if coverage_status != 'ok':
+if os.environ.get('BANANA_NATIVE_COVERAGE_STATUS', 'ok') != 'ok':
     print(f"[coverage] warning: coverage tool reported a problem; fallback inventory summary was written")
 PY
 

--- a/scripts/run-native-coverage.sh
+++ b/scripts/run-native-coverage.sh
@@ -63,12 +63,8 @@ done
 cd "$ROOT_DIR"
 
 if [[ "$SKIP_BUILD" -eq 0 ]]; then
-  if [[ -f "$BUILD_DIR/CMakeCache.txt" ]]; then
-    echo "[coverage] reusing existing build tree at $BUILD_DIR"
-  else
-    echo "[coverage] configuring native coverage build in $BUILD_DIR"
-    cmake -S "$ROOT_DIR/src/native" -B "$BUILD_DIR" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBANANA_ENABLE_COVERAGE=ON
-  fi
+  echo "[coverage] configuring native coverage build in $BUILD_DIR"
+  cmake -S "$ROOT_DIR/src/native" -B "$BUILD_DIR" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBANANA_ENABLE_COVERAGE=ON
 
   echo "[coverage] building native targets"
   cmake --build "$BUILD_DIR" --parallel

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -7,6 +7,12 @@ option(BANANA_ENABLE_POSTGRES "Enable native PostgreSQL/PgBouncer bridge paths" 
 option(BANANA_ENABLE_DETERMINISTIC_PERSISTENCE_TESTS
 	"Enable deterministic persistent-world native test targets"
 	ON)
+option(BANANA_ENABLE_COVERAGE "Enable native coverage instrumentation for GCC/Clang toolchains" OFF)
+
+if(BANANA_ENABLE_COVERAGE AND NOT MSVC)
+	add_compile_options(--coverage)
+	add_link_options(--coverage)
+endif()
 
 add_subdirectory(engine)
 

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -7,7 +7,7 @@ option(BANANA_ENABLE_POSTGRES "Enable native PostgreSQL/PgBouncer bridge paths" 
 option(BANANA_ENABLE_DETERMINISTIC_PERSISTENCE_TESTS
 	"Enable deterministic persistent-world native test targets"
 	ON)
-option(BANANA_ENABLE_COVERAGE "Enable native coverage instrumentation for GCC/Clang toolchains" OFF)
+option(BANANA_ENABLE_COVERAGE "Enable native coverage instrumentation" OFF)
 
 if(BANANA_ENABLE_COVERAGE AND NOT MSVC)
 	add_compile_options(--coverage)

--- a/src/native/engine/CMakeLists.txt
+++ b/src/native/engine/CMakeLists.txt
@@ -373,8 +373,16 @@ endif()
 # ─────────────────────────────────────────────────────────────────────────────
 
 if(BANANA_ENABLE_COVERAGE)
-  target_compile_options(banana_engine_core PRIVATE -fprofile-arcs -ftest-coverage)
-  target_link_options(banana_engine_core PRIVATE -fprofile-arcs -ftest-coverage)
+  if(MSVC)
+    target_compile_options(banana_engine_core PRIVATE /Zi)
+    target_link_options(banana_engine_core PRIVATE /PROFILE /DEBUG)
+
+    target_compile_options(banana_asset_compiler PRIVATE /Zi)
+    target_link_options(banana_asset_compiler PRIVATE /PROFILE /DEBUG)
+  else()
+    target_compile_options(banana_engine_core PRIVATE -fprofile-arcs -ftest-coverage)
+    target_link_options(banana_engine_core PRIVATE -fprofile-arcs -ftest-coverage)
+  endif()
 endif()
 
 if(BUILD_TESTING)

--- a/tests/native/runtime/ai/controller/controller_system_test.c
+++ b/tests/native/runtime/ai/controller/controller_system_test.c
@@ -127,7 +127,37 @@ static void test_controller_signal_type_filters_by_controller_type(void **state)
     controller_system_destroy(sys);
 }
 
+static void test_controller_system_destroy_tears_down_instances(void **state)
+{
+    (void)state;
+    ControllerSystem *sys = NULL;
+    uint32_t first_id;
+    uint32_t second_id;
+
+    g_updates = 0;
+    g_signals = 0;
+    g_destroys = 0;
+    g_alpha_signals = 0;
+    g_beta_signals = 0;
+
+    controller_register("alpha", alpha_factory);
+    controller_register("beta", beta_factory);
+    sys = controller_system_create();
+    BANANA_TEST_ASSERT_TRUE(sys != NULL, "controller system must allocate for teardown test");
+
+    first_id = controller_system_spawn(sys, "alpha", 1.0f, 2.0f, 3.0f);
+    second_id = controller_system_spawn(sys, "beta", 4.0f, 5.0f, 6.0f);
+    BANANA_TEST_ASSERT_INT_EQ(first_id, 1, "first spawned controller should receive id 1");
+    BANANA_TEST_ASSERT_INT_EQ(second_id, 2, "second spawned controller should receive id 2");
+    BANANA_TEST_ASSERT_INT_EQ(sys->count, 2, "teardown test should create two instances");
+
+    controller_system_destroy(sys);
+
+    BANANA_TEST_ASSERT_INT_EQ(g_destroys, 2, "destroying the system should invoke the destroy callback for each instance");
+}
+
 BANANA_TEST_MAIN(
     BANANA_TEST_CASE(test_controller_factory_and_system),
-    BANANA_TEST_CASE(test_controller_signal_type_filters_by_controller_type)
+    BANANA_TEST_CASE(test_controller_signal_type_filters_by_controller_type),
+    BANANA_TEST_CASE(test_controller_system_destroy_tears_down_instances)
 )

--- a/tests/native/runtime/runtime/controller/controller_runtime_test.c
+++ b/tests/native/runtime/runtime/controller/controller_runtime_test.c
@@ -75,6 +75,8 @@ static void test_runtime_controller_helpers(void **state)
                             "signal-by-id must dispatch to matched controller");
     BANANA_TEST_ASSERT_INT_EQ(g_signal_calls, 1,
                               "signal-by-id must trigger controller callback");
+    BANANA_TEST_ASSERT_INT_EQ(g_last_signal_value, 7,
+                              "signal-by-id must forward payload through callback");
 
     BANANA_TEST_ASSERT_TRUE(runtime_controller_assign_team_by_id(controllers, 2, 2, CONTROLLER_TEAM_NEUTRAL),
                             "assign-team-by-id must update team membership");

--- a/tests/native/runtime/support/copy_runtime_dlls.cmake
+++ b/tests/native/runtime/support/copy_runtime_dlls.cmake
@@ -1,3 +1,7 @@
+if(NOT DEFINED banana_target_dir OR banana_target_dir STREQUAL "")
+	message(FATAL_ERROR "banana_target_dir must be set when invoking copy_runtime_dlls.cmake")
+endif()
+
 if(NOT DEFINED banana_runtime_dlls OR banana_runtime_dlls STREQUAL "")
 	return()
 endif()

--- a/tests/native/runtime/support/test_support.h
+++ b/tests/native/runtime/support/test_support.h
@@ -63,6 +63,17 @@ typedef int (*banana_native_test_teardown_fn)(void **state);
             fail_msg("%s", (message));                                                             \
     } while (0)
 
+/* For helpers that return a value: asserts condition and returns ret on failure. */
+#define BANANA_TEST_ASSERT_TRUE_RET(condition, message, ret)                                        \
+    do                                                                                              \
+    {                                                                                               \
+        if (!(condition))                                                                           \
+        {                                                                                           \
+            fail_msg("%s", (message));                                                             \
+            return (ret);                                                                           \
+        }                                                                                           \
+    } while (0)
+
 #define BANANA_TEST_ASSERT_INT_EQ(actual, expected, message)                                        \
     do                                                                                              \
     {                                                                                               \
@@ -182,6 +193,17 @@ static inline int banana_native_run_tests(const BananaNativeTestCase *tests,
         {                                                                                            \
             banana_native_record_failure((message), __FILE__, __LINE__);                            \
             return;                                                                                  \
+        }                                                                                            \
+    } while (0)
+
+/* For helpers that return a value: records failure and returns ret without aborting the process. */
+#define BANANA_TEST_ASSERT_TRUE_RET(condition, message, ret)                                         \
+    do                                                                                               \
+    {                                                                                                \
+        if (!(condition))                                                                            \
+        {                                                                                            \
+            banana_native_record_failure((message), __FILE__, __LINE__);                            \
+            return (ret);                                                                            \
         }                                                                                            \
     } while (0)
 


### PR DESCRIPTION
## Summary
- add a native coverage script that produces a source-inventory summary page for the full native tree
- surface the overall native inventory coverage as an informational CI notice instead of a blocker
- upload the generated coverage artifacts for inspection

## Notes
- The Native / coverage job remains visible in CI and uploads artifacts, but it no longer blocks PRs.