### PR TITLE
feat(k3h4): add bounded memory delta compression

### DIFF
--- a/modules/k3h4/native/CMakeLists.txt
+++ b/modules/k3h4/native/CMakeLists.txt
@@ -30,6 +30,7 @@ banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_cluster_router.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_template_layer.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_generative_surface_layer.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_spectral_transition_graph.c")
+banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_memory_delta_store.c")
 banana_k3h4_add_source_if_exists("src/k3h4/application/k3h4_metrics_application_service.c")
 banana_k3h4_add_source_if_exists("src/k3h4/infrastructure/k3h4_metrics_infrastructure_adapter.c")
 

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_memory_delta_store.c
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_memory_delta_store.c
@@ -1,0 +1,200 @@
+#include "k3h4_dialogue_memory_delta_store.h"
+
+#include <stddef.h>
+#include <string.h>
+
+static int clamp_int(int value, int min_value, int max_value)
+{
+    if (value < min_value)
+        return min_value;
+    if (value > max_value)
+        return max_value;
+    return value;
+}
+
+static int feature_is_valid(BananaK3h4DialogueMemoryFeature feature)
+{
+    return feature >= BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_TRUST_DELTA &&
+           feature <= BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_HELPFULNESS_DELTA;
+}
+
+static int entry_is_active(const BananaK3h4DialogueMemoryEntry *entry, uint64_t current_tick)
+{
+    return entry->occupied != 0 && current_tick < entry->expires_tick;
+}
+
+static int find_existing_index(const BananaK3h4DialogueMemoryStore *store,
+                               uint32_t npc_id,
+                               BananaK3h4DialogueMemoryFeature feature)
+{
+    size_t index;
+
+    for (index = 0; index < sizeof(store->entries) / sizeof(store->entries[0]); ++index)
+    {
+        const BananaK3h4DialogueMemoryEntry *entry = &store->entries[index];
+
+        if (entry->occupied != 0 && entry->npc_id == npc_id && entry->feature == feature)
+            return (int)index;
+    }
+
+    return -1;
+}
+
+static int find_free_or_expired_index(BananaK3h4DialogueMemoryStore *store, uint64_t current_tick)
+{
+    size_t index;
+
+    for (index = 0; index < sizeof(store->entries) / sizeof(store->entries[0]); ++index)
+    {
+        BananaK3h4DialogueMemoryEntry *entry = &store->entries[index];
+
+        if (entry->occupied == 0 || current_tick >= entry->expires_tick)
+            return (int)index;
+    }
+
+    return -1;
+}
+
+static int find_evict_index(const BananaK3h4DialogueMemoryStore *store)
+{
+    size_t index;
+    int selected = -1;
+
+    for (index = 0; index < sizeof(store->entries) / sizeof(store->entries[0]); ++index)
+    {
+        const BananaK3h4DialogueMemoryEntry *entry = &store->entries[index];
+
+        if (entry->occupied == 0)
+            continue;
+
+        if (selected < 0)
+        {
+            selected = (int)index;
+            continue;
+        }
+
+        if (entry->expires_tick < store->entries[selected].expires_tick)
+        {
+            selected = (int)index;
+            continue;
+        }
+
+        if (entry->expires_tick == store->entries[selected].expires_tick &&
+            entry->sequence < store->entries[selected].sequence)
+        {
+            selected = (int)index;
+        }
+    }
+
+    return selected;
+}
+
+void banana_native_k3h4_dialogue_memory_init(BananaK3h4DialogueMemoryStore *store,
+                                              BananaK3h4DialogueMemoryPolicy policy)
+{
+    if (store == NULL)
+        return;
+
+    memset(store, 0, sizeof(*store));
+
+    if (policy.ttl_ticks <= 0)
+        policy.ttl_ticks = 1;
+
+    if (policy.delta_min > policy.delta_max)
+    {
+        int temp = policy.delta_min;
+        policy.delta_min = policy.delta_max;
+        policy.delta_max = temp;
+    }
+
+    store->policy = policy;
+    store->next_sequence = 1;
+}
+
+void banana_native_k3h4_dialogue_memory_prune_expired(BananaK3h4DialogueMemoryStore *store,
+                                                       uint64_t current_tick)
+{
+    size_t index;
+
+    if (store == NULL)
+        return;
+
+    for (index = 0; index < sizeof(store->entries) / sizeof(store->entries[0]); ++index)
+    {
+        BananaK3h4DialogueMemoryEntry *entry = &store->entries[index];
+
+        if (entry->occupied != 0 && current_tick >= entry->expires_tick)
+            memset(entry, 0, sizeof(*entry));
+    }
+}
+
+int banana_native_k3h4_dialogue_memory_upsert_delta(BananaK3h4DialogueMemoryStore *store,
+                                                     uint32_t npc_id,
+                                                     BananaK3h4DialogueMemoryFeature feature,
+                                                     int delta,
+                                                     uint64_t current_tick)
+{
+    int index;
+    BananaK3h4DialogueMemoryEntry *entry;
+
+    if (store == NULL || !feature_is_valid(feature) || npc_id == 0)
+        return -1;
+
+    banana_native_k3h4_dialogue_memory_prune_expired(store, current_tick);
+
+    index = find_existing_index(store, npc_id, feature);
+    if (index < 0)
+        index = find_free_or_expired_index(store, current_tick);
+    if (index < 0)
+        index = find_evict_index(store);
+    if (index < 0)
+        return -2;
+
+    entry = &store->entries[index];
+    entry->occupied = 1;
+    entry->npc_id = npc_id;
+    entry->feature = feature;
+    entry->delta = clamp_int(delta, store->policy.delta_min, store->policy.delta_max);
+    entry->updated_tick = current_tick;
+    entry->expires_tick = current_tick + (uint64_t)store->policy.ttl_ticks;
+    entry->sequence = store->next_sequence++;
+
+    return 0;
+}
+
+int banana_native_k3h4_dialogue_memory_get_delta(const BananaK3h4DialogueMemoryStore *store,
+                                                  uint32_t npc_id,
+                                                  BananaK3h4DialogueMemoryFeature feature,
+                                                  uint64_t current_tick,
+                                                  int *out_delta)
+{
+    int index;
+
+    if (store == NULL || out_delta == NULL || !feature_is_valid(feature) || npc_id == 0)
+        return -1;
+
+    index = find_existing_index(store, npc_id, feature);
+    if (index < 0 || !entry_is_active(&store->entries[index], current_tick))
+        return -2;
+
+    *out_delta = store->entries[index].delta;
+    return 0;
+}
+
+int banana_native_k3h4_dialogue_memory_count_active(const BananaK3h4DialogueMemoryStore *store,
+                                                     uint64_t current_tick)
+{
+    size_t index;
+    int count = 0;
+
+    if (store == NULL)
+        return 0;
+
+    for (index = 0; index < sizeof(store->entries) / sizeof(store->entries[0]); ++index)
+    {
+        if (entry_is_active(&store->entries[index], current_tick))
+            count += 1;
+    }
+
+    return count;
+}

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_memory_delta_store.h
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_memory_delta_store.h
@@ -1,0 +1,74 @@
+#ifndef BANANA_NATIVE_K3H4_DIALOGUE_MEMORY_DELTA_STORE_H
+#define BANANA_NATIVE_K3H4_DIALOGUE_MEMORY_DELTA_STORE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef enum BananaK3h4DialogueMemoryFeature
+    {
+        BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_TRUST_DELTA = 0,
+        BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_HOSTILITY_DELTA = 1,
+        BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_HELPFULNESS_DELTA = 2,
+    } BananaK3h4DialogueMemoryFeature;
+
+    enum
+    {
+        BANANA_K3H4_DIALOGUE_MEMORY_NPC_CAP = 8,
+        BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_CAP = 3,
+    };
+
+    typedef struct BananaK3h4DialogueMemoryPolicy
+    {
+        int ttl_ticks;
+        int delta_min;
+        int delta_max;
+    } BananaK3h4DialogueMemoryPolicy;
+
+    typedef struct BananaK3h4DialogueMemoryEntry
+    {
+        uint32_t npc_id;
+        BananaK3h4DialogueMemoryFeature feature;
+        int delta;
+        uint64_t updated_tick;
+        uint64_t expires_tick;
+        uint64_t sequence;
+        int occupied;
+    } BananaK3h4DialogueMemoryEntry;
+
+    typedef struct BananaK3h4DialogueMemoryStore
+    {
+        BananaK3h4DialogueMemoryPolicy policy;
+        BananaK3h4DialogueMemoryEntry entries[BANANA_K3H4_DIALOGUE_MEMORY_NPC_CAP * BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_CAP];
+        uint64_t next_sequence;
+    } BananaK3h4DialogueMemoryStore;
+
+    void banana_native_k3h4_dialogue_memory_init(BananaK3h4DialogueMemoryStore *store,
+                                                  BananaK3h4DialogueMemoryPolicy policy);
+
+    void banana_native_k3h4_dialogue_memory_prune_expired(BananaK3h4DialogueMemoryStore *store,
+                                                           uint64_t current_tick);
+
+    int banana_native_k3h4_dialogue_memory_upsert_delta(BananaK3h4DialogueMemoryStore *store,
+                                                         uint32_t npc_id,
+                                                         BananaK3h4DialogueMemoryFeature feature,
+                                                         int delta,
+                                                         uint64_t current_tick);
+
+    int banana_native_k3h4_dialogue_memory_get_delta(const BananaK3h4DialogueMemoryStore *store,
+                                                      uint32_t npc_id,
+                                                      BananaK3h4DialogueMemoryFeature feature,
+                                                      uint64_t current_tick,
+                                                      int *out_delta);
+
+    int banana_native_k3h4_dialogue_memory_count_active(const BananaK3h4DialogueMemoryStore *store,
+                                                         uint64_t current_tick);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/modules/k3h4/native/tests/CMakeLists.txt
+++ b/modules/k3h4/native/tests/CMakeLists.txt
@@ -50,6 +50,11 @@ banana_k3h4_add_test_if_exists(
 )
 
 banana_k3h4_add_test_if_exists(
+  banana_k3h4_dialogue_memory_delta_store_test
+  "k3h4/k3h4_dialogue_memory_delta_store_test.c"
+)
+
+banana_k3h4_add_test_if_exists(
   banana_k3h4_metrics_infrastructure_adapter_test
   "k3h4/infrastructure/k3h4_metrics_infrastructure_adapter_test.c"
 )

