### PR TITLE
feat(k3h4): add deterministic template dialogue layer

### DIFF
--- a/modules/k3h4/native/CMakeLists.txt
+++ b/modules/k3h4/native/CMakeLists.txt
@@ -27,6 +27,7 @@ endfunction()
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_native_orchestrator.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_metrics_orchestration_layer.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_cluster_router.c")
+banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_template_layer.c")
 banana_k3h4_add_source_if_exists("src/k3h4/application/k3h4_metrics_application_service.c")
 banana_k3h4_add_source_if_exists("src/k3h4/infrastructure/k3h4_metrics_infrastructure_adapter.c")
 

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_template_layer.c
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_template_layer.c
@@ -1,0 +1,222 @@
+#include "k3h4_dialogue_template_layer.h"
+
+#include <stddef.h>
+#include <string.h>
+
+enum
+{
+    BANANA_K3H4_DIALOGUE_TEMPLATE_POLICY_VERSION = 1,
+    BANANA_K3H4_CLUSTER_GLOBAL_FALLBACK = 1099,
+};
+
+static void copy_literal(char *out_text, size_t out_text_size, const char *literal)
+{
+    if (out_text == NULL || out_text_size == 0)
+        return;
+
+    if (literal == NULL)
+    {
+        out_text[0] = '\0';
+        return;
+    }
+
+    strncpy(out_text, literal, out_text_size - 1);
+    out_text[out_text_size - 1] = '\0';
+}
+
+static int fallback_cluster_for_mode(BananaK3h4DialogueResponseMode mode)
+{
+    switch (mode)
+    {
+    case BANANA_K3H4_DIALOGUE_RESPONSE_DENY:
+        return 1001;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_REDIRECT:
+        return 1002;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_DEESCALATE:
+        return 1003;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_ASSIST:
+        return 1004;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_NEUTRAL:
+    default:
+        return 1001;
+    }
+}
+
+static uint32_t forbidden_fact_mask_for_route(const BananaK3h4DialogueRouteOutput *route_output)
+{
+    uint32_t forbidden = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_SECRET_TUNNEL_LOCATION |
+                         BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_GUARD_ROTATION_WINDOWS;
+
+    if (route_output->resolved_gate == BANANA_K3H4_DIALOGUE_GATE_DO_NOT_REVEAL_SECRET_TUNNEL)
+        forbidden |= BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS;
+
+    if (route_output->resolved_gate == BANANA_K3H4_DIALOGUE_GATE_DO_NOT_GRANT_ENTRY_WITHOUT_WRIT)
+        forbidden |= BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ENTRY_WRIT_STATUS;
+
+    return forbidden;
+}
+
+static uint32_t allowed_fact_mask_for_route(const BananaK3h4DialogueRouteOutput *route_output)
+{
+    uint32_t allowed = 0u;
+
+    switch (route_output->response_contract.response_mode)
+    {
+    case BANANA_K3H4_DIALOGUE_RESPONSE_DENY:
+        allowed = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ESCALATION_WARNING;
+        break;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_REDIRECT:
+        allowed = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS |
+                  BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ESCALATION_WARNING;
+        break;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_DEESCALATE:
+        allowed = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ESCALATION_WARNING;
+        break;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_ASSIST:
+        allowed = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_HELP_GUIDANCE |
+                  BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS;
+        break;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_NEUTRAL:
+    default:
+        allowed = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ENTRY_WRIT_STATUS |
+                  BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS;
+        break;
+    }
+
+    return allowed;
+}
+
+static void build_cluster_stack(const BananaK3h4DialogueRouteOutput *route_output,
+                                BananaK3h4DialogueTemplateOutput *out_output)
+{
+    out_output->selected_cluster_stack_count = BANANA_K3H4_DIALOGUE_TEMPLATE_STACK_MAX;
+    out_output->selected_cluster_stack[0] = route_output->cluster_id;
+    out_output->selected_cluster_stack[1] = fallback_cluster_for_mode(route_output->response_contract.response_mode);
+    out_output->selected_cluster_stack[2] = BANANA_K3H4_CLUSTER_GLOBAL_FALLBACK;
+}
+
+static void resolve_primary_template(const BananaK3h4DialogueRouteOutput *route_output,
+                                     BananaK3h4DialogueTemplateOutput *out_output)
+{
+    out_output->selected_cluster_for_template = out_output->selected_cluster_stack[0];
+
+    if (route_output->resolved_gate == BANANA_K3H4_DIALOGUE_GATE_DO_NOT_REVEAL_SECRET_TUNNEL)
+    {
+        copy_literal(out_output->selected_template_key,
+                     sizeof(out_output->selected_template_key),
+                     "k3h4.template.edda.south_gate.redirect_public");
+        return;
+    }
+
+    if (route_output->resolved_gate == BANANA_K3H4_DIALOGUE_GATE_DO_NOT_GRANT_ENTRY_WITHOUT_WRIT)
+    {
+        copy_literal(out_output->selected_template_key,
+                     sizeof(out_output->selected_template_key),
+                     "k3h4.template.edda.south_gate.require_writ");
+        return;
+    }
+
+    switch (route_output->response_contract.response_mode)
+    {
+    case BANANA_K3H4_DIALOGUE_RESPONSE_DEESCALATE:
+        copy_literal(out_output->selected_template_key,
+                     sizeof(out_output->selected_template_key),
+                     "k3h4.template.edda.south_gate.deescalate");
+        return;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_ASSIST:
+        copy_literal(out_output->selected_template_key,
+                     sizeof(out_output->selected_template_key),
+                     "k3h4.template.edda.south_gate.assist");
+        return;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_REDIRECT:
+        copy_literal(out_output->selected_template_key,
+                     sizeof(out_output->selected_template_key),
+                     "k3h4.template.edda.south_gate.redirect");
+        return;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_DENY:
+        copy_literal(out_output->selected_template_key,
+                     sizeof(out_output->selected_template_key),
+                     "k3h4.template.edda.south_gate.deny");
+        return;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_NEUTRAL:
+    default:
+        copy_literal(out_output->selected_template_key,
+                     sizeof(out_output->selected_template_key),
+                     "k3h4.template.edda.south_gate.neutral");
+        return;
+    }
+}
+
+static void resolve_fallback(BananaK3h4DialogueTemplateOutput *out_output,
+                             BananaK3h4DialogueTemplateReason reason,
+                             int fallback_rank,
+                             const char *fallback_template_key)
+{
+    out_output->fallback_applied = 1;
+    out_output->fallback_reason = reason;
+    out_output->fallback_rank = fallback_rank;
+    out_output->selected_cluster_for_template = out_output->selected_cluster_stack[fallback_rank];
+    copy_literal(out_output->fallback_template_key,
+                 sizeof(out_output->fallback_template_key),
+                 fallback_template_key);
+    copy_literal(out_output->selected_template_key,
+                 sizeof(out_output->selected_template_key),
+                 fallback_template_key);
+}
+
+int banana_native_k3h4_resolve_dialogue_template(const BananaK3h4DialogueTemplateInput *input,
+                                                  BananaK3h4DialogueTemplateOutput *out_output)
+{
+    BananaK3h4DialogueTemplateValidationResult validation;
+
+    if (input == NULL || out_output == NULL)
+        return -1;
+
+    memset(out_output, 0, sizeof(*out_output));
+
+    out_output->policy_version = BANANA_K3H4_DIALOGUE_TEMPLATE_POLICY_VERSION;
+    build_cluster_stack(&input->route_output, out_output);
+    resolve_primary_template(&input->route_output, out_output);
+
+    validation.allowed_fact_mask = allowed_fact_mask_for_route(&input->route_output);
+    validation.forbidden_fact_mask = forbidden_fact_mask_for_route(&input->route_output);
+    validation.unauthorized_fact_mask = input->proposed_fact_mask &
+        (~validation.allowed_fact_mask | validation.forbidden_fact_mask);
+    validation.has_unauthorized_facts = validation.unauthorized_fact_mask != 0u;
+
+    out_output->fact_validation = validation;
+
+    if (validation.has_unauthorized_facts)
+    {
+        resolve_fallback(out_output,
+                         BANANA_K3H4_DIALOGUE_TEMPLATE_REASON_FACT_VALIDATION,
+                         1,
+                         "k3h4.template.edda.south_gate.fallback.safe");
+        return 0;
+    }
+
+    if (input->route_output.resolved_gate != BANANA_K3H4_DIALOGUE_GATE_NONE)
+    {
+        resolve_fallback(out_output,
+                         BANANA_K3H4_DIALOGUE_TEMPLATE_REASON_GATE_BLOCK,
+                         1,
+                         "k3h4.template.edda.south_gate.fallback.gate");
+        return 0;
+    }
+
+    if (input->route_output.boundary_state == BANANA_K3H4_DIALOGUE_BOUNDARY_OUTSIDE)
+    {
+        resolve_fallback(out_output,
+                         BANANA_K3H4_DIALOGUE_TEMPLATE_REASON_BOUNDARY_OUTSIDE,
+                         2,
+                         "k3h4.template.edda.south_gate.fallback.boundary");
+        return 0;
+    }
+
+    out_output->fallback_applied = 0;
+    out_output->fallback_reason = BANANA_K3H4_DIALOGUE_TEMPLATE_REASON_PRIMARY;
+    out_output->fallback_rank = 0;
+    out_output->fallback_template_key[0] = '\0';
+
+    return 0;
+}

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_template_layer.h
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_template_layer.h
@@ -1,0 +1,77 @@
+#ifndef BANANA_NATIVE_K3H4_DIALOGUE_TEMPLATE_LAYER_H
+#define BANANA_NATIVE_K3H4_DIALOGUE_TEMPLATE_LAYER_H
+
+#include "k3h4_dialogue_cluster_router.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef enum BananaK3h4DialogueFact
+    {
+        BANANA_K3H4_DIALOGUE_FACT_ENTRY_WRIT_STATUS = 0,
+        BANANA_K3H4_DIALOGUE_FACT_PUBLIC_GATE_DIRECTIONS = 1,
+        BANANA_K3H4_DIALOGUE_FACT_ESCALATION_WARNING = 2,
+        BANANA_K3H4_DIALOGUE_FACT_HELP_GUIDANCE = 3,
+        BANANA_K3H4_DIALOGUE_FACT_SECRET_TUNNEL_LOCATION = 4,
+        BANANA_K3H4_DIALOGUE_FACT_GUARD_ROTATION_WINDOWS = 5,
+    } BananaK3h4DialogueFact;
+
+    typedef enum BananaK3h4DialogueTemplateReason
+    {
+        BANANA_K3H4_DIALOGUE_TEMPLATE_REASON_PRIMARY = 0,
+        BANANA_K3H4_DIALOGUE_TEMPLATE_REASON_GATE_BLOCK = 1,
+        BANANA_K3H4_DIALOGUE_TEMPLATE_REASON_BOUNDARY_OUTSIDE = 2,
+        BANANA_K3H4_DIALOGUE_TEMPLATE_REASON_FACT_VALIDATION = 3,
+    } BananaK3h4DialogueTemplateReason;
+
+    enum
+    {
+        BANANA_K3H4_DIALOGUE_TEMPLATE_STACK_MAX = 3,
+        BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ENTRY_WRIT_STATUS = 1u << BANANA_K3H4_DIALOGUE_FACT_ENTRY_WRIT_STATUS,
+        BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS = 1u << BANANA_K3H4_DIALOGUE_FACT_PUBLIC_GATE_DIRECTIONS,
+        BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ESCALATION_WARNING = 1u << BANANA_K3H4_DIALOGUE_FACT_ESCALATION_WARNING,
+        BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_HELP_GUIDANCE = 1u << BANANA_K3H4_DIALOGUE_FACT_HELP_GUIDANCE,
+        BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_SECRET_TUNNEL_LOCATION = 1u << BANANA_K3H4_DIALOGUE_FACT_SECRET_TUNNEL_LOCATION,
+        BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_GUARD_ROTATION_WINDOWS = 1u << BANANA_K3H4_DIALOGUE_FACT_GUARD_ROTATION_WINDOWS,
+    };
+
+    typedef struct BananaK3h4DialogueTemplateInput
+    {
+        BananaK3h4DialogueRouteOutput route_output;
+        uint32_t proposed_fact_mask;
+    } BananaK3h4DialogueTemplateInput;
+
+    typedef struct BananaK3h4DialogueTemplateValidationResult
+    {
+        uint32_t allowed_fact_mask;
+        uint32_t forbidden_fact_mask;
+        uint32_t unauthorized_fact_mask;
+        int has_unauthorized_facts;
+    } BananaK3h4DialogueTemplateValidationResult;
+
+    typedef struct BananaK3h4DialogueTemplateOutput
+    {
+        int policy_version;
+        int selected_cluster_stack[BANANA_K3H4_DIALOGUE_TEMPLATE_STACK_MAX];
+        int selected_cluster_stack_count;
+        int selected_cluster_for_template;
+        char selected_template_key[64];
+        BananaK3h4DialogueTemplateValidationResult fact_validation;
+        int fallback_applied;
+        char fallback_template_key[64];
+        BananaK3h4DialogueTemplateReason fallback_reason;
+        int fallback_rank;
+    } BananaK3h4DialogueTemplateOutput;
+
+    int banana_native_k3h4_resolve_dialogue_template(const BananaK3h4DialogueTemplateInput *input,
+                                                      BananaK3h4DialogueTemplateOutput *out_output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/modules/k3h4/native/tests/CMakeLists.txt
+++ b/modules/k3h4/native/tests/CMakeLists.txt
@@ -35,6 +35,11 @@ banana_k3h4_add_test_if_exists(
 )
 
 banana_k3h4_add_test_if_exists(
+  banana_k3h4_dialogue_template_layer_test
+  "k3h4/k3h4_dialogue_template_layer_test.c"
+)
+
+banana_k3h4_add_test_if_exists(
   banana_k3h4_metrics_infrastructure_adapter_test
   "k3h4/infrastructure/k3h4_metrics_infrastructure_adapter_test.c"
 )

--- a/modules/k3h4/native/tests/k3h4/k3h4_dialogue_template_layer_test.c
+++ b/modules/k3h4/native/tests/k3h4/k3h4_dialogue_template_layer_test.c
@@ -1,0 +1,169 @@
+#include "k3h4/k3h4_dialogue_cluster_router.h"
+#include "k3h4/k3h4_dialogue_template_layer.h"
+
+#include "runtime/support/test_support.h"
+
+#include <string.h>
+
+static int build_route(BananaK3h4DialogueIntent intent,
+                       int has_entry_writ,
+                       int mentions_secret_tunnel,
+                       int ambiguity_basis_points,
+                       BananaK3h4DialogueRouteOutput *out_output)
+{
+    BananaK3h4DialogueRouteInput route_input = {
+        .intent = intent,
+        .has_entry_writ = has_entry_writ,
+        .mentions_secret_tunnel = mentions_secret_tunnel,
+        .ambiguity_basis_points = ambiguity_basis_points,
+    };
+
+    return banana_native_k3h4_route_dialogue_cluster(&route_input, out_output);
+}
+
+static void test_template_policy_uses_deterministic_cluster_stack(void **state)
+{
+    BananaK3h4DialogueRouteOutput route_output = {0};
+    BananaK3h4DialogueTemplateInput input;
+    BananaK3h4DialogueTemplateOutput output = {0};
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        build_route(BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS, 1, 0, 0, &route_output),
+        0,
+        "route generation must succeed");
+
+    input.route_output = route_output;
+    input.proposed_fact_mask = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_resolve_dialogue_template(&input, &output),
+        0,
+        "template resolver must succeed");
+
+    BANANA_TEST_ASSERT_INT_EQ(output.selected_cluster_stack_count,
+                              BANANA_K3H4_DIALOGUE_TEMPLATE_STACK_MAX,
+                              "cluster stack count must be fixed deterministically");
+    BANANA_TEST_ASSERT_INT_EQ(output.selected_cluster_stack[0],
+                              route_output.cluster_id,
+                              "stack must begin with routed cluster");
+    BANANA_TEST_ASSERT_INT_EQ(output.selected_cluster_stack[2],
+                              1099,
+                              "stack must end with global deterministic fallback cluster");
+}
+
+static void test_fact_validator_blocks_unauthorized_leaks(void **state)
+{
+    BananaK3h4DialogueRouteOutput route_output = {0};
+    BananaK3h4DialogueTemplateInput input;
+    BananaK3h4DialogueTemplateOutput output = {0};
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        build_route(BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS, 1, 0, 0, &route_output),
+        0,
+        "route generation must succeed");
+
+    input.route_output = route_output;
+    input.proposed_fact_mask = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_SECRET_TUNNEL_LOCATION;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_resolve_dialogue_template(&input, &output),
+        0,
+        "template resolver must succeed for forbidden fact case");
+
+    BANANA_TEST_ASSERT_INT_EQ(output.fact_validation.has_unauthorized_facts,
+                              1,
+                              "forbidden fact must be flagged as unauthorized");
+    BANANA_TEST_ASSERT_TRUE((output.fact_validation.unauthorized_fact_mask &
+                             BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_SECRET_TUNNEL_LOCATION) != 0u,
+                            "unauthorized mask must include leaked secret tunnel fact");
+    BANANA_TEST_ASSERT_INT_EQ(output.fallback_applied,
+                              1,
+                              "forbidden leaks must trigger deterministic fallback");
+    BANANA_TEST_ASSERT_STR_EQ(output.fallback_template_key,
+                              "k3h4.template.edda.south_gate.fallback.safe",
+                              "fallback metadata must identify safe template selection");
+}
+
+static void test_validation_golden_scenarios_have_zero_unauthorized_leaks(void **state)
+{
+    struct
+    {
+        BananaK3h4DialogueIntent intent;
+        int has_entry_writ;
+        int mentions_secret_tunnel;
+        int ambiguity_basis_points;
+        uint32_t proposed_fact_mask;
+    } golden_cases[] = {
+        {
+            .intent = BANANA_K3H4_DIALOGUE_INTENT_ASK_CASTLE_ENTRY,
+            .has_entry_writ = 1,
+            .mentions_secret_tunnel = 0,
+            .ambiguity_basis_points = 0,
+            .proposed_fact_mask = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ENTRY_WRIT_STATUS,
+        },
+        {
+            .intent = BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS,
+            .has_entry_writ = 1,
+            .mentions_secret_tunnel = 0,
+            .ambiguity_basis_points = 70,
+            .proposed_fact_mask = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS,
+        },
+        {
+            .intent = BANANA_K3H4_DIALOGUE_INTENT_INSULT,
+            .has_entry_writ = 0,
+            .mentions_secret_tunnel = 0,
+            .ambiguity_basis_points = 0,
+            .proposed_fact_mask = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ESCALATION_WARNING,
+        },
+        {
+            .intent = BANANA_K3H4_DIALOGUE_INTENT_REQUEST_HELP,
+            .has_entry_writ = 1,
+            .mentions_secret_tunnel = 0,
+            .ambiguity_basis_points = 120,
+            .proposed_fact_mask = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_HELP_GUIDANCE,
+        },
+    };
+    size_t index;
+
+    (void)state;
+
+    for (index = 0; index < sizeof(golden_cases) / sizeof(golden_cases[0]); ++index)
+    {
+        BananaK3h4DialogueRouteOutput route_output = {0};
+        BananaK3h4DialogueTemplateInput input;
+        BananaK3h4DialogueTemplateOutput output = {0};
+
+        BANANA_TEST_ASSERT_INT_EQ(
+            build_route(golden_cases[index].intent,
+                        golden_cases[index].has_entry_writ,
+                        golden_cases[index].mentions_secret_tunnel,
+                        golden_cases[index].ambiguity_basis_points,
+                        &route_output),
+            0,
+            "route generation must succeed for golden case");
+
+        input.route_output = route_output;
+        input.proposed_fact_mask = golden_cases[index].proposed_fact_mask;
+
+        BANANA_TEST_ASSERT_INT_EQ(
+            banana_native_k3h4_resolve_dialogue_template(&input, &output),
+            0,
+            "template resolution must succeed for golden case");
+
+        BANANA_TEST_ASSERT_INT_EQ(output.fact_validation.has_unauthorized_facts,
+                                  0,
+                                  "golden scenarios must not leak unauthorized facts");
+        BANANA_TEST_ASSERT_INT_EQ((int)output.fact_validation.unauthorized_fact_mask,
+                                  0,
+                                  "unauthorized fact mask must remain zero on golden scenarios");
+    }
+}
+
+BANANA_TEST_MAIN(
+    BANANA_TEST_CASE(test_template_policy_uses_deterministic_cluster_stack),
+    BANANA_TEST_CASE(test_fact_validator_blocks_unauthorized_leaks),
+    BANANA_TEST_CASE(test_validation_golden_scenarios_have_zero_unauthorized_leaks))

