### PR TITLE
feat(k3h4): add constrained generative surface layer

### DIFF
--- a/modules/k3h4/native/CMakeLists.txt
+++ b/modules/k3h4/native/CMakeLists.txt
@@ -28,6 +28,7 @@ banana_k3h4_add_source_if_exists("src/k3h4/k3h4_native_orchestrator.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_metrics_orchestration_layer.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_cluster_router.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_template_layer.c")
+banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_generative_surface_layer.c")
 banana_k3h4_add_source_if_exists("src/k3h4/application/k3h4_metrics_application_service.c")
 banana_k3h4_add_source_if_exists("src/k3h4/infrastructure/k3h4_metrics_infrastructure_adapter.c")
 

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_generative_surface_layer.c
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_generative_surface_layer.c
@@ -1,0 +1,115 @@
+#include "k3h4_dialogue_generative_surface_layer.h"
+
+#include <stddef.h>
+#include <string.h>
+
+enum
+{
+    BANANA_K3H4_DIALOGUE_GENERATOR_CONTRACT_VERSION = 1,
+    BANANA_K3H4_DIALOGUE_GENERATOR_STATUS_OK = 0,
+    BANANA_K3H4_DIALOGUE_GENERATOR_STATUS_VALIDATION_FAILED = 2,
+};
+
+static void copy_literal(char *out_text, size_t out_text_size, const char *literal)
+{
+    if (out_text == NULL || out_text_size == 0)
+        return;
+
+    if (literal == NULL)
+    {
+        out_text[0] = '\0';
+        return;
+    }
+
+    strncpy(out_text, literal, out_text_size - 1);
+    out_text[out_text_size - 1] = '\0';
+}
+
+static int build_deny_code(BananaK3h4DialogueGeneratorDenyReason reason,
+                           const BananaK3h4DialogueGeneratorOutput *output)
+{
+    uint32_t hash = 2166136261u;
+    const uint32_t fields[] = {
+        (uint32_t)reason,
+        (uint32_t)output->selected_cluster_stack_count,
+        (uint32_t)output->selected_cluster_stack[0],
+        output->validated_fact_mask,
+    };
+    size_t index;
+
+    for (index = 0; index < sizeof(fields) / sizeof(fields[0]); ++index)
+    {
+        hash ^= fields[index];
+        hash *= 16777619u;
+    }
+
+    return (int)(hash & 0x7fffffff);
+}
+
+static void populate_base_output(const BananaK3h4DialogueGeneratorInput *input,
+                                 BananaK3h4DialogueGeneratorOutput *out_output)
+{
+    memset(out_output, 0, sizeof(*out_output));
+
+    out_output->contract_version = BANANA_K3H4_DIALOGUE_GENERATOR_CONTRACT_VERSION;
+    out_output->selected_cluster_stack_count = input->template_output.selected_cluster_stack_count;
+    memcpy(out_output->selected_cluster_stack,
+           input->template_output.selected_cluster_stack,
+           sizeof(out_output->selected_cluster_stack));
+
+    out_output->validated_fact_mask = input->selected_fact_mask &
+                                      input->template_output.fact_validation.allowed_fact_mask &
+                                      ~input->template_output.fact_validation.forbidden_fact_mask;
+
+    copy_literal(out_output->selected_template_key,
+                 sizeof(out_output->selected_template_key),
+                 input->template_output.selected_template_key);
+
+    out_output->fail_closed = 0;
+    out_output->status_code = BANANA_K3H4_DIALOGUE_GENERATOR_STATUS_OK;
+    out_output->deny_reason = BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_NONE;
+    out_output->deny_code = 0;
+    out_output->deny_template_key[0] = '\0';
+}
+
+static int validate_contract(const BananaK3h4DialogueGeneratorInput *input,
+                             BananaK3h4DialogueGeneratorOutput *out_output)
+{
+    uint32_t unauthorized_from_template = input->template_output.fact_validation.unauthorized_fact_mask;
+    uint32_t selected_forbidden = input->selected_fact_mask & input->template_output.fact_validation.forbidden_fact_mask;
+    BananaK3h4DialogueGeneratorDenyReason deny_reason = BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_NONE;
+
+    if (unauthorized_from_template != 0u)
+        deny_reason = BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_UNAUTHORIZED_FACT;
+    else if (selected_forbidden != 0u)
+        deny_reason = BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_FORBIDDEN_FACT;
+    else if (input->canon_violation_mask != 0u)
+        deny_reason = BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_CANON_VIOLATION;
+
+    if (deny_reason == BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_NONE)
+        return 0;
+
+    out_output->fail_closed = 1;
+    out_output->status_code = BANANA_K3H4_DIALOGUE_GENERATOR_STATUS_VALIDATION_FAILED;
+    out_output->deny_reason = deny_reason;
+    copy_literal(out_output->deny_template_key,
+                 sizeof(out_output->deny_template_key),
+                 "k3h4.template.edda.south_gate.deny.fail_closed");
+    out_output->deny_code = build_deny_code(deny_reason, out_output);
+    copy_literal(out_output->selected_template_key,
+                 sizeof(out_output->selected_template_key),
+                 out_output->deny_template_key);
+
+    return -BANANA_K3H4_DIALOGUE_GENERATOR_STATUS_VALIDATION_FAILED;
+}
+
+int banana_native_k3h4_assemble_dialogue_generator_contract(
+    const BananaK3h4DialogueGeneratorInput *input,
+    BananaK3h4DialogueGeneratorOutput *out_output)
+{
+    if (input == NULL || out_output == NULL)
+        return -1;
+
+    populate_base_output(input, out_output);
+    return validate_contract(input, out_output);
+}

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_generative_surface_layer.h
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_generative_surface_layer.h
@@ -1,0 +1,50 @@
+#ifndef BANANA_NATIVE_K3H4_DIALOGUE_GENERATIVE_SURFACE_LAYER_H
+#define BANANA_NATIVE_K3H4_DIALOGUE_GENERATIVE_SURFACE_LAYER_H
+
+#include "k3h4_dialogue_template_layer.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef enum BananaK3h4DialogueGeneratorDenyReason
+    {
+        BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_NONE = 0,
+        BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_UNAUTHORIZED_FACT = 1,
+        BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_FORBIDDEN_FACT = 2,
+        BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_CANON_VIOLATION = 3,
+    } BananaK3h4DialogueGeneratorDenyReason;
+
+    typedef struct BananaK3h4DialogueGeneratorInput
+    {
+        BananaK3h4DialogueTemplateOutput template_output;
+        uint32_t selected_fact_mask;
+        uint32_t canon_violation_mask;
+    } BananaK3h4DialogueGeneratorInput;
+
+    typedef struct BananaK3h4DialogueGeneratorOutput
+    {
+        int contract_version;
+        int selected_cluster_stack[BANANA_K3H4_DIALOGUE_TEMPLATE_STACK_MAX];
+        int selected_cluster_stack_count;
+        uint32_t validated_fact_mask;
+        char selected_template_key[64];
+        int fail_closed;
+        int status_code;
+        BananaK3h4DialogueGeneratorDenyReason deny_reason;
+        int deny_code;
+        char deny_template_key[64];
+    } BananaK3h4DialogueGeneratorOutput;
+
+    int banana_native_k3h4_assemble_dialogue_generator_contract(
+        const BananaK3h4DialogueGeneratorInput *input,
+        BananaK3h4DialogueGeneratorOutput *out_output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/modules/k3h4/native/tests/CMakeLists.txt
+++ b/modules/k3h4/native/tests/CMakeLists.txt
@@ -40,6 +40,11 @@ banana_k3h4_add_test_if_exists(
 )
 
 banana_k3h4_add_test_if_exists(
+  banana_k3h4_dialogue_generative_surface_layer_test
+  "k3h4/k3h4_dialogue_generative_surface_layer_test.c"
+)
+
+banana_k3h4_add_test_if_exists(
   banana_k3h4_metrics_infrastructure_adapter_test
   "k3h4/infrastructure/k3h4_metrics_infrastructure_adapter_test.c"
 )

--- a/modules/k3h4/native/tests/k3h4/k3h4_dialogue_generative_surface_layer_test.c
+++ b/modules/k3h4/native/tests/k3h4/k3h4_dialogue_generative_surface_layer_test.c
@@ -1,0 +1,115 @@
+#include "k3h4/k3h4_dialogue_cluster_router.h"
+#include "k3h4/k3h4_dialogue_generative_surface_layer.h"
+#include "k3h4/k3h4_dialogue_template_layer.h"
+
+#include "runtime/support/test_support.h"
+
+static int build_template(BananaK3h4DialogueIntent intent,
+                          int has_entry_writ,
+                          int mentions_secret_tunnel,
+                          int ambiguity_basis_points,
+                          uint32_t proposed_fact_mask,
+                          BananaK3h4DialogueTemplateOutput *out_template_output)
+{
+    BananaK3h4DialogueRouteInput route_input = {
+        .intent = intent,
+        .has_entry_writ = has_entry_writ,
+        .mentions_secret_tunnel = mentions_secret_tunnel,
+        .ambiguity_basis_points = ambiguity_basis_points,
+    };
+    BananaK3h4DialogueRouteOutput route_output = {0};
+    BananaK3h4DialogueTemplateInput template_input;
+
+    if (banana_native_k3h4_route_dialogue_cluster(&route_input, &route_output) != 0)
+        return -1;
+
+    template_input.route_output = route_output;
+    template_input.proposed_fact_mask = proposed_fact_mask;
+
+    return banana_native_k3h4_resolve_dialogue_template(&template_input, out_template_output);
+}
+
+static void test_assembler_builds_generator_contract_from_stack_and_facts(void **state)
+{
+    BananaK3h4DialogueTemplateOutput template_output = {0};
+    BananaK3h4DialogueGeneratorInput generator_input;
+    BananaK3h4DialogueGeneratorOutput generator_output = {0};
+    int status;
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        build_template(BANANA_K3H4_DIALOGUE_INTENT_REQUEST_HELP,
+                       1,
+                       0,
+                       40,
+                       BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_HELP_GUIDANCE,
+                       &template_output),
+        0,
+        "template output generation must succeed");
+
+    generator_input.template_output = template_output;
+    generator_input.selected_fact_mask = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_HELP_GUIDANCE;
+    generator_input.canon_violation_mask = 0u;
+
+    status = banana_native_k3h4_assemble_dialogue_generator_contract(&generator_input, &generator_output);
+
+    BANANA_TEST_ASSERT_INT_EQ(status, 0, "contract assembly must succeed for valid facts");
+    BANANA_TEST_ASSERT_INT_EQ(generator_output.fail_closed, 0, "valid contract must not fail closed");
+    BANANA_TEST_ASSERT_INT_EQ(generator_output.selected_cluster_stack_count,
+                              template_output.selected_cluster_stack_count,
+                              "generator contract must include selected cluster stack");
+    BANANA_TEST_ASSERT_TRUE((generator_output.validated_fact_mask &
+                             BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_HELP_GUIDANCE) != 0u,
+                            "validated fact mask must preserve allowed selected facts");
+}
+
+static void test_validator_rejects_violations_with_deterministic_deny_metadata(void **state)
+{
+    BananaK3h4DialogueTemplateOutput template_output = {0};
+    BananaK3h4DialogueGeneratorInput generator_input;
+    BananaK3h4DialogueGeneratorOutput first_output = {0};
+    BananaK3h4DialogueGeneratorOutput second_output = {0};
+    int first_status;
+    int second_status;
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        build_template(BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS,
+                       1,
+                       0,
+                       0,
+                       BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS,
+                       &template_output),
+        0,
+        "template output generation must succeed");
+
+    generator_input.template_output = template_output;
+    generator_input.selected_fact_mask = BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS;
+    generator_input.canon_violation_mask = 1u;
+
+    first_status = banana_native_k3h4_assemble_dialogue_generator_contract(&generator_input, &first_output);
+    second_status = banana_native_k3h4_assemble_dialogue_generator_contract(&generator_input, &second_output);
+
+    BANANA_TEST_ASSERT_TRUE(first_status != 0,
+                            "canon violations must be rejected with non-zero status");
+    BANANA_TEST_ASSERT_TRUE(second_status != 0,
+                            "repeat canon violations must remain non-zero");
+    BANANA_TEST_ASSERT_INT_EQ(first_output.fail_closed,
+                              1,
+                              "violation must trigger fail-closed output");
+    BANANA_TEST_ASSERT_INT_EQ(first_output.deny_reason,
+                              BANANA_K3H4_DIALOGUE_GENERATOR_DENY_REASON_CANON_VIOLATION,
+                              "deny reason must encode canon violation");
+    BANANA_TEST_ASSERT_STR_EQ(first_output.deny_template_key,
+                              "k3h4.template.edda.south_gate.deny.fail_closed",
+                              "deny metadata must provide deterministic deny template key");
+    BANANA_TEST_ASSERT_INT_EQ(first_output.deny_code,
+                              second_output.deny_code,
+                              "deny code must be deterministic for identical violating input");
+}
+
+BANANA_TEST_MAIN(
+    BANANA_TEST_CASE(test_assembler_builds_generator_contract_from_stack_and_facts),
+    BANANA_TEST_CASE(test_validator_rejects_violations_with_deterministic_deny_metadata))

