### PR TITLE
feat(k3h4): add native dialogue ABI envelope

### DIFF
--- a/modules/k3h4/native/CMakeLists.txt
+++ b/modules/k3h4/native/CMakeLists.txt
@@ -31,6 +31,7 @@ banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_template_layer.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_generative_surface_layer.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_spectral_transition_graph.c")
 banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_memory_delta_store.c")
+banana_k3h4_add_source_if_exists("src/k3h4/k3h4_dialogue_abi_envelope.c")
 banana_k3h4_add_source_if_exists("src/k3h4/application/k3h4_metrics_application_service.c")
 banana_k3h4_add_source_if_exists("src/k3h4/infrastructure/k3h4_metrics_infrastructure_adapter.c")
 

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_abi_envelope.c
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_abi_envelope.c
@@ -1,0 +1,189 @@
+#include "k3h4_dialogue_abi_envelope.h"
+
+#include <string.h>
+
+enum
+{
+    BANANA_K3H4_DIALOGUE_ABI_HEADER_BYTES = 20,
+};
+
+static uint32_t crc32_iso3309(const uint8_t *bytes, size_t length)
+{
+    uint32_t crc = 0xffffffffu;
+    size_t index;
+
+    for (index = 0; index < length; ++index)
+    {
+        uint32_t value = (crc ^ bytes[index]) & 0xffu;
+        int bit;
+
+        for (bit = 0; bit < 8; ++bit)
+        {
+            if ((value & 1u) != 0u)
+                value = (value >> 1) ^ 0xedb88320u;
+            else
+                value >>= 1;
+        }
+
+        crc = (crc >> 8) ^ value;
+    }
+
+    return crc ^ 0xffffffffu;
+}
+
+static uint32_t crc32_update(uint32_t crc, const uint8_t *bytes, size_t length)
+{
+    size_t index;
+
+    for (index = 0; index < length; ++index)
+    {
+        uint32_t value = (crc ^ bytes[index]) & 0xffu;
+        int bit;
+
+        for (bit = 0; bit < 8; ++bit)
+        {
+            if ((value & 1u) != 0u)
+                value = (value >> 1) ^ 0xedb88320u;
+            else
+                value >>= 1;
+        }
+
+        crc = (crc >> 8) ^ value;
+    }
+
+    return crc;
+}
+
+static uint32_t crc32_envelope_without_crc(const uint8_t *buffer, size_t payload_bytes)
+{
+    uint32_t crc = 0xffffffffu;
+
+    crc = crc32_update(crc, buffer, 16);
+    crc = crc32_update(crc, buffer + BANANA_K3H4_DIALOGUE_ABI_HEADER_BYTES, payload_bytes);
+    return crc ^ 0xffffffffu;
+}
+
+static uint32_t deterministic_hash_from_payload(const BananaK3h4DialogueSpectralTransitionOutput *payload)
+{
+    uint32_t hash = 2166136261u;
+    const uint32_t fields[] = {
+        (uint32_t)payload->graph_version,
+        (uint32_t)payload->current_state,
+        (uint32_t)payload->next_state,
+        (uint32_t)payload->candidate_count,
+        (uint32_t)payload->transition_allowed,
+        (uint32_t)payload->deny_reason,
+        (uint32_t)payload->deny_reason_code,
+    };
+    size_t index;
+
+    for (index = 0; index < sizeof(fields) / sizeof(fields[0]); ++index)
+    {
+        hash ^= fields[index];
+        hash *= 16777619u;
+    }
+
+    return hash;
+}
+
+static void write_u32_le(uint8_t *target, uint32_t value)
+{
+    target[0] = (uint8_t)(value & 0xffu);
+    target[1] = (uint8_t)((value >> 8) & 0xffu);
+    target[2] = (uint8_t)((value >> 16) & 0xffu);
+    target[3] = (uint8_t)((value >> 24) & 0xffu);
+}
+
+static uint32_t read_u32_le(const uint8_t *source)
+{
+    return (uint32_t)source[0] |
+           ((uint32_t)source[1] << 8) |
+           ((uint32_t)source[2] << 16) |
+           ((uint32_t)source[3] << 24);
+}
+
+size_t banana_native_k3h4_dialogue_abi_payload_size(void)
+{
+    return sizeof(BananaK3h4DialogueSpectralTransitionOutput);
+}
+
+int banana_native_k3h4_dialogue_abi_encode(const BananaK3h4DialogueSpectralTransitionOutput *payload,
+                                            uint8_t *out_buffer,
+                                            size_t out_buffer_size,
+                                            size_t *out_written_bytes)
+{
+    size_t payload_bytes = banana_native_k3h4_dialogue_abi_payload_size();
+    size_t required = BANANA_K3H4_DIALOGUE_ABI_HEADER_BYTES + payload_bytes;
+    uint32_t crc;
+
+    if (payload == NULL || out_buffer == NULL || out_written_bytes == NULL)
+        return BANANA_K3H4_DIALOGUE_ABI_INVALID_ARGUMENT;
+
+    if (out_buffer_size < required)
+        return BANANA_K3H4_DIALOGUE_ABI_BUFFER_TOO_SMALL;
+
+    memset(out_buffer, 0, required);
+
+    write_u32_le(out_buffer + 0, BANANA_K3H4_DIALOGUE_ABI_MAGIC);
+    write_u32_le(out_buffer + 4, BANANA_K3H4_DIALOGUE_ABI_CONTRACT_VERSION);
+    write_u32_le(out_buffer + 8, BANANA_K3H4_DIALOGUE_ABI_BYTE_ORDER_LITTLE_ENDIAN);
+    write_u32_le(out_buffer + 12, (uint32_t)payload_bytes);
+
+    memcpy(out_buffer + BANANA_K3H4_DIALOGUE_ABI_HEADER_BYTES, payload, payload_bytes);
+
+    crc = crc32_envelope_without_crc(out_buffer, payload_bytes);
+    write_u32_le(out_buffer + 16, crc);
+
+    *out_written_bytes = required;
+    return BANANA_K3H4_DIALOGUE_ABI_OK;
+}
+
+int banana_native_k3h4_dialogue_abi_decode(const uint8_t *buffer,
+                                            size_t buffer_size,
+                                            BananaK3h4DialogueAbiEnvelope *out_envelope)
+{
+    size_t payload_bytes = banana_native_k3h4_dialogue_abi_payload_size();
+    size_t required = BANANA_K3H4_DIALOGUE_ABI_HEADER_BYTES + payload_bytes;
+    BananaK3h4DialogueAbiEnvelope parsed;
+    uint32_t expected_crc;
+
+    if (buffer == NULL || out_envelope == NULL)
+        return BANANA_K3H4_DIALOGUE_ABI_INVALID_ARGUMENT;
+
+    if (buffer_size < required)
+        return BANANA_K3H4_DIALOGUE_ABI_BUFFER_TOO_SMALL;
+
+    memset(&parsed, 0, sizeof(parsed));
+
+    parsed.magic = read_u32_le(buffer + 0);
+    parsed.contract_version = read_u32_le(buffer + 4);
+    parsed.byte_order_tag = read_u32_le(buffer + 8);
+    parsed.payload_bytes = read_u32_le(buffer + 12);
+    parsed.crc32 = read_u32_le(buffer + 16);
+
+    if (parsed.magic != BANANA_K3H4_DIALOGUE_ABI_MAGIC)
+        return BANANA_K3H4_DIALOGUE_ABI_MAGIC_MISMATCH;
+
+    if (parsed.contract_version != BANANA_K3H4_DIALOGUE_ABI_CONTRACT_VERSION)
+        return BANANA_K3H4_DIALOGUE_ABI_CONTRACT_VERSION_MISMATCH;
+
+    if (parsed.byte_order_tag != BANANA_K3H4_DIALOGUE_ABI_BYTE_ORDER_LITTLE_ENDIAN)
+        return BANANA_K3H4_DIALOGUE_ABI_ENDIANNESS_MISMATCH;
+
+    if (parsed.payload_bytes != payload_bytes)
+        return BANANA_K3H4_DIALOGUE_ABI_PAYLOAD_SIZE_MISMATCH;
+
+    expected_crc = crc32_envelope_without_crc(buffer, payload_bytes);
+    if (expected_crc != parsed.crc32)
+        return BANANA_K3H4_DIALOGUE_ABI_CRC_MISMATCH;
+
+    memcpy(&parsed.payload,
+           buffer + BANANA_K3H4_DIALOGUE_ABI_HEADER_BYTES,
+           payload_bytes);
+    parsed.telemetry.payload_bytes = (int)parsed.payload_bytes;
+    parsed.telemetry.deterministic_hash = (int)deterministic_hash_from_payload(&parsed.payload);
+    parsed.telemetry.endianness_decode_path = BANANA_K3H4_DIALOGUE_ABI_DECODE_PATH_LITTLE_ENDIAN;
+
+    *out_envelope = parsed;
+    return BANANA_K3H4_DIALOGUE_ABI_OK;
+}

