### PR TITLE
feat(k3h4): add spectral transition graph constraints

### DIFF
--- a/modules/k3h4/native/CMakeLists.txt
+++ b/modules/k3h4/native/CMakeLists.txt
@@ -29,6 +29,7 @@ banana_k3h4_add_source_if_exists("src/k3h4/k3h4_metrics_orchestration_layer.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_cluster_router.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_template_layer.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_generative_surface_layer.c")
+banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_spectral_transition_graph.c")
 banana_k3h4_add_source_if_exists("src/k3h4/application/k3h4_metrics_application_service.c")
 banana_k3h4_add_source_if_exists("src/k3h4/infrastructure/k3h4_metrics_infrastructure_adapter.c")
 

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_spectral_transition_graph.c
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_spectral_transition_graph.c
@@ -1,0 +1,131 @@
+#include "k3h4_dialogue_spectral_transition_graph.h"
+
+#include <stddef.h>
+#include <string.h>
+
+enum
+{
+    BANANA_K3H4_DIALOGUE_SPECTRAL_GRAPH_VERSION = 1,
+};
+
+static int is_candidate(BananaK3h4DialogueSpectralState state,
+                        const BananaK3h4DialogueSpectralTransitionOutput *output)
+{
+    int index;
+
+    for (index = 0; index < output->candidate_count; ++index)
+    {
+        if (output->candidate_states[index] == state)
+            return 1;
+    }
+
+    return 0;
+}
+
+static int build_deny_reason_code(BananaK3h4DialogueSpectralDenyReason reason,
+                                  const BananaK3h4DialogueSpectralTransitionInput *input)
+{
+    uint32_t hash = 2166136261u;
+    const uint32_t fields[] = {
+        (uint32_t)reason,
+        (uint32_t)input->current_state,
+        (uint32_t)input->requested_state,
+        (uint32_t)input->route_output.boundary_state,
+        (uint32_t)input->route_output.resolved_gate,
+    };
+    size_t index;
+
+    for (index = 0; index < sizeof(fields) / sizeof(fields[0]); ++index)
+    {
+        hash ^= fields[index];
+        hash *= 16777619u;
+    }
+
+    return (int)(hash & 0x7fffffff);
+}
+
+static void populate_candidates(const BananaK3h4DialogueSpectralTransitionInput *input,
+                                BananaK3h4DialogueSpectralTransitionOutput *out_output)
+{
+    out_output->candidate_count = 0;
+
+    if (input->route_output.boundary_state == BANANA_K3H4_DIALOGUE_BOUNDARY_OUTSIDE)
+    {
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_DENY;
+        return;
+    }
+
+    if (input->route_output.resolved_gate != BANANA_K3H4_DIALOGUE_GATE_NONE)
+    {
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_DENY;
+
+        if (input->route_output.response_contract.response_mode == BANANA_K3H4_DIALOGUE_RESPONSE_REDIRECT)
+            out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_REDIRECT;
+
+        return;
+    }
+
+    switch (input->route_output.response_contract.response_mode)
+    {
+    case BANANA_K3H4_DIALOGUE_RESPONSE_ASSIST:
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ASSIST;
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_REDIRECT;
+        break;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_DEESCALATE:
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_DEESCALATE;
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_REDIRECT;
+        break;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_REDIRECT:
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_REDIRECT;
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ENTRY_GATE;
+        break;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_DENY:
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_DENY;
+        break;
+    case BANANA_K3H4_DIALOGUE_RESPONSE_NEUTRAL:
+    default:
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ENTRY_GATE;
+        out_output->candidate_states[out_output->candidate_count++] = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_REDIRECT;
+        break;
+    }
+}
+
+int banana_native_k3h4_resolve_spectral_transition(
+    const BananaK3h4DialogueSpectralTransitionInput *input,
+    BananaK3h4DialogueSpectralTransitionOutput *out_output)
+{
+    BananaK3h4DialogueSpectralDenyReason deny_reason = BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_NONE;
+
+    if (input == NULL || out_output == NULL)
+        return -1;
+
+    memset(out_output, 0, sizeof(*out_output));
+    out_output->graph_version = BANANA_K3H4_DIALOGUE_SPECTRAL_GRAPH_VERSION;
+    out_output->current_state = input->current_state;
+
+    populate_candidates(input, out_output);
+
+    if (input->route_output.boundary_state == BANANA_K3H4_DIALOGUE_BOUNDARY_OUTSIDE)
+        deny_reason = BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_BOUNDARY_OUTSIDE;
+    else if (input->route_output.resolved_gate != BANANA_K3H4_DIALOGUE_GATE_NONE)
+        deny_reason = BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_GATE_BLOCKED;
+
+    if (is_candidate(input->requested_state, out_output))
+    {
+        out_output->transition_allowed = 1;
+        out_output->next_state = input->requested_state;
+        out_output->deny_reason = BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_NONE;
+        out_output->deny_reason_code = 0;
+        return 0;
+    }
+
+    out_output->transition_allowed = 0;
+    out_output->next_state = out_output->candidate_states[0];
+    out_output->deny_reason =
+        (deny_reason == BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_NONE)
+            ? BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_ILLEGAL_JUMP
+            : deny_reason;
+    out_output->deny_reason_code = build_deny_reason_code(out_output->deny_reason, input);
+
+    return -2;
+}

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_spectral_transition_graph.h
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_spectral_transition_graph.h
@@ -1,0 +1,62 @@
+#ifndef BANANA_NATIVE_K3H4_DIALOGUE_SPECTRAL_TRANSITION_GRAPH_H
+#define BANANA_NATIVE_K3H4_DIALOGUE_SPECTRAL_TRANSITION_GRAPH_H
+
+#include "k3h4_dialogue_cluster_router.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef enum BananaK3h4DialogueSpectralState
+    {
+        BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ENTRY_GATE = 0,
+        BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_REDIRECT = 1,
+        BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ASSIST = 2,
+        BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_DEESCALATE = 3,
+        BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_DENY = 4,
+    } BananaK3h4DialogueSpectralState;
+
+    typedef enum BananaK3h4DialogueSpectralDenyReason
+    {
+        BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_NONE = 0,
+        BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_ILLEGAL_JUMP = 1,
+        BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_BOUNDARY_OUTSIDE = 2,
+        BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_GATE_BLOCKED = 3,
+    } BananaK3h4DialogueSpectralDenyReason;
+
+    enum
+    {
+        BANANA_K3H4_DIALOGUE_SPECTRAL_CANDIDATE_MAX = 3,
+    };
+
+    typedef struct BananaK3h4DialogueSpectralTransitionInput
+    {
+        BananaK3h4DialogueSpectralState current_state;
+        BananaK3h4DialogueSpectralState requested_state;
+        BananaK3h4DialogueRouteOutput route_output;
+    } BananaK3h4DialogueSpectralTransitionInput;
+
+    typedef struct BananaK3h4DialogueSpectralTransitionOutput
+    {
+        int graph_version;
+        BananaK3h4DialogueSpectralState current_state;
+        BananaK3h4DialogueSpectralState candidate_states[BANANA_K3H4_DIALOGUE_SPECTRAL_CANDIDATE_MAX];
+        int candidate_count;
+        BananaK3h4DialogueSpectralState next_state;
+        int transition_allowed;
+        BananaK3h4DialogueSpectralDenyReason deny_reason;
+        int deny_reason_code;
+    } BananaK3h4DialogueSpectralTransitionOutput;
+
+    int banana_native_k3h4_resolve_spectral_transition(
+        const BananaK3h4DialogueSpectralTransitionInput *input,
+        BananaK3h4DialogueSpectralTransitionOutput *out_output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/modules/k3h4/native/tests/CMakeLists.txt
+++ b/modules/k3h4/native/tests/CMakeLists.txt
@@ -45,6 +45,11 @@ banana_k3h4_add_test_if_exists(
 )
 
 banana_k3h4_add_test_if_exists(
+  banana_k3h4_dialogue_spectral_transition_graph_test
+  "k3h4/k3h4_dialogue_spectral_transition_graph_test.c"
+)
+
+banana_k3h4_add_test_if_exists(
   banana_k3h4_metrics_infrastructure_adapter_test
   "k3h4/infrastructure/k3h4_metrics_infrastructure_adapter_test.c"
 )

--- a/modules/k3h4/native/tests/k3h4/k3h4_dialogue_spectral_transition_graph_test.c
+++ b/modules/k3h4/native/tests/k3h4/k3h4_dialogue_spectral_transition_graph_test.c
@@ -1,0 +1,126 @@
+#include "k3h4/k3h4_dialogue_cluster_router.h"
+#include "k3h4/k3h4_dialogue_spectral_transition_graph.h"
+
+#include "runtime/support/test_support.h"
+
+static int build_route(BananaK3h4DialogueIntent intent,
+                       int has_entry_writ,
+                       int mentions_secret_tunnel,
+                       int ambiguity_basis_points,
+                       BananaK3h4DialogueRouteOutput *out_output)
+{
+    BananaK3h4DialogueRouteInput route_input = {
+        .intent = intent,
+        .has_entry_writ = has_entry_writ,
+        .mentions_secret_tunnel = mentions_secret_tunnel,
+        .ambiguity_basis_points = ambiguity_basis_points,
+    };
+
+    return banana_native_k3h4_route_dialogue_cluster(&route_input, out_output);
+}
+
+static void test_generates_boundary_aware_transition_candidates(void **state)
+{
+    BananaK3h4DialogueRouteOutput route_output = {0};
+    BananaK3h4DialogueSpectralTransitionInput transition_input;
+    BananaK3h4DialogueSpectralTransitionOutput transition_output = {0};
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        build_route(BANANA_K3H4_DIALOGUE_INTENT_REQUEST_HELP, 1, 0, 0, &route_output),
+        0,
+        "route output generation must succeed");
+
+    transition_input.current_state = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ENTRY_GATE;
+    transition_input.requested_state = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ASSIST;
+    transition_input.route_output = route_output;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_resolve_spectral_transition(&transition_input, &transition_output),
+        0,
+        "legal transition request must resolve successfully");
+
+    BANANA_TEST_ASSERT_INT_EQ(transition_output.transition_allowed,
+                              1,
+                              "assist transition should be allowed for assist response profile");
+    BANANA_TEST_ASSERT_INT_EQ(transition_output.next_state,
+                              BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ASSIST,
+                              "next state must match requested legal assist state");
+    BANANA_TEST_ASSERT_INT_EQ(transition_output.candidate_count,
+                              2,
+                              "assist profile should emit deterministic two-state candidate set");
+}
+
+static void test_blocks_illegal_jump_with_stable_deny_reason_codes(void **state)
+{
+    BananaK3h4DialogueRouteOutput route_output = {0};
+    BananaK3h4DialogueSpectralTransitionInput transition_input;
+    BananaK3h4DialogueSpectralTransitionOutput first_output = {0};
+    BananaK3h4DialogueSpectralTransitionOutput second_output = {0};
+    int first_status;
+    int second_status;
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        build_route(BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS, 1, 0, 0, &route_output),
+        0,
+        "route output generation must succeed");
+
+    transition_input.current_state = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ENTRY_GATE;
+    transition_input.requested_state = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ASSIST;
+    transition_input.route_output = route_output;
+
+    first_status = banana_native_k3h4_resolve_spectral_transition(&transition_input, &first_output);
+    second_status = banana_native_k3h4_resolve_spectral_transition(&transition_input, &second_output);
+
+    BANANA_TEST_ASSERT_TRUE(first_status != 0,
+                            "illegal jump must return non-zero status");
+    BANANA_TEST_ASSERT_TRUE(second_status != 0,
+                            "repeat illegal jump must remain non-zero");
+    BANANA_TEST_ASSERT_INT_EQ(first_output.transition_allowed,
+                              0,
+                              "illegal jump must be disallowed");
+    BANANA_TEST_ASSERT_INT_EQ(first_output.deny_reason,
+                              BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_ILLEGAL_JUMP,
+                              "illegal jump deny reason must be encoded");
+    BANANA_TEST_ASSERT_INT_EQ(first_output.deny_reason_code,
+                              second_output.deny_reason_code,
+                              "deny reason code must be stable for identical illegal jump input");
+}
+
+static void test_gate_blocked_transitions_emit_gate_deny_reason(void **state)
+{
+    BananaK3h4DialogueRouteOutput route_output = {0};
+    BananaK3h4DialogueSpectralTransitionInput transition_input;
+    BananaK3h4DialogueSpectralTransitionOutput transition_output = {0};
+    int status;
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        build_route(BANANA_K3H4_DIALOGUE_INTENT_ASK_CASTLE_ENTRY, 0, 0, 0, &route_output),
+        0,
+        "route output generation must succeed");
+
+    transition_input.current_state = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ENTRY_GATE;
+    transition_input.requested_state = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ASSIST;
+    transition_input.route_output = route_output;
+
+    status = banana_native_k3h4_resolve_spectral_transition(&transition_input, &transition_output);
+
+    BANANA_TEST_ASSERT_TRUE(status != 0,
+                            "gate-blocked illegal request must return non-zero status");
+    BANANA_TEST_ASSERT_INT_EQ(transition_output.deny_reason,
+                              BANANA_K3H4_DIALOGUE_SPECTRAL_DENY_GATE_BLOCKED,
+                              "gate-blocked route must emit gate deny reason");
+    BANANA_TEST_ASSERT_INT_EQ(transition_output.next_state,
+                              BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_DENY,
+                              "gate-blocked transition must deterministically resolve to deny state");
+}
+
+BANANA_TEST_MAIN(
+    BANANA_TEST_CASE(test_generates_boundary_aware_transition_candidates),
+    BANANA_TEST_CASE(test_blocks_illegal_jump_with_stable_deny_reason_codes),
+    BANANA_TEST_CASE(test_gate_blocked_transitions_emit_gate_deny_reason))

