### PR TITLE
Scaffold root Banana CLI with K3H4 command router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 !tests/native/runtime/player/build/**
 out/
 bin/
+!cli/banana/bin/
+!cli/banana/bin/banana.mjs
 obj/
 CMakeFiles/
 CMakeCache.txt

--- a/cli/banana/README.md
+++ b/cli/banana/README.md
@@ -1,0 +1,29 @@
+# Banana CLI (Scaffold)
+
+This package hosts the root-level Banana CLI under `cli/*`.
+
+Current scope is K3H4-only command scaffolding so iteration can happen from terminal workflows without frontend dependencies.
+
+## Commands (Scaffold)
+
+- `banana k3h4 sample`
+- `banana k3h4 run`
+- `banana k3h4 explain`
+- `banana k3h4 export`
+
+All commands are currently stubs and print help or a not-implemented placeholder.
+
+## Local usage
+
+From repo root:
+
+```bash
+bun run banana --help
+bun run banana k3h4 --help
+```
+
+From package folder:
+
+```bash
+bun run banana --help
+```

--- a/cli/banana/bin/banana.mjs
+++ b/cli/banana/bin/banana.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env bun
+
+const argv = process.argv.slice(2);
+
+function printRootHelp() {
+  console.log(`banana CLI (scaffold)
+
+Usage:
+  banana <command> [options]
+
+Commands:
+  k3h4      K3H4 command group
+
+Examples:
+  banana --help
+  banana k3h4 --help
+`);
+}
+
+function printK3h4Help() {
+  console.log(`banana k3h4 (scaffold)
+
+Usage:
+  banana k3h4 <command> [options]
+
+Commands:
+  sample    Generate deterministic sample dataset (stub)
+  run       Execute K3H4 via API contract path (stub)
+  explain   Explain K3H4 outputs (stub)
+  export    Export K3H4 artifacts (stub)
+
+Global options:
+  --api-url <url>    Override API base URL (default: http://localhost:3000)
+
+Examples:
+  banana k3h4 sample --help
+  banana k3h4 run --help
+`);
+}
+
+function printSubcommandHelp(name) {
+  console.log(`banana k3h4 ${name} (stub)
+
+Status:
+  This command is scaffolded but not implemented yet.
+
+Usage:
+  banana k3h4 ${name} [options]
+
+Notes:
+  - V1 will use stdin JSON as canonical input/output chaining contract.
+  - V1 defaults to strict validation and non-zero exit on contract violations.
+`);
+}
+
+function notImplemented(name) {
+  console.error(`banana k3h4 ${name}: not implemented yet (scaffold placeholder)`);
+  process.exitCode = 2;
+}
+
+if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
+  printRootHelp();
+  process.exit(0);
+}
+
+const [command, ...rest] = argv;
+
+if (command !== "k3h4") {
+  console.error(`Unknown command: ${command}`);
+  printRootHelp();
+  process.exit(1);
+}
+
+if (rest.length === 0 || rest.includes("--help") || rest.includes("-h")) {
+  printK3h4Help();
+  process.exit(0);
+}
+
+const [subcommand, ...subArgs] = rest;
+const supported = new Set(["sample", "run", "explain", "export"]);
+
+if (!supported.has(subcommand)) {
+  console.error(`Unknown k3h4 subcommand: ${subcommand}`);
+  printK3h4Help();
+  process.exit(1);
+}
+
+if (subArgs.includes("--help") || subArgs.includes("-h")) {
+  printSubcommandHelp(subcommand);
+  process.exit(0);
+}
+
+notImplemented(subcommand);

--- a/cli/banana/package.json
+++ b/cli/banana/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@banana/cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "banana": "./bin/banana.mjs"
+  },
+  "scripts": {
+    "banana": "bun ./bin/banana.mjs",
+    "test:smoke": "bun ./bin/banana.mjs --help && bun ./bin/banana.mjs k3h4 --help"
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,17 @@
 
 This repository includes a K3H4-first netcode analytics pipeline that flows across native, API, and frontend layers.
 
+## CLI Quickstart
+
+The root CLI scaffold now lives under `cli/*` and starts with K3H4-only commands.
+
+From repo root:
+
+```bash
+bun run banana --help
+bun run banana k3h4 --help
+```
+
 ## K3H4 Model
 
 K3H4 is the authoritative analytics model used for netcode clustering, convergence scoring, and ABI coverage reporting in the runtime UI.

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "1.0.0",
   "private": true,
   "workspaces": [
+    "cli/*",
     "src/typescript/api",
     "src/typescript/react",
     "src/typescript/shared/*"
   ],
   "scripts": {
+    "banana": "bun run --cwd cli/banana banana",
+    "test:banana-cli:smoke": "bun run --cwd cli/banana test:smoke",
     "kickoff:status": "bash scripts/kickoff-return-to-work.sh --status-only",
     "kickoff:return:auto-fix": "bash scripts/kickoff-return-to-work.sh --auto-fix",
     "kickoff:return": "bash scripts/kickoff-return-to-work.sh",


### PR DESCRIPTION
## Summary
- scaffold root CLI package under `cli/*` at `cli/banana`
- add executable `banana` entrypoint with K3H4 command router
- add stubs for `sample`, `run`, `explain`, and `export`
- wire root workspace/scripts and add docs quickstart

## Story
- Closes #1162

## Golden Pipeline Example (Required)

```bash
bun run banana --help
bun run banana k3h4 --help
```

Expected behavior:
- root help lists `k3h4` command group
- `banana k3h4 --help` lists stub subcommands and `--api-url` override

## Validation
```bash
bun run banana --help
bun run banana k3h4 --help
bun run --cwd cli/banana test:smoke
```

## Notes
- `cli/banana/bin/banana.mjs` is intentionally tracked with a `.gitignore` exception so the CLI executable is versioned.
- command implementations remain stubs for downstream stories #1163-#1166.