--- a/modules/k3h4/native/src/k3h4/k3h4_dialogue_abi_envelope.h
+++ b/modules/k3h4/native/src/k3h4/k3h4_dialogue_abi_envelope.h
@@ -1,0 +1,69 @@
+#ifndef BANANA_NATIVE_K3H4_DIALOGUE_ABI_ENVELOPE_H
+#define BANANA_NATIVE_K3H4_DIALOGUE_ABI_ENVELOPE_H
+
+#include "k3h4_dialogue_spectral_transition_graph.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    enum
+    {
+        BANANA_K3H4_DIALOGUE_ABI_MAGIC = 0x4b334834u,
+        BANANA_K3H4_DIALOGUE_ABI_CONTRACT_VERSION = 1u,
+        BANANA_K3H4_DIALOGUE_ABI_BYTE_ORDER_LITTLE_ENDIAN = 1u,
+        BANANA_K3H4_DIALOGUE_ABI_BYTE_ORDER_BYTE_SWAPPED = 2u,
+        BANANA_K3H4_DIALOGUE_ABI_DECODE_PATH_LITTLE_ENDIAN = 1u,
+        BANANA_K3H4_DIALOGUE_ABI_DECODE_PATH_BYTE_SWAPPED = 2u,
+    };
+
+    typedef enum BananaK3h4DialogueAbiStatus
+    {
+        BANANA_K3H4_DIALOGUE_ABI_OK = 0,
+        BANANA_K3H4_DIALOGUE_ABI_INVALID_ARGUMENT = -1,
+        BANANA_K3H4_DIALOGUE_ABI_BUFFER_TOO_SMALL = -2,
+        BANANA_K3H4_DIALOGUE_ABI_CONTRACT_VERSION_MISMATCH = -3001,
+        BANANA_K3H4_DIALOGUE_ABI_ENDIANNESS_MISMATCH = -3002,
+        BANANA_K3H4_DIALOGUE_ABI_PAYLOAD_SIZE_MISMATCH = -3003,
+        BANANA_K3H4_DIALOGUE_ABI_CRC_MISMATCH = -3004,
+        BANANA_K3H4_DIALOGUE_ABI_MAGIC_MISMATCH = -3005,
+    } BananaK3h4DialogueAbiStatus;
+
+    typedef struct BananaK3h4DialogueAbiTelemetry
+    {
+        int payload_bytes;
+        int deterministic_hash;
+        int endianness_decode_path;
+    } BananaK3h4DialogueAbiTelemetry;
+
+    typedef struct BananaK3h4DialogueAbiEnvelope
+    {
+        uint32_t magic;
+        uint32_t contract_version;
+        uint32_t byte_order_tag;
+        uint32_t payload_bytes;
+        uint32_t crc32;
+        BananaK3h4DialogueAbiTelemetry telemetry;
+        BananaK3h4DialogueSpectralTransitionOutput payload;
+    } BananaK3h4DialogueAbiEnvelope;
+
+    size_t banana_native_k3h4_dialogue_abi_payload_size(void);
+
+    int banana_native_k3h4_dialogue_abi_encode(const BananaK3h4DialogueSpectralTransitionOutput *payload,
+                                                uint8_t *out_buffer,
+                                                size_t out_buffer_size,
+                                                size_t *out_written_bytes);
+
+    int banana_native_k3h4_dialogue_abi_decode(const uint8_t *buffer,
+                                                size_t buffer_size,
+                                                BananaK3h4DialogueAbiEnvelope *out_envelope);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/modules/k3h4/native/tests/CMakeLists.txt
+++ b/modules/k3h4/native/tests/CMakeLists.txt
@@ -55,6 +55,11 @@ banana_k3h4_add_test_if_exists(
 )
 
 banana_k3h4_add_test_if_exists(
+  banana_k3h4_dialogue_abi_envelope_test
+  "k3h4/k3h4_dialogue_abi_envelope_test.c"
+)
+
+banana_k3h4_add_test_if_exists(
   banana_k3h4_metrics_infrastructure_adapter_test
   "k3h4/infrastructure/k3h4_metrics_infrastructure_adapter_test.c"
 )