--- a/tests/native/CMakeLists.txt
+++ b/tests/native/CMakeLists.txt
@@ -1320,6 +1320,40 @@ if(EXISTS "${BANANA_K3H4_DIALOGUE_GENERATIVE_SURFACE_LAYER_TEST_SOURCE}")
 	)
 endif()
 
+set(BANANA_K3H4_DIALOGUE_SPECTRAL_TRANSITION_GRAPH_TEST_SOURCE
+	"${BANANA_K3H4_TEST_DIR}/k3h4/k3h4_dialogue_spectral_transition_graph_test.c"
+)
+
+if(EXISTS "${BANANA_K3H4_DIALOGUE_SPECTRAL_TRANSITION_GRAPH_TEST_SOURCE}")
+	add_executable(banana_native_k3h4_dialogue_spectral_transition_graph_test
+		${BANANA_K3H4_DIALOGUE_SPECTRAL_TRANSITION_GRAPH_TEST_SOURCE}
+	)
+
+	add_test(NAME banana_native_k3h4_dialogue_spectral_transition_graph_test
+		COMMAND banana_native_k3h4_dialogue_spectral_transition_graph_test
+	)
+
+	target_link_libraries(banana_native_k3h4_dialogue_spectral_transition_graph_test PRIVATE banana_k3h4_core)
+	target_link_libraries(banana_native_k3h4_dialogue_spectral_transition_graph_test PRIVATE banana_engine_core)
+
+	if(WIN32)
+		add_custom_command(TARGET banana_native_k3h4_dialogue_spectral_transition_graph_test POST_BUILD
+			COMMAND ${CMAKE_COMMAND}
+				-Dbanana_runtime_dlls=$<JOIN:$<TARGET_RUNTIME_DLLS:banana_native_k3h4_dialogue_spectral_transition_graph_test>,|>
+				-Dbanana_target_dir=$<TARGET_FILE_DIR:banana_native_k3h4_dialogue_spectral_transition_graph_test>
+				-P ${CMAKE_CURRENT_LIST_DIR}/runtime/support/copy_runtime_dlls.cmake
+			COMMENT "Copying runtime DLLs next to banana_native_k3h4_dialogue_spectral_transition_graph_test"
+		)
+	endif()
+
+	target_include_directories(banana_native_k3h4_dialogue_spectral_transition_graph_test PRIVATE
+		${BANANA_ENGINE_DIR}
+		${BANANA_ENGINE_DIR}/runtime
+		${CMAKE_CURRENT_LIST_DIR}/../../src/native
+		${BANANA_K3H4_SRC_DIR}
+	)
+endif()
+
 add_executable(banana_runtime_terrain_generation_test
 	${CMAKE_CURRENT_LIST_DIR}/runtime/terrain/terrain_generation_test.c
 )


### PR DESCRIPTION
## Summary
- add spectral transition graph model and deterministic next-state resolver for dialogue flow legality
- generate boundary-state-aware transition candidates from route output and response mode
- block illegal transitions with deterministic deny reasons and stable deny reason codes
- add illegal transition suite validating disallowed jump blocking and stable deny code behavior
- wire Story D source and tests into K3H4/native CMake targets

## Deliverable Coverage
- legal transition graph model and deterministic next-state resolver
- boundary-state aware transition candidate generation
- deterministic deny reasons for illegal transitions

## Acceptance Gate
- illegal transition suite blocks disallowed jumps and asserts stable deny reason codes across identical inputs

## Validation
- cmake -S src/native -B out/v3-native
- cmake --build out/v3-native --config Debug --target banana_native_k3h4_dialogue_spectral_transition_graph_test -- -m:1
- ctest -C Debug --test-dir out/v3-native -R banana_native_k3h4_dialogue_spectral_transition_graph_test --output-on-failure

Depends on #1178
Closes #1179