--- a/tests/native/CMakeLists.txt
+++ b/tests/native/CMakeLists.txt
@@ -1252,6 +1252,40 @@ if(EXISTS "${BANANA_K3H4_DIALOGUE_CLUSTER_ROUTER_TEST_SOURCE}")
 	)
 endif()
 
+set(BANANA_K3H4_DIALOGUE_TEMPLATE_LAYER_TEST_SOURCE
+	"${BANANA_K3H4_TEST_DIR}/k3h4/k3h4_dialogue_template_layer_test.c"
+)
+
+if(EXISTS "${BANANA_K3H4_DIALOGUE_TEMPLATE_LAYER_TEST_SOURCE}")
+	add_executable(banana_native_k3h4_dialogue_template_layer_test
+		${BANANA_K3H4_DIALOGUE_TEMPLATE_LAYER_TEST_SOURCE}
+	)
+
+	add_test(NAME banana_native_k3h4_dialogue_template_layer_test
+		COMMAND banana_native_k3h4_dialogue_template_layer_test
+	)
+
+	target_link_libraries(banana_native_k3h4_dialogue_template_layer_test PRIVATE banana_k3h4_core)
+	target_link_libraries(banana_native_k3h4_dialogue_template_layer_test PRIVATE banana_engine_core)
+
+	if(WIN32)
+		add_custom_command(TARGET banana_native_k3h4_dialogue_template_layer_test POST_BUILD
+			COMMAND ${CMAKE_COMMAND}
+				-Dbanana_runtime_dlls=$<JOIN:$<TARGET_RUNTIME_DLLS:banana_native_k3h4_dialogue_template_layer_test>,|>
+				-Dbanana_target_dir=$<TARGET_FILE_DIR:banana_native_k3h4_dialogue_template_layer_test>
+				-P ${CMAKE_CURRENT_LIST_DIR}/runtime/support/copy_runtime_dlls.cmake
+			COMMENT "Copying runtime DLLs next to banana_native_k3h4_dialogue_template_layer_test"
+		)
+	endif()
+
+	target_include_directories(banana_native_k3h4_dialogue_template_layer_test PRIVATE
+		${BANANA_ENGINE_DIR}
+		${BANANA_ENGINE_DIR}/runtime
+		${CMAKE_CURRENT_LIST_DIR}/../../src/native
+		${BANANA_K3H4_SRC_DIR}
+	)
+endif()
+
 add_executable(banana_runtime_terrain_generation_test
 	${CMAKE_CURRENT_LIST_DIR}/runtime/terrain/terrain_generation_test.c
 )


### PR DESCRIPTION
## Summary
- add deterministic template dialogue policy layer bound to the Story A route output and selected cluster stack
- implement allowed/forbidden fact validator for template outputs with unauthorized-leak masking
- emit deterministic fallback template metadata with reason and fallback rank
- add template validation suite including golden scenarios asserting zero unauthorized fact leaks
- wire Story B source and tests into K3H4/native CMake targets

## Deliverable Coverage
- template policy resolver using selected cluster stack
- allowed/forbidden fact validator for template outputs
- deterministic fallback template selection metadata

## Acceptance Gate
- `banana_native_k3h4_dialogue_template_layer_test` includes golden scenarios where `unauthorized_fact_mask == 0` and `has_unauthorized_facts == 0`

## Validation
- `cmake -S src/native -B out/v3-native`
- `cmake --build out/v3-native --config Debug --target banana_native_k3h4_dialogue_template_layer_test -- -m:1`
- `ctest -C Debug --test-dir out/v3-native -R banana_native_k3h4_dialogue_template_layer_test --output-on-failure`

Depends on #1176
Closes #1177
