### PR TITLE
Implement deterministic banana k3h4 sample command

### DIFF
--- a/cli/banana/README.md
+++ b/cli/banana/README.md
@@ -5,9 +5,33 @@ This package scaffolds the root-level Banana CLI under `cli/*` with K3H4-focused
 Current implementation status:
 
 - command router is implemented
-- `k3h4` subcommands are scaffolded: sample, run, explain, export
+- `k3h4 sample` emits deterministic canonical JSON datasets (`schema_version=1`)
+- `k3h4` remaining subcommands are scaffolded: run, explain, export
 - `k3h4 doctor` runs read-only preflight diagnostics for Python, native ABI, and schema checks
 - native-direct execution is planned for follow-up stories
+
+## Sample dataset generation
+
+`banana k3h4 sample` emits canonical JSON to stdout and is designed for stdin piping into `banana k3h4 run`.
+
+Flags:
+
+- `--seed` (default `42`)
+- `--count` (default `4`, must be `>=1`)
+- `--dims` (default `16`, must be `1..16`)
+- `--preset` (`baseline` or `combat`)
+
+Determinism contract:
+
+- Same args and seed produce byte-identical output.
+- Output is emitted with stable key ordering.
+
+Golden sample examples:
+
+```bash
+python -m banana_cli k3h4 sample --seed 7 --count 2 --dims 16 --preset baseline
+python -m banana_cli k3h4 sample --seed 7 --count 2 --dims 16 --preset baseline | python -m banana_cli k3h4 run
+```
 
 ## Doctor preflight checks
 
@@ -46,6 +70,7 @@ From `cli/banana`:
 ```bash
 python -m banana_cli --help
 python -m banana_cli k3h4 --help
+python -m banana_cli k3h4 sample --help
 python -m banana_cli k3h4 doctor --help
 ```
 

--- a/cli/banana/banana_cli/main.py
+++ b/cli/banana/banana_cli/main.py
@@ -6,6 +6,7 @@ import json
 import os
 from pathlib import Path
 import platform
+import random
 import sys
 from dataclasses import dataclass
 from typing import Sequence
@@ -16,6 +17,8 @@ EXPECTED_ABI_VERSION = 3
 EXPECTED_PING_STATUS = 0
 REQUIRED_PYTHON = (3, 10)
 CANONICAL_SCHEMA_RELATIVE = Path("src/typescript/api/coverage-denominator.json")