--- a/modules/k3h4/native/tests/k3h4/k3h4_dialogue_abi_envelope_test.c
+++ b/modules/k3h4/native/tests/k3h4/k3h4_dialogue_abi_envelope_test.c
@@ -1,0 +1,131 @@
+#include "k3h4/k3h4_dialogue_abi_envelope.h"
+#include "k3h4/k3h4_dialogue_cluster_router.h"
+#include "k3h4/k3h4_dialogue_spectral_transition_graph.h"
+
+#include "runtime/support/test_support.h"
+
+#include <string.h>
+
+static int build_transition_payload(BananaK3h4DialogueSpectralTransitionOutput *out_payload)
+{
+    BananaK3h4DialogueRouteInput route_input = {
+        .intent = BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS,
+        .has_entry_writ = 1,
+        .mentions_secret_tunnel = 0,
+        .ambiguity_basis_points = 0,
+    };
+    BananaK3h4DialogueRouteOutput route_output = {0};
+    BananaK3h4DialogueSpectralTransitionInput transition_input;
+
+    if (banana_native_k3h4_route_dialogue_cluster(&route_input, &route_output) != 0)
+        return -1;
+
+    transition_input.current_state = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ENTRY_GATE;
+    transition_input.requested_state = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_REDIRECT;
+    transition_input.route_output = route_output;
+
+    return banana_native_k3h4_resolve_spectral_transition(&transition_input, out_payload);
+}
+
+static void test_roundtrip_decode_emits_telemetry_and_payload(void **state)
+{
+    BananaK3h4DialogueSpectralTransitionOutput payload = {0};
+    uint8_t buffer[512];
+    size_t written = 0;
+    BananaK3h4DialogueAbiEnvelope envelope = {0};
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(build_transition_payload(&payload),
+                              0,
+                              "transition payload build must succeed");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_abi_encode(&payload, buffer, sizeof(buffer), &written),
+        BANANA_K3H4_DIALOGUE_ABI_OK,
+        "abi encode must succeed");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_abi_decode(buffer, written, &envelope),
+        BANANA_K3H4_DIALOGUE_ABI_OK,
+        "abi decode must succeed");
+
+    BANANA_TEST_ASSERT_INT_EQ((int)envelope.contract_version,
+                              BANANA_K3H4_DIALOGUE_ABI_CONTRACT_VERSION,
+                              "decoded contract version must match");
+    BANANA_TEST_ASSERT_INT_EQ(envelope.telemetry.payload_bytes,
+                              (int)banana_native_k3h4_dialogue_abi_payload_size(),
+                              "telemetry payload bytes must match contract payload size");
+    BANANA_TEST_ASSERT_INT_EQ(envelope.telemetry.endianness_decode_path,
+                              BANANA_K3H4_DIALOGUE_ABI_DECODE_PATH_LITTLE_ENDIAN,
+                              "decode path telemetry must report little-endian path");
+    BANANA_TEST_ASSERT_INT_EQ(envelope.payload.next_state,
+                              payload.next_state,
+                              "decoded payload must preserve transition next_state");
+}
+
+static void test_mismatch_rejections_do_not_partially_mutate_output(void **state)
+{
+    BananaK3h4DialogueSpectralTransitionOutput payload = {0};
+    uint8_t buffer[512];
+    size_t written = 0;
+    BananaK3h4DialogueAbiEnvelope before;
+    BananaK3h4DialogueAbiEnvelope after;
+    int status;
+
+    (void)state;
+
+    BANANA_TEST_ASSERT_INT_EQ(build_transition_payload(&payload),
+                              0,
+                              "transition payload build must succeed");
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_k3h4_dialogue_abi_encode(&payload, buffer, sizeof(buffer), &written),
+        BANANA_K3H4_DIALOGUE_ABI_OK,
+        "abi encode must succeed");
+
+    memset(&before, 0x5a, sizeof(before));
+    after = before;
+
+    /* Version mismatch */
+    buffer[4] ^= 0x01u;
+    status = banana_native_k3h4_dialogue_abi_decode(buffer, written, &after);
+    BANANA_TEST_ASSERT_INT_EQ(status,
+                              BANANA_K3H4_DIALOGUE_ABI_CONTRACT_VERSION_MISMATCH,
+                              "version mismatch must reject payload");
+    BANANA_TEST_ASSERT_TRUE(memcmp(&before, &after, sizeof(before)) == 0,
+                            "version mismatch must not partially mutate output");
+    buffer[4] ^= 0x01u;
+
+    /* Endianness mismatch */
+    buffer[8] = 0xffu;
+    status = banana_native_k3h4_dialogue_abi_decode(buffer, written, &after);
+    BANANA_TEST_ASSERT_INT_EQ(status,
+                              BANANA_K3H4_DIALOGUE_ABI_ENDIANNESS_MISMATCH,
+                              "endianness mismatch must reject payload");
+    BANANA_TEST_ASSERT_TRUE(memcmp(&before, &after, sizeof(before)) == 0,
+                            "endianness mismatch must not partially mutate output");
+    buffer[8] = (uint8_t)BANANA_K3H4_DIALOGUE_ABI_BYTE_ORDER_LITTLE_ENDIAN;
+
+    /* Payload size mismatch */
+    buffer[12] ^= 0x01u;
+    status = banana_native_k3h4_dialogue_abi_decode(buffer, written, &after);
+    BANANA_TEST_ASSERT_INT_EQ(status,
+                              BANANA_K3H4_DIALOGUE_ABI_PAYLOAD_SIZE_MISMATCH,
+                              "size mismatch must reject payload");
+    BANANA_TEST_ASSERT_TRUE(memcmp(&before, &after, sizeof(before)) == 0,
+                            "size mismatch must not partially mutate output");
+    buffer[12] ^= 0x01u;
+
+    /* CRC mismatch */
+    buffer[20] ^= 0x01u;
+    status = banana_native_k3h4_dialogue_abi_decode(buffer, written, &after);
+    BANANA_TEST_ASSERT_INT_EQ(status,
+                              BANANA_K3H4_DIALOGUE_ABI_CRC_MISMATCH,
+                              "crc mismatch must reject payload");
+    BANANA_TEST_ASSERT_TRUE(memcmp(&before, &after, sizeof(before)) == 0,
+                            "crc mismatch must not partially mutate output");
+}
+
+BANANA_TEST_MAIN(
+    BANANA_TEST_CASE(test_roundtrip_decode_emits_telemetry_and_payload),
+    BANANA_TEST_CASE(test_mismatch_rejections_do_not_partially_mutate_output))