--- a/modules/k3h4/native/tests/k3h4/k3h4_dialogue_memory_delta_store_test.c
+++ b/modules/k3h4/native/tests/k3h4/k3h4_dialogue_memory_delta_store_test.c
@@ -1,0 +1,157 @@
+#include "k3h4/k3h4_dialogue_memory_delta_store.h"
+
+#include "runtime/support/test_support.h"
+
+static BananaK3h4DialogueMemoryPolicy default_policy(void)
+{
+    BananaK3h4DialogueMemoryPolicy policy = {
+        .ttl_ticks = 5,
+        .delta_min = -100,
+        .delta_max = 100,
+    };
+    return policy;
+}
+
+static void test_delta_store_applies_cap_and_range_policy(void **state)
+{
+    BananaK3h4DialogueMemoryStore store;
+    int delta = 0;
+
+    (void)state;
+
+    banana_native_k3h4_dialogue_memory_init(&store, default_policy());
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_memory_upsert_delta(
+            &store,
+            1001,
+            BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_TRUST_DELTA,
+            1000,
+            10),
+        0,
+        "upsert should succeed");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_memory_get_delta(
+            &store,
+            1001,
+            BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_TRUST_DELTA,
+            11,
+            &delta),
+        0,
+        "stored delta should be retrievable before TTL expiry");
+    BANANA_TEST_ASSERT_INT_EQ(delta,
+                              100,
+                              "delta must clamp to configured upper range boundary");
+}
+
+static void test_ttl_prunes_expired_entries_deterministically(void **state)
+{
+    BananaK3h4DialogueMemoryStore store;
+    int delta = 0;
+
+    (void)state;
+
+    banana_native_k3h4_dialogue_memory_init(&store, default_policy());
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_memory_upsert_delta(
+            &store,
+            2001,
+            BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_HELPFULNESS_DELTA,
+            20,
+            0),
+        0,
+        "initial upsert should succeed");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_memory_get_delta(
+            &store,
+            2001,
+            BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_HELPFULNESS_DELTA,
+            4,
+            &delta),
+        0,
+        "entry should remain active before TTL");
+
+    banana_native_k3h4_dialogue_memory_prune_expired(&store, 5);
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_memory_get_delta(
+            &store,
+            2001,
+            BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_HELPFULNESS_DELTA,
+            5,
+            &delta),
+        -2,
+        "entry should be unavailable at or after expiry tick");
+}
+
+static void test_capacity_pressure_uses_deterministic_eviction_order(void **state)
+{
+    BananaK3h4DialogueMemoryStore store;
+    int expected_capacity = BANANA_K3H4_DIALOGUE_MEMORY_NPC_CAP * BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_CAP;
+    int index;
+    int delta = 0;
+
+    (void)state;
+
+    banana_native_k3h4_dialogue_memory_init(&store, default_policy());
+
+    for (index = 0; index < expected_capacity; ++index)
+    {
+        uint32_t npc_id = (uint32_t)(3000 + (index / BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_CAP));
+        BananaK3h4DialogueMemoryFeature feature =
+            (BananaK3h4DialogueMemoryFeature)(index % BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_CAP);
+
+        BANANA_TEST_ASSERT_INT_EQ(
+            banana_native_k3h4_dialogue_memory_upsert_delta(
+                &store,
+                npc_id,
+                feature,
+                index,
+                100),
+            0,
+            "filling capacity entries should succeed");
+    }
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_memory_count_active(&store, 101),
+        expected_capacity,
+        "active count must be capped at configured store capacity");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_memory_upsert_delta(
+            &store,
+            9999,
+            BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_TRUST_DELTA,
+            77,
+            100),
+        0,
+        "over-capacity insert should succeed by deterministic eviction");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_memory_get_delta(
+            &store,
+            3000,
+            BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_TRUST_DELTA,
+            101,
+            &delta),
+        -2,
+        "first inserted entry should be evicted first under equal-expiry pressure");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_memory_get_delta(
+            &store,
+            9999,
+            BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_TRUST_DELTA,
+            101,
+            &delta),
+        0,
+        "new entry should be retained after deterministic eviction");
+}
+
+BANANA_TEST_MAIN(
+    BANANA_TEST_CASE(test_delta_store_applies_cap_and_range_policy),
+    BANANA_TEST_CASE(test_ttl_prunes_expired_entries_deterministically),
+    BANANA_TEST_CASE(test_capacity_pressure_uses_deterministic_eviction_order))