--- a/tests/native/CMakeLists.txt
+++ b/tests/native/CMakeLists.txt
@@ -1286,6 +1286,40 @@ if(EXISTS "${BANANA_K3H4_DIALOGUE_TEMPLATE_LAYER_TEST_SOURCE}")
 	)
 endif()
 
+set(BANANA_K3H4_DIALOGUE_GENERATIVE_SURFACE_LAYER_TEST_SOURCE
+	"${BANANA_K3H4_TEST_DIR}/k3h4/k3h4_dialogue_generative_surface_layer_test.c"
+)
+
+if(EXISTS "${BANANA_K3H4_DIALOGUE_GENERATIVE_SURFACE_LAYER_TEST_SOURCE}")
+	add_executable(banana_native_k3h4_dialogue_generative_surface_layer_test
+		${BANANA_K3H4_DIALOGUE_GENERATIVE_SURFACE_LAYER_TEST_SOURCE}
+	)
+
+	add_test(NAME banana_native_k3h4_dialogue_generative_surface_layer_test
+		COMMAND banana_native_k3h4_dialogue_generative_surface_layer_test
+	)
+
+	target_link_libraries(banana_native_k3h4_dialogue_generative_surface_layer_test PRIVATE banana_k3h4_core)
+	target_link_libraries(banana_native_k3h4_dialogue_generative_surface_layer_test PRIVATE banana_engine_core)
+
+	if(WIN32)
+		add_custom_command(TARGET banana_native_k3h4_dialogue_generative_surface_layer_test POST_BUILD
+			COMMAND ${CMAKE_COMMAND}
+				-Dbanana_runtime_dlls=$<JOIN:$<TARGET_RUNTIME_DLLS:banana_native_k3h4_dialogue_generative_surface_layer_test>,|>
+				-Dbanana_target_dir=$<TARGET_FILE_DIR:banana_native_k3h4_dialogue_generative_surface_layer_test>
+				-P ${CMAKE_CURRENT_LIST_DIR}/runtime/support/copy_runtime_dlls.cmake
+			COMMENT "Copying runtime DLLs next to banana_native_k3h4_dialogue_generative_surface_layer_test"
+		)
+	endif()
+
+	target_include_directories(banana_native_k3h4_dialogue_generative_surface_layer_test PRIVATE
+		${BANANA_ENGINE_DIR}
+		${BANANA_ENGINE_DIR}/runtime
+		${CMAKE_CURRENT_LIST_DIR}/../../src/native
+		${BANANA_K3H4_SRC_DIR}
+	)
+endif()
+
 add_executable(banana_runtime_terrain_generation_test
 	${CMAKE_CURRENT_LIST_DIR}/runtime/terrain/terrain_generation_test.c
 )


### PR DESCRIPTION
## Summary
- add K3H4 generative surface layer constrained by dialogue template outputs
- implement generator input contract assembly from selected cluster stack plus validated facts
- enforce fail-closed validator for unauthorized/forbidden facts and canon violations
- emit deterministic deny fallback metadata (`deny_reason`, `deny_code`, `deny_template_key`) on violation paths
- add focused Story C acceptance test suite for success assembly and violation rejection semantics

## Deliverable Coverage
- generator input contract assembler from cluster stack and validated facts
- fail-closed validator for forbidden facts/canon violations
- deterministic deny fallback behavior and reason coding

## Acceptance Gate
- violation cases in `banana_native_k3h4_dialogue_generative_surface_layer_test` assert non-zero status and deterministic deny metadata

## Validation
- `cmake -S src/native -B out/v3-native`
- `cmake --build out/v3-native --config Debug --target banana_native_k3h4_dialogue_generative_surface_layer_test -- -m:1`
- `ctest -C Debug --test-dir out/v3-native -R banana_native_k3h4_dialogue_generative_surface_layer_test --output-on-failure`

Depends on #1177
Closes #1178