--- a/tests/native/CMakeLists.txt
+++ b/tests/native/CMakeLists.txt
@@ -1388,6 +1388,40 @@ if(EXISTS "${BANANA_K3H4_DIALOGUE_MEMORY_DELTA_STORE_TEST_SOURCE}")
 	)
 endif()
 
+set(BANANA_K3H4_DIALOGUE_ABI_ENVELOPE_TEST_SOURCE
+	"${BANANA_K3H4_TEST_DIR}/k3h4/k3h4_dialogue_abi_envelope_test.c"
+)
+
+if(EXISTS "${BANANA_K3H4_DIALOGUE_ABI_ENVELOPE_TEST_SOURCE}")
+	add_executable(banana_native_k3h4_dialogue_abi_envelope_test
+		${BANANA_K3H4_DIALOGUE_ABI_ENVELOPE_TEST_SOURCE}
+	)
+
+	add_test(NAME banana_native_k3h4_dialogue_abi_envelope_test
+		COMMAND banana_native_k3h4_dialogue_abi_envelope_test
+	)
+
+	target_link_libraries(banana_native_k3h4_dialogue_abi_envelope_test PRIVATE banana_k3h4_core)
+	target_link_libraries(banana_native_k3h4_dialogue_abi_envelope_test PRIVATE banana_engine_core)
+
+	if(WIN32)
+		add_custom_command(TARGET banana_native_k3h4_dialogue_abi_envelope_test POST_BUILD
+			COMMAND ${CMAKE_COMMAND}
+				-Dbanana_runtime_dlls=$<JOIN:$<TARGET_RUNTIME_DLLS:banana_native_k3h4_dialogue_abi_envelope_test>,|>
+				-Dbanana_target_dir=$<TARGET_FILE_DIR:banana_native_k3h4_dialogue_abi_envelope_test>
+				-P ${CMAKE_CURRENT_LIST_DIR}/runtime/support/copy_runtime_dlls.cmake
+			COMMENT "Copying runtime DLLs next to banana_native_k3h4_dialogue_abi_envelope_test"
+		)
+	endif()
+
+	target_include_directories(banana_native_k3h4_dialogue_abi_envelope_test PRIVATE
+		${BANANA_ENGINE_DIR}
+		${BANANA_ENGINE_DIR}/runtime
+		${CMAKE_CURRENT_LIST_DIR}/../../src/native
+		${BANANA_K3H4_SRC_DIR}
+	)
+endif()
+
 add_executable(banana_runtime_terrain_generation_test
 	${CMAKE_CURRENT_LIST_DIR}/runtime/terrain/terrain_generation_test.c
 )


### PR DESCRIPTION
## Summary
- add native dialogue ABI envelope export/decode for deterministic routing artifacts
- include versioned envelope fields for contract version, byte-order tag, payload size, and CRC32 integrity
- emit decode telemetry with deterministic hash and decode-path markers on successful decode
- enforce fail-closed decode path that rejects mismatches without partial output mutation
- add mismatch suite covering version, endianness, payload-size, and CRC rejection behavior

## Deliverable Coverage
- versioned envelope fields for contract version, byte order, payload size, CRC
- deterministic hash and decode-path telemetry
- fail-closed decode path with no partial state mutation

## Acceptance Gate
- mismatch tests reject version, endianness, size, and CRC errors while preserving preexisting output state

## Validation
- cmake -S src/native -B out/v3-native
- cmake --build out/v3-native --config Debug --target banana_native_k3h4_dialogue_abi_envelope_test -- -m:1
- ctest -C Debug --test-dir out/v3-native -R banana_native_k3h4_dialogue_abi_envelope_test --output-on-failure

Depends on #1180
Closes #1181