--- a/tests/native/CMakeLists.txt
+++ b/tests/native/CMakeLists.txt
@@ -1354,6 +1354,40 @@ if(EXISTS "${BANANA_K3H4_DIALOGUE_SPECTRAL_TRANSITION_GRAPH_TEST_SOURCE}")
 	)
 endif()
 
+set(BANANA_K3H4_DIALOGUE_MEMORY_DELTA_STORE_TEST_SOURCE
+	"${BANANA_K3H4_TEST_DIR}/k3h4/k3h4_dialogue_memory_delta_store_test.c"
+)
+
+if(EXISTS "${BANANA_K3H4_DIALOGUE_MEMORY_DELTA_STORE_TEST_SOURCE}")
+	add_executable(banana_native_k3h4_dialogue_memory_delta_store_test
+		${BANANA_K3H4_DIALOGUE_MEMORY_DELTA_STORE_TEST_SOURCE}
+	)
+
+	add_test(NAME banana_native_k3h4_dialogue_memory_delta_store_test
+		COMMAND banana_native_k3h4_dialogue_memory_delta_store_test
+	)
+
+	target_link_libraries(banana_native_k3h4_dialogue_memory_delta_store_test PRIVATE banana_k3h4_core)
+	target_link_libraries(banana_native_k3h4_dialogue_memory_delta_store_test PRIVATE banana_engine_core)
+
+	if(WIN32)
+		add_custom_command(TARGET banana_native_k3h4_dialogue_memory_delta_store_test POST_BUILD
+			COMMAND ${CMAKE_COMMAND}
+				-Dbanana_runtime_dlls=$<JOIN:$<TARGET_RUNTIME_DLLS:banana_native_k3h4_dialogue_memory_delta_store_test>,|>
+				-Dbanana_target_dir=$<TARGET_FILE_DIR:banana_native_k3h4_dialogue_memory_delta_store_test>
+				-P ${CMAKE_CURRENT_LIST_DIR}/runtime/support/copy_runtime_dlls.cmake
+			COMMENT "Copying runtime DLLs next to banana_native_k3h4_dialogue_memory_delta_store_test"
+		)
+	endif()
+
+	target_include_directories(banana_native_k3h4_dialogue_memory_delta_store_test PRIVATE
+		${BANANA_ENGINE_DIR}
+		${BANANA_ENGINE_DIR}/runtime
+		${CMAKE_CURRENT_LIST_DIR}/../../src/native
+		${BANANA_K3H4_SRC_DIR}
+	)
+endif()
+
 add_executable(banana_runtime_terrain_generation_test
 	${CMAKE_CURRENT_LIST_DIR}/runtime/terrain/terrain_generation_test.c
 )


### PR DESCRIPTION
## Summary
- add bounded per-NPC dialogue memory delta store for routing features with explicit TTL and range policies
- enforce deterministic eviction under capacity pressure using expiry-first then sequence-order tie-breaks
- keep routing memory numeric/feature-based only with no transcript persistence surface in store entries
- add focused acceptance tests for cap bounds, TTL expiry behavior, and deterministic eviction order
- wire Story E source and test targets into K3H4/native CMake graphs

## Deliverable Coverage
- capped per-NPC delta store with explicit TTL/range policies
- deterministic eviction behavior under capacity pressure
- no transcript persistence in routing memory model

## Acceptance Gate
- cap and TTL tests validate bounded memory and deterministic eviction order via banana_native_k3h4_dialogue_memory_delta_store_test

## Validation
- cmake -S src/native -B out/v3-native
- cmake --build out/v3-native --config Debug --target banana_native_k3h4_dialogue_memory_delta_store_test -- -m:1
- ctest -C Debug --test-dir out/v3-native -R banana_native_k3h4_dialogue_memory_delta_store_test --output-on-failure

Depends on #1179
Closes #1180
