### PR TITLE
feat(k3h4): static deterministic pilot dialogue cluster routing

### DIFF
--- a/modules/k3h4/native/CMakeLists.txt
+++ b/modules/k3h4/native/CMakeLists.txt
@@ -26,6 +26,7 @@ endfunction()
 # Native K3H4 core
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_native_orchestrator.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_metrics_orchestration_layer.c")
+banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_cluster_router.c")
 banana_k3h4_add_source_if_exists("src/k3h4/application/k3h4_metrics_application_service.c")
 banana_k3h4_add_source_if_exists("src/k3h4/infrastructure/k3h4_metrics_infrastructure_adapter.c")
 

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_cluster_router.c
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_cluster_router.c
@@ -1,0 +1,237 @@
+#include "k3h4_dialogue_cluster_router.h"
+
+#include <stddef.h>
+#include <string.h>
+
+enum
+{
+    BANANA_K3H4_DIALOGUE_ROUTE_VERSION = 1,
+    BANANA_K3H4_RESPONSE_CONTRACT_VERSION = 1,
+};
+
+typedef struct BananaK3h4IntentRouteProfile
+{
+    int cluster_id;
+    int base_score_basis_points;
+} BananaK3h4IntentRouteProfile;
+
+static int clamp_int(int value, int min_value, int max_value)
+{
+    if (value < min_value)
+        return min_value;
+    if (value > max_value)
+        return max_value;
+    return value;
+}
+
+static void copy_literal(char *out_text, size_t out_text_size, const char *literal)
+{
+    if (out_text == NULL || out_text_size == 0)
+        return;
+
+    if (literal == NULL)
+    {
+        out_text[0] = '\0';
+        return;
+    }
+
+    strncpy(out_text, literal, out_text_size - 1);
+    out_text[out_text_size - 1] = '\0';
+}
+
+static BananaK3h4IntentRouteProfile profile_for_intent(BananaK3h4DialogueIntent intent)
+{
+    switch (intent)
+    {
+    case BANANA_K3H4_DIALOGUE_INTENT_ASK_CASTLE_ENTRY:
+        return (BananaK3h4IntentRouteProfile){ .cluster_id = 1001, .base_score_basis_points = 9200 };
+    case BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS:
+        return (BananaK3h4IntentRouteProfile){ .cluster_id = 1002, .base_score_basis_points = 8800 };
+    case BANANA_K3H4_DIALOGUE_INTENT_INSULT:
+        return (BananaK3h4IntentRouteProfile){ .cluster_id = 1003, .base_score_basis_points = 9000 };
+    case BANANA_K3H4_DIALOGUE_INTENT_REQUEST_HELP:
+        return (BananaK3h4IntentRouteProfile){ .cluster_id = 1004, .base_score_basis_points = 8700 };
+    case BANANA_K3H4_DIALOGUE_INTENT_UNKNOWN:
+    default:
+        return (BananaK3h4IntentRouteProfile){ .cluster_id = 1099, .base_score_basis_points = 6200 };
+    }
+}
+
+static BananaK3h4DialogueBoundaryState boundary_for_score(int score_basis_points)
+{
+    if (score_basis_points >= 8500)
+        return BANANA_K3H4_DIALOGUE_BOUNDARY_CORE;
+    if (score_basis_points >= 6500)
+        return BANANA_K3H4_DIALOGUE_BOUNDARY_EDGE;
+    return BANANA_K3H4_DIALOGUE_BOUNDARY_OUTSIDE;
+}
+
+static int compute_transition_id(const BananaK3h4DialogueRouteOutput *output)
+{
+    uint32_t hash = 2166136261u;
+    const uint32_t fields[] = {
+        (uint32_t)output->route_version,
+        (uint32_t)output->cluster_id,
+        (uint32_t)output->normalized_score_basis_points,
+        (uint32_t)output->boundary_state,
+        (uint32_t)output->resolved_gate,
+        (uint32_t)output->gate_precedence_rank,
+        output->triggered_gate_mask,
+    };
+    size_t index;
+
+    for (index = 0; index < sizeof(fields) / sizeof(fields[0]); ++index)
+    {
+        hash ^= fields[index];
+        hash *= 16777619u;
+    }
+
+    return (int)(hash & 0x7fffffff);
+}
+
+static void resolve_gates(const BananaK3h4DialogueRouteInput *input,
+                          BananaK3h4DialogueRouteOutput *out_output)
+{
+    uint32_t triggered_mask = 0u;
+    int secret_gate_triggered = input->mentions_secret_tunnel != 0;
+    int writ_gate_triggered =
+        input->intent == BANANA_K3H4_DIALOGUE_INTENT_ASK_CASTLE_ENTRY && input->has_entry_writ == 0;
+
+    if (secret_gate_triggered)
+        triggered_mask |= BANANA_K3H4_DIALOGUE_GATE_MASK_SECRET_TUNNEL;
+    if (writ_gate_triggered)
+        triggered_mask |= BANANA_K3H4_DIALOGUE_GATE_MASK_WRIT_REQUIRED;
+
+    out_output->triggered_gate_mask = triggered_mask;
+
+    if (secret_gate_triggered)
+    {
+        out_output->resolved_gate = BANANA_K3H4_DIALOGUE_GATE_DO_NOT_REVEAL_SECRET_TUNNEL;
+        out_output->gate_precedence_rank = 1;
+        out_output->tie_break_applied = writ_gate_triggered ? 1 : 0;
+        copy_literal(out_output->tie_break_rule,
+                     sizeof(out_output->tie_break_rule),
+                     writ_gate_triggered ? "precedence-order" : "single-gate");
+        return;
+    }
+
+    if (writ_gate_triggered)
+    {
+        out_output->resolved_gate = BANANA_K3H4_DIALOGUE_GATE_DO_NOT_GRANT_ENTRY_WITHOUT_WRIT;
+        out_output->gate_precedence_rank = 2;
+        out_output->tie_break_applied = 0;
+        copy_literal(out_output->tie_break_rule, sizeof(out_output->tie_break_rule), "single-gate");
+        return;
+    }
+
+    out_output->resolved_gate = BANANA_K3H4_DIALOGUE_GATE_NONE;
+    out_output->gate_precedence_rank = 0;
+    out_output->tie_break_applied = 0;
+    copy_literal(out_output->tie_break_rule, sizeof(out_output->tie_break_rule), "no-gate");
+}
+
+static void fill_response_contract(const BananaK3h4DialogueRouteInput *input,
+                                   BananaK3h4DialogueRouteOutput *out_output)
+{
+    BananaK3h4DialogueResponseContract *contract = &out_output->response_contract;
+
+    memset(contract, 0, sizeof(*contract));
+    contract->contract_version = BANANA_K3H4_RESPONSE_CONTRACT_VERSION;
+    contract->target_cluster_id = out_output->cluster_id;
+
+    if (out_output->resolved_gate == BANANA_K3H4_DIALOGUE_GATE_DO_NOT_REVEAL_SECRET_TUNNEL)
+    {
+        contract->response_mode = BANANA_K3H4_DIALOGUE_RESPONSE_REDIRECT;
+        contract->may_grant_entry = 0;
+        contract->should_transition = 1;
+        copy_literal(contract->response_key,
+                     sizeof(contract->response_key),
+                     "k3h4.edda.south_gate.redirect.public_route");
+        return;
+    }
+
+    if (out_output->resolved_gate == BANANA_K3H4_DIALOGUE_GATE_DO_NOT_GRANT_ENTRY_WITHOUT_WRIT)
+    {
+        contract->response_mode = BANANA_K3H4_DIALOGUE_RESPONSE_DENY;
+        contract->may_grant_entry = 0;
+        contract->should_transition = 1;
+        copy_literal(contract->response_key,
+                     sizeof(contract->response_key),
+                     "k3h4.edda.south_gate.require_writ");
+        return;
+    }
+
+    switch (input->intent)
+    {
+    case BANANA_K3H4_DIALOGUE_INTENT_INSULT:
+        contract->response_mode = BANANA_K3H4_DIALOGUE_RESPONSE_DEESCALATE;
+        contract->may_grant_entry = 0;
+        contract->should_transition = 1;
+        copy_literal(contract->response_key,
+                     sizeof(contract->response_key),
+                     "k3h4.edda.south_gate.deescalate");
+        return;
+    case BANANA_K3H4_DIALOGUE_INTENT_REQUEST_HELP:
+        contract->response_mode = BANANA_K3H4_DIALOGUE_RESPONSE_ASSIST;
+        contract->may_grant_entry = input->has_entry_writ ? 1 : 0;
+        contract->should_transition = 0;
+        copy_literal(contract->response_key,
+                     sizeof(contract->response_key),
+                     "k3h4.edda.south_gate.assist");
+        return;
+    case BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS:
+        contract->response_mode = BANANA_K3H4_DIALOGUE_RESPONSE_REDIRECT;
+        contract->may_grant_entry = input->has_entry_writ ? 1 : 0;
+        contract->should_transition = 0;
+        copy_literal(contract->response_key,
+                     sizeof(contract->response_key),
+                     "k3h4.edda.south_gate.directions");
+        return;
+    case BANANA_K3H4_DIALOGUE_INTENT_ASK_CASTLE_ENTRY:
+        contract->response_mode = BANANA_K3H4_DIALOGUE_RESPONSE_NEUTRAL;
+        contract->may_grant_entry = input->has_entry_writ ? 1 : 0;
+        contract->should_transition = 0;
+        copy_literal(contract->response_key,
+                     sizeof(contract->response_key),
+                     input->has_entry_writ ?
+                         "k3h4.edda.south_gate.entry_review" :
+                         "k3h4.edda.south_gate.entry_incomplete");
+        return;
+    case BANANA_K3H4_DIALOGUE_INTENT_UNKNOWN:
+    default:
+        contract->response_mode = BANANA_K3H4_DIALOGUE_RESPONSE_NEUTRAL;
+        contract->may_grant_entry = 0;
+        contract->should_transition = 1;
+        copy_literal(contract->response_key,
+                     sizeof(contract->response_key),
+                     "k3h4.edda.south_gate.fallback");
+        return;
+    }
+}
+
+int banana_native_k3h4_route_dialogue_cluster(const BananaK3h4DialogueRouteInput *input,
+                                               BananaK3h4DialogueRouteOutput *out_output)
+{
+    BananaK3h4IntentRouteProfile profile;
+
+    if (input == NULL || out_output == NULL)
+        return -1;
+
+    memset(out_output, 0, sizeof(*out_output));
+
+    profile = profile_for_intent(input->intent);
+    out_output->route_version = BANANA_K3H4_DIALOGUE_ROUTE_VERSION;
+    out_output->cluster_id = profile.cluster_id;
+    out_output->normalized_score_basis_points = clamp_int(
+        profile.base_score_basis_points - clamp_int(input->ambiguity_basis_points, 0, 3000),
+        0,
+        10000);
+    out_output->boundary_state = boundary_for_score(out_output->normalized_score_basis_points);
+
+    resolve_gates(input, out_output);
+    fill_response_contract(input, out_output);
+
+    out_output->transition_id = compute_transition_id(out_output);
+
+    return 0;
+}

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_cluster_router.h
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_cluster_router.h
@@ -1,0 +1,94 @@
+#ifndef BANANA_NATIVE_K3H4_DIALOGUE_CLUSTER_ROUTER_H
+#define BANANA_NATIVE_K3H4_DIALOGUE_CLUSTER_ROUTER_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef enum BananaK3h4DialogueIntent
+    {
+        BANANA_K3H4_DIALOGUE_INTENT_UNKNOWN = 0,
+        BANANA_K3H4_DIALOGUE_INTENT_ASK_CASTLE_ENTRY = 1,
+        BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS = 2,
+        BANANA_K3H4_DIALOGUE_INTENT_INSULT = 3,
+        BANANA_K3H4_DIALOGUE_INTENT_REQUEST_HELP = 4,
+    } BananaK3h4DialogueIntent;
+
+    typedef enum BananaK3h4DialogueBoundaryState
+    {
+        BANANA_K3H4_DIALOGUE_BOUNDARY_OUTSIDE = 0,
+        BANANA_K3H4_DIALOGUE_BOUNDARY_EDGE = 1,
+        BANANA_K3H4_DIALOGUE_BOUNDARY_CORE = 2,
+    } BananaK3h4DialogueBoundaryState;
+
+    typedef enum BananaK3h4DialogueSafetyGate
+    {
+        BANANA_K3H4_DIALOGUE_GATE_NONE = 0,
+        BANANA_K3H4_DIALOGUE_GATE_DO_NOT_REVEAL_SECRET_TUNNEL = 1,
+        BANANA_K3H4_DIALOGUE_GATE_DO_NOT_GRANT_ENTRY_WITHOUT_WRIT = 2,
+    } BananaK3h4DialogueSafetyGate;
+
+    typedef enum BananaK3h4DialogueResponseMode
+    {
+        BANANA_K3H4_DIALOGUE_RESPONSE_NEUTRAL = 0,
+        BANANA_K3H4_DIALOGUE_RESPONSE_DENY = 1,
+        BANANA_K3H4_DIALOGUE_RESPONSE_REDIRECT = 2,
+        BANANA_K3H4_DIALOGUE_RESPONSE_DEESCALATE = 3,
+        BANANA_K3H4_DIALOGUE_RESPONSE_ASSIST = 4,
+    } BananaK3h4DialogueResponseMode;
+
+    enum
+    {
+        BANANA_K3H4_DIALOGUE_GATE_MASK_SECRET_TUNNEL = 1u << 0,
+        BANANA_K3H4_DIALOGUE_GATE_MASK_WRIT_REQUIRED = 1u << 1,
+    };
+
+    typedef struct BananaK3h4DialogueRouteInput
+    {
+        BananaK3h4DialogueIntent intent;
+        int has_entry_writ;
+        int mentions_secret_tunnel;
+        int ambiguity_basis_points;
+    } BananaK3h4DialogueRouteInput;
+
+    typedef struct BananaK3h4DialogueResponseContract
+    {
+        int contract_version;
+        BananaK3h4DialogueResponseMode response_mode;
+        int may_grant_entry;
+        int should_transition;
+        int target_cluster_id;
+        char response_key[64];
+    } BananaK3h4DialogueResponseContract;
+
+    typedef struct BananaK3h4DialogueRouteOutput
+    {
+        int route_version;
+        int cluster_id;
+        int normalized_score_basis_points;
+        BananaK3h4DialogueBoundaryState boundary_state;
+        int transition_id;
+        BananaK3h4DialogueSafetyGate resolved_gate;
+        int gate_precedence_rank;
+        uint32_t triggered_gate_mask;
+        int tie_break_applied;
+        char tie_break_rule[32];
+        BananaK3h4DialogueResponseContract response_contract;
+    } BananaK3h4DialogueRouteOutput;
+
+    /*
+     * Routes the pilot dialogue slice for Edda at South Gate deterministically.
+     * This function emits routing evidence only; gameplay mutations are owned
+     * by higher layers across the state authority boundary.
+     */
+    int banana_native_k3h4_route_dialogue_cluster(const BananaK3h4DialogueRouteInput *input,
+                                                   BananaK3h4DialogueRouteOutput *out_output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/modules/k3h4/native/tests/CMakeLists.txt
+++ b/modules/k3h4/native/tests/CMakeLists.txt
@@ -30,6 +30,11 @@ banana_k3h4_add_test_if_exists(
 )
 
 banana_k3h4_add_test_if_exists(
+  banana_k3h4_dialogue_cluster_router_test
+  "k3h4/k3h4_dialogue_cluster_router_test.c"
+)
+
+banana_k3h4_add_test_if_exists(
   banana_k3h4_metrics_infrastructure_adapter_test
   "k3h4/infrastructure/k3h4_metrics_infrastructure_adapter_test.c"
 )

--- a/modules/k3h4/native/tests/k3h4/k3h4_dialogue_cluster_router_test.c
+++ b/modules/k3h4/native/tests/k3h4/k3h4_dialogue_cluster_router_test.c
@@ -1,0 +1,145 @@
+#include "k3h4/k3h4_dialogue_cluster_router.h"
+
+#include "runtime/support/test_support.h"
+
+#include <string.h>
+
+static void assert_same_bytes(const void *left,
+                              const void *right,
+                              size_t size,
+                              const char *message)
+{
+    BANANA_TEST_ASSERT_TRUE(memcmp(left, right, size) == 0, message);
+}
+
+static void test_replay_is_byte_identical_for_identical_input_streams(void **state)
+{
+    BananaK3h4DialogueRouteInput inputs[] = {
+        {
+            .intent = BANANA_K3H4_DIALOGUE_INTENT_ASK_CASTLE_ENTRY,
+            .has_entry_writ = 0,
+            .mentions_secret_tunnel = 0,
+            .ambiguity_basis_points = 90,
+        },
+        {
+            .intent = BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS,
+            .has_entry_writ = 1,
+            .mentions_secret_tunnel = 0,
+            .ambiguity_basis_points = 120,
+        },
+        {
+            .intent = BANANA_K3H4_DIALOGUE_INTENT_INSULT,
+            .has_entry_writ = 0,
+            .mentions_secret_tunnel = 0,
+            .ambiguity_basis_points = 30,
+        },
+        {
+            .intent = BANANA_K3H4_DIALOGUE_INTENT_REQUEST_HELP,
+            .has_entry_writ = 1,
+            .mentions_secret_tunnel = 1,
+            .ambiguity_basis_points = 250,
+        },
+    };
+    BananaK3h4DialogueRouteOutput replay_a[sizeof(inputs) / sizeof(inputs[0])];
+    BananaK3h4DialogueRouteOutput replay_b[sizeof(inputs) / sizeof(inputs[0])];
+    size_t index;
+
+    (void)state;
+
+    memset(replay_a, 0, sizeof(replay_a));
+    memset(replay_b, 0, sizeof(replay_b));
+
+    for (index = 0; index < sizeof(inputs) / sizeof(inputs[0]); ++index)
+    {
+        BANANA_TEST_ASSERT_INT_EQ(
+            banana_native_k3h4_route_dialogue_cluster(&inputs[index], &replay_a[index]),
+            0,
+            "first replay routing pass must succeed");
+        BANANA_TEST_ASSERT_INT_EQ(
+            banana_native_k3h4_route_dialogue_cluster(&inputs[index], &replay_b[index]),
+            0,
+            "second replay routing pass must succeed");
+
+        BANANA_TEST_ASSERT_INT_EQ(
+            replay_a[index].transition_id,
+            replay_b[index].transition_id,
+            "transition ids must match for identical inputs");
+    }
+
+    assert_same_bytes(replay_a,
+                      replay_b,
+                      sizeof(replay_a),
+                      "routing outputs must be byte-identical across deterministic replay");
+}
+
+static void test_gate_precedence_emits_tie_break_metadata(void **state)
+{
+    BananaK3h4DialogueRouteInput input = {
+        .intent = BANANA_K3H4_DIALOGUE_INTENT_ASK_CASTLE_ENTRY,
+        .has_entry_writ = 0,
+        .mentions_secret_tunnel = 1,
+        .ambiguity_basis_points = 50,
+    };
+    BananaK3h4DialogueRouteOutput output = {0};
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_route_dialogue_cluster(&input, &output),
+        0,
+        "routing must succeed for tie-break case");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        output.resolved_gate,
+        BANANA_K3H4_DIALOGUE_GATE_DO_NOT_REVEAL_SECRET_TUNNEL,
+        "secret tunnel gate must win precedence tie-break");
+    BANANA_TEST_ASSERT_INT_EQ(output.gate_precedence_rank,
+                              1,
+                              "winning gate must report precedence rank");
+    BANANA_TEST_ASSERT_INT_EQ(output.tie_break_applied,
+                              1,
+                              "tie-break flag must indicate resolver tie use");
+    BANANA_TEST_ASSERT_INT_EQ((int)output.triggered_gate_mask,
+                              BANANA_K3H4_DIALOGUE_GATE_MASK_SECRET_TUNNEL |
+                                  BANANA_K3H4_DIALOGUE_GATE_MASK_WRIT_REQUIRED,
+                              "both gates must be represented in triggered mask");
+    BANANA_TEST_ASSERT_STR_EQ(output.tie_break_rule,
+                              "precedence-order",
+                              "tie-break metadata must preserve deterministic rule id");
+}
+
+static void test_response_contract_is_skeleton_without_phrasing_authority(void **state)
+{
+    BananaK3h4DialogueRouteInput input = {
+        .intent = BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS,
+        .has_entry_writ = 1,
+        .mentions_secret_tunnel = 0,
+        .ambiguity_basis_points = 0,
+    };
+    BananaK3h4DialogueRouteOutput output = {0};
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_route_dialogue_cluster(&input, &output),
+        0,
+        "routing must succeed for response skeleton checks");
+
+    BANANA_TEST_ASSERT_INT_EQ(output.response_contract.contract_version,
+                              1,
+                              "response contract version must be set");
+    BANANA_TEST_ASSERT_INT_EQ(output.response_contract.response_mode,
+                              BANANA_K3H4_DIALOGUE_RESPONSE_REDIRECT,
+                              "directions intent should emit redirect mode skeleton");
+    BANANA_TEST_ASSERT_INT_EQ(output.response_contract.target_cluster_id,
+                              output.cluster_id,
+                              "response contract must reference routed cluster");
+    BANANA_TEST_ASSERT_STR_EQ(output.response_contract.response_key,
+                              "k3h4.edda.south_gate.directions",
+                              "response contract must emit deterministic key only");
+}
+
+BANANA_TEST_MAIN(
+    BANANA_TEST_CASE(test_replay_is_byte_identical_for_identical_input_streams),
+    BANANA_TEST_CASE(test_gate_precedence_emits_tie_break_metadata),
+    BANANA_TEST_CASE(test_response_contract_is_skeleton_without_phrasing_authority))