+SAMPLE_SCHEMA_VERSION = 1
+DEFAULT_SAMPLE_PRESET = "baseline"
 NATIVE_LIBRARY_FILENAMES = (
     "libbanana_native.so",
     "banana_native.so",
@@ -132,7 +135,73 @@ def _k3h4_group_help(args: argparse.Namespace) -> int:
 
 
 def _k3h4_sample(args: argparse.Namespace) -> int:
-    return _not_implemented("sample")
+    if args.count < 1:
+        finding = DoctorFinding(
+            level="error",
+            check="sample_validation",
+            error_code="BANANA_SAMPLE_COUNT_INVALID",
+            message="count must be >= 1",
+            field_path="count",
+        )
+        _emit_error_envelope(finding)
+        return 1
+
+    if args.dims < 1 or args.dims > 16:
+        finding = DoctorFinding(
+            level="error",
+            check="sample_validation",
+            error_code="BANANA_SAMPLE_DIMS_INVALID",
+            message="dims must be in range 1..16",
+            field_path="dims",
+        )
+        _emit_error_envelope(finding)
+        return 1
+
+    rng = random.Random(args.seed)
+    samples = [_build_k3h4_sample_vector(rng=rng, dims=args.dims, preset=args.preset) for _ in range(args.count)]
+    payload = {
+        "count": args.count,
+        "dims": args.dims,
+        "preset": args.preset,
+        "samples": samples,
+        "schema_version": SAMPLE_SCHEMA_VERSION,
+        "seed": args.seed,
+    }
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+def _build_k3h4_sample_vector(*, rng: random.Random, dims: int, preset: str) -> dict[str, int]:
+    base = {
+        "call_density": rng.randint(20, 95),
+        "quest_percent": rng.randint(5, 100),
+        "player_level": rng.randint(1, 100),
+        "combo_streak": rng.randint(0, 32),
+        "branch_pressure": rng.randint(0, 100),
+        "dependency_pulse": rng.randint(0, 100),
+        "workflow_depth": rng.randint(1, 64),
+        "neural_relevance_score": rng.randint(0, 100),
+        "network_dimensions": dims,
+        "model_confidence": rng.randint(0, 100),
+        "policy_momentum": rng.randint(0, 100),
+        "assignment_family": 0,
+        "spectral_mode": 1,
+        "hardware_byte_order_tag": 0x01020304,
+        "hardware_dtype_tag": 1,
+        "hardware_alignment_bytes": 4,
+    }
+
+    if preset == "baseline":
+        return base
+
+    if preset == "combat":
+        base["call_density"] = rng.randint(70, 100)
+        base["combo_streak"] = rng.randint(8, 48)
+        base["branch_pressure"] = rng.randint(45, 100)
+        base["policy_momentum"] = rng.randint(55, 100)
+        return base
+
+    return base
 
 
 def _k3h4_run(args: argparse.Namespace) -> int:
@@ -359,7 +428,37 @@ def build_parser() -> argparse.ArgumentParser:
             configure(cmd)
         cmd.set_defaults(handler=handler)
 
-    add_k3h4_subcommand("sample", "Generate deterministic sample dataset (stub)", _k3h4_sample)
+    add_k3h4_subcommand(
+        "sample",
+        "Generate deterministic sample dataset",
+        _k3h4_sample,
+        configure=lambda cmd: (
+            cmd.add_argument(
+                "--seed",
+                type=int,
+                default=42,
+                help="Seed for deterministic sample generation",
+            ),
+            cmd.add_argument(
+                "--count",
+                type=int,
+                default=4,
+                help="Number of sample vectors to emit",
+            ),
+            cmd.add_argument(
+                "--dims",
+                type=int,
+                default=16,
+                help="network_dimensions value (1..16)",
+            ),
+            cmd.add_argument(
+                "--preset",
+                choices=("baseline", "combat"),
+                default=DEFAULT_SAMPLE_PRESET,
+                help="Distribution preset",
+            ),
+        ),
+    )
     add_k3h4_subcommand("run", "Execute K3H4 pipeline (stub)", _k3h4_run)
     add_k3h4_subcommand("explain", "Explain K3H4 outputs (stub)", _k3h4_explain)
     add_k3h4_subcommand("export", "Export K3H4 artifacts (stub)", _k3h4_export)


### PR DESCRIPTION
## Summary
- implement `banana k3h4 sample` deterministic dataset generation
- add seeded generation flags (`--seed`, `--count`, `--dims`) and baseline preset support (`--preset baseline|combat`)
- emit canonical JSON to stdout with stable key ordering and `schema_version: 1`
- validate invalid args with non-zero exit and JSON diagnostics on stderr

## Golden pipeline example
```bash
cd cli/banana
python -m banana_cli k3h4 sample --seed 7 --count 2 --dims 16 --preset baseline | python -m banana_cli k3h4 run
```

## Deterministic output snippet (sample stage)
```json
{"count":2,"dims":16,"preset":"baseline","samples":[{"assignment_family":0,"branch_pressure":9,"call_density":61,"combo_streak":3,"dependency_pulse":68,"hardware_alignment_bytes":4,"hardware_byte_order_tag":16909060,"hardware_dtype_tag":1,"model_confidence":74,"network_dimensions":16,"neural_relevance_score":46,"player_level":51,"policy_momentum":7,"quest_percent":24,"spectral_mode":1,"workflow_depth":13},{"assignment_family":0,"branch_pressure":55,"call_density":84,"combo_streak":5,"dependency_pulse":53,"hardware_alignment_bytes":4,"hardware_byte_order_tag":16909060,"hardware_dtype_tag":1,"model_confidence":11,"network_dimensions":16,"neural_relevance_score":30,"player_level":5,"policy_momentum":70,"quest_percent":32,"spectral_mode":1,"workflow_depth":9}],"schema_version":1,"seed":7}
```

## Validation
- `cd cli/banana && python -m banana_cli k3h4 sample --help`
- `cd cli/banana && OUT1=$(python -m banana_cli k3h4 sample --seed 7 --count 2 --dims 16 --preset baseline) && OUT2=$(python -m banana_cli k3h4 sample --seed 7 --count 2 --dims 16 --preset baseline) && [[ "$OUT1" == "$OUT2" ]]`
- `cd cli/banana && python -m banana_cli k3h4 sample --seed 7 --count 2 --dims 16 --preset baseline`
- `cd cli/banana && python -m banana_cli k3h4 sample --count 0` (expected non-zero)
- `cd cli/banana && python -m banana_cli k3h4 sample --dims 17` (expected non-zero)

Closes #1163
