### PR TITLE
Scaffold Python root Banana CLI with K3H4 command router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ coverage/
 # Universal workspace noise
 .DS_Store
 Thumbs.db
+**/__pycache__/
+*.pyc
 *.tmp
 *.swp
 .idea/

--- a/cli/banana/README.md
+++ b/cli/banana/README.md
@@ -1,0 +1,28 @@
+# Banana CLI (Python Scaffold)
+
+This package scaffolds the root-level Banana CLI under `cli/*` with K3H4-focused command routing.
+
+Current implementation status:
+
+- command router is implemented
+- `k3h4` subcommands are scaffolded stubs
+- native-direct execution is planned for follow-up stories
+
+## Local usage (no install)
+
+From `cli/banana`:
+
+```bash
+python -m banana_cli --help
+python -m banana_cli k3h4 --help
+```
+
+## Install editable script entrypoint
+
+From repo root:
+
+```bash
+python -m pip install -e cli/banana
+banana --help
+banana k3h4 --help
+```

--- a/cli/banana/README.md
+++ b/cli/banana/README.md
@@ -5,7 +5,7 @@ This package scaffolds the root-level Banana CLI under `cli/*` with K3H4-focused
 Current implementation status:
 
 - command router is implemented
-- `k3h4` subcommands are scaffolded stubs
+- `k3h4` subcommands are scaffolded stubs: sample, run, explain, export, doctor
 - native-direct execution is planned for follow-up stories
 
 ## Local usage (no install)

--- a/cli/banana/banana_cli/__init__.py
+++ b/cli/banana/banana_cli/__init__.py
@@ -1,0 +1,1 @@
+"""Banana CLI package."""

--- a/cli/banana/banana_cli/__main__.py
+++ b/cli/banana/banana_cli/__main__.py
@@ -1,0 +1,5 @@
+from .main import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/banana/banana_cli/main.py
+++ b/cli/banana/banana_cli/main.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+
+DEFAULT_API_URL = "http://localhost:3000"
+
+
+def _not_implemented(command: str) -> int:
+    print(f"banana k3h4 {command}: not implemented yet (scaffold placeholder)", file=sys.stderr)
+    return 2
+
+
+def _k3h4_group_help(args: argparse.Namespace) -> int:
+    parser = args._parser
+    parser.print_help()
+    return 0
+
+
+def _k3h4_sample(args: argparse.Namespace) -> int:
+    return _not_implemented("sample")
+
+
+def _k3h4_run(args: argparse.Namespace) -> int:
+    return _not_implemented("run")
+
+
+def _k3h4_explain(args: argparse.Namespace) -> int:
+    return _not_implemented("explain")
+
+
+def _k3h4_export(args: argparse.Namespace) -> int:
+    return _not_implemented("export")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="banana",
+        description="Banana CLI (Python scaffold)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    k3h4_parser = subparsers.add_parser("k3h4", help="K3H4 command group")
+    k3h4_parser.set_defaults(handler=_k3h4_group_help, _parser=k3h4_parser)
+    k3h4_subparsers = k3h4_parser.add_subparsers(dest="k3h4_command")
+
+    def add_k3h4_subcommand(name: str, help_text: str, handler):
+        cmd = k3h4_subparsers.add_parser(name, help=help_text)
+        cmd.add_argument(
+            "--api-url",
+            default=DEFAULT_API_URL,
+            help=f"API base URL override (default: {DEFAULT_API_URL})",
+        )
+        cmd.set_defaults(handler=handler)
+
+    add_k3h4_subcommand("sample", "Generate deterministic sample dataset (stub)", _k3h4_sample)
+    add_k3h4_subcommand("run", "Execute K3H4 pipeline (stub)", _k3h4_run)
+    add_k3h4_subcommand("explain", "Explain K3H4 outputs (stub)", _k3h4_explain)
+    add_k3h4_subcommand("export", "Export K3H4 artifacts (stub)", _k3h4_export)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not hasattr(args, "handler"):
+        parser.print_help()
+        return 0
+
+    return int(args.handler(args))

--- a/cli/banana/banana_cli/main.py
+++ b/cli/banana/banana_cli/main.py
@@ -35,6 +35,10 @@ def _k3h4_export(args: argparse.Namespace) -> int:
     return _not_implemented("export")
 
 
+def _k3h4_doctor(args: argparse.Namespace) -> int:
+    return _not_implemented("doctor")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="banana",
@@ -60,6 +64,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_k3h4_subcommand("run", "Execute K3H4 pipeline (stub)", _k3h4_run)
     add_k3h4_subcommand("explain", "Explain K3H4 outputs (stub)", _k3h4_explain)
     add_k3h4_subcommand("export", "Export K3H4 artifacts (stub)", _k3h4_export)
+    add_k3h4_subcommand("doctor", "Run read-only preflight diagnostics (stub)", _k3h4_doctor)
 
     return parser
 

--- a/cli/banana/pyproject.toml
+++ b/cli/banana/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "banana-cli"
+version = "0.1.0"
+description = "Banana root CLI scaffold (Python, native-direct direction)"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.scripts]
+banana = "banana_cli.main:main"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["banana_cli*"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,17 @@
 
 This repository includes a K3H4-first netcode analytics pipeline that flows across native, API, and frontend layers.
 
+## CLI Quickstart (Python)
+
+Root CLI scaffolding now lives under `cli/*` with a Python entrypoint in `cli/banana`.
+
+From `cli/banana`:
+
+```bash
+python -m banana_cli --help
+python -m banana_cli k3h4 --help
+```
+
 ## K3H4 Model
 
 K3H4 is the authoritative analytics model used for netcode clustering, convergence scoring, and ABI coverage reporting in the runtime UI.


### PR DESCRIPTION
## Summary
- scaffold root Python CLI package under `cli/banana`
- add executable-style entrypoint via Python module/package (`banana_cli.main`)
- add `k3h4` command namespace with stubs for `sample`, `run`, `explain`, `export`
- add docs quickstart for Python CLI invocation

## Story
- Closes #1162

## Golden Pipeline Example (Required)
```bash
cd cli/banana
python -m banana_cli --help
python -m banana_cli k3h4 --help
```

Expected behavior:
- root help lists `k3h4` command group
- `k3h4` help lists `sample`, `run`, `explain`, `export`

## Validation
```bash
cd cli/banana
python -m banana_cli --help
python -m banana_cli k3h4 --help
```

## Notes
- This PR intentionally replaces the prior JS scaffold direction with Python-first scaffolding for native-direct CLI strategy.