--- a/tests/native/CMakeLists.txt
+++ b/tests/native/CMakeLists.txt
@@ -1218,6 +1218,40 @@ target_include_directories(banana_native_k3h4_metrics_orchestration_layer_test P
 	${CMAKE_CURRENT_LIST_DIR}/../../src/native
 )
 
+set(BANANA_K3H4_DIALOGUE_CLUSTER_ROUTER_TEST_SOURCE
+	"${BANANA_K3H4_TEST_DIR}/k3h4/k3h4_dialogue_cluster_router_test.c"
+)
+
+if(EXISTS "${BANANA_K3H4_DIALOGUE_CLUSTER_ROUTER_TEST_SOURCE}")
+	add_executable(banana_native_k3h4_dialogue_cluster_router_test
+		${BANANA_K3H4_DIALOGUE_CLUSTER_ROUTER_TEST_SOURCE}
+	)
+
+	add_test(NAME banana_native_k3h4_dialogue_cluster_router_test
+		COMMAND banana_native_k3h4_dialogue_cluster_router_test
+	)
+
+	target_link_libraries(banana_native_k3h4_dialogue_cluster_router_test PRIVATE banana_k3h4_core)
+	target_link_libraries(banana_native_k3h4_dialogue_cluster_router_test PRIVATE banana_engine_core)
+
+	if(WIN32)
+		add_custom_command(TARGET banana_native_k3h4_dialogue_cluster_router_test POST_BUILD
+			COMMAND ${CMAKE_COMMAND}
+				-Dbanana_runtime_dlls=$<JOIN:$<TARGET_RUNTIME_DLLS:banana_native_k3h4_dialogue_cluster_router_test>,|>
+				-Dbanana_target_dir=$<TARGET_FILE_DIR:banana_native_k3h4_dialogue_cluster_router_test>
+				-P ${CMAKE_CURRENT_LIST_DIR}/runtime/support/copy_runtime_dlls.cmake
+			COMMENT "Copying runtime DLLs next to banana_native_k3h4_dialogue_cluster_router_test"
+		)
+	endif()
+
+	target_include_directories(banana_native_k3h4_dialogue_cluster_router_test PRIVATE
+		${BANANA_ENGINE_DIR}
+		${BANANA_ENGINE_DIR}/runtime
+		${CMAKE_CURRENT_LIST_DIR}/../../src/native
+		${BANANA_K3H4_SRC_DIR}
+	)
+endif()
+
 add_executable(banana_runtime_terrain_generation_test
 	${CMAKE_CURRENT_LIST_DIR}/runtime/terrain/terrain_generation_test.c
 )


### PR DESCRIPTION
## Summary
- add deterministic pilot-slice dialogue cluster router for K3H4 (Edda / Castle Entry Writ / South Gate)
- emit deterministic assignment, normalized boundary-state, gate precedence resolution, tie-break metadata, transition id, and response contract skeleton
- add replay acceptance test asserting byte-identical outputs and identical transition ids for identical input streams
- wire new router source and test into native build/test CMake

## Acceptance Coverage
- deterministic assignment + boundary state output for pilot intents
- deterministic gate precedence resolver output and tie-break metadata
- response contract skeleton output without phrasing authority
- replay test proving byte-identical routing output and transition ids for identical streams

## Validation
- `cmake -S src/native -B out/v3-native`
- `cmake --build out/v3-native --config Debug --target banana_native_k3h4_dialogue_cluster_router_test -- -m:1`
- `ctest -C Debug --test-dir out/v3-native -R banana_native_k3h4_dialogue_cluster_router_test --output-on-failure`

Closes #1176
