### PR TITLE
feat(k3h4): harden local dialogue CLI loop

### DIFF
--- a/cli/banana/README.md
+++ b/cli/banana/README.md
@@ -6,7 +6,10 @@ Current implementation status:
 
 - command router is implemented
 - `k3h4 sample` emits deterministic canonical JSON datasets (`schema_version=1`)
+- `k3h4 dialogue-sample` emits deterministic single-turn dialogue fixture JSON (`schema_version=1`)
 - `k3h4 run` executes native-direct K3H4 pipeline via `ctypes` and canonical stdin JSON
+- `k3h4 dialogue-run` executes deterministic dialogue turn routing through native full-chain symbol binding
+- `k3h4 dialogue-export` emits machine-consumable dialogue turn artifacts in canonical JSON or CSV
 - `k3h4 explain` interprets run output with field-referenced analysis records
 - `k3h4 export` emits machine-consumable artifacts in canonical JSON or CSV
 - `k3h4 doctor` runs read-only preflight diagnostics for Python, native ABI, and schema checks
@@ -73,6 +76,82 @@ Golden run examples:
 ```bash
 python -m banana_cli k3h4 sample --seed 7 --count 2 --dims 16 --preset baseline | python -m banana_cli k3h4 run
 python -m banana_cli k3h4 run --input-file sample.json --native-lib out/v3-native/Debug/banana_native.dll
+```
+
+## Dialogue fixture generation and preflight
+
+`banana k3h4 dialogue-sample` emits canonical single-turn dialogue fixture JSON for local iteration.
+
+Flags:
+
+- `--seed` (default `42`)
+- `--preset` (`pilot-edda` or `hard-block-self-harm`)
+
+`banana k3h4 dialogue-run` validates fixture shape and executes one deterministic dialogue turn through the native full-chain symbol.
+
+Input contract:
+
+- Primary path: canonical fixture JSON from stdin (`dialogue-sample | dialogue-run`)
+- Optional path: `--input-file`
+- Required fields: `npc_id`, `quest_state_id`, `region_id`, `intent_id`, `policy_context`, `prior_memory_delta`
+- Requires `schema_version=1`
+- Validated against checked-in input schema: `cli/banana/schema/k3h4-dialogue-run-input.v1.json`
+
+Current output contract:
+
+- canonical JSON with `fixture_hash`, decision metadata, mutation flags, renderable line candidate, observability, native resolution metadata, and `status=executed`
+- Validated against checked-in output schema: `cli/banana/schema/k3h4-dialogue-run-output.v1.json`
+- Taxonomy invariants:
+	- `response_policy=hard_block` requires `deny_reason_code` in reserved range `9100..9199`, both mutation guards true, and `memory_delta_applied=0`
+	- `response_policy=safe_redirect` requires both mutation guards true and deny code outside `9100..9199`
+
+Schema override flags:
+
+- `--schema-path`: dialogue-run input schema path
+- `--output-schema-path`: dialogue-run output schema path
+
+Golden dialogue examples:
+
+```bash
+python -m banana_cli k3h4 dialogue-sample --seed 11 --preset pilot-edda \
+	| python -m banana_cli k3h4 dialogue-run --native-lib out/v3-native/Debug/banana_native.dll
+
+python -m banana_cli k3h4 dialogue-sample --seed 11 --preset hard-block-self-harm > fixture.json
+python -m banana_cli k3h4 dialogue-run --input-file fixture.json --native-lib out/v3-native/Debug/banana_native.dll
+```
+
+## Dialogue export artifacts
+
+`banana k3h4 dialogue-export` exports dialogue-run output into machine-consumable JSON or CSV.
+
+Input and strict behavior:
+
+- Primary path: dialogue-run output from stdin (`dialogue-sample | dialogue-run | dialogue-export`)
+- Optional path: `--input-file`
+- Strict mode defaults on and returns non-zero on invalid input
+- Input validated against checked-in schema: `cli/banana/schema/k3h4-dialogue-run-output.v1.json`
+- Dialogue-export also enforces dialogue-run taxonomy invariants before writing artifacts
+
+Output formats:
+
+- `--format json` (default): canonical JSON with `schema_version=1`
+- `--format csv`: single-row artifact summary
+- Export output validated against checked-in schema: `cli/banana/schema/k3h4-dialogue-export-output.v1.json`
+
+Schema override flags:
+
+- `--input-schema-path`: dialogue-export input schema path
+- `--schema-path`: dialogue-export output schema path
+
+Golden dialogue-export examples:
+
+```bash
+python -m banana_cli k3h4 dialogue-sample --seed 11 --preset pilot-edda \
+	| python -m banana_cli k3h4 dialogue-run --native-lib out/v3-native/Debug/banana_native.dll \
+	| python -m banana_cli k3h4 dialogue-export
+
+python -m banana_cli k3h4 dialogue-run --input-file fixture.json --native-lib out/v3-native/Debug/banana_native.dll \
+	| python -m banana_cli k3h4 dialogue-export --format csv --output-file artifacts/dialogue-turn.csv
 ```
 
 ## Explain interpretation
@@ -167,6 +246,20 @@ With explicit native library override:
 python -m banana_cli k3h4 doctor --native-lib out/v3-native/Debug/banana_native.dll
 ```
 
+## Dialogue taxonomy smoke script
+
+Run the local dialogue taxonomy smoke checks (standard pass, hard-block pass, fail-closed invalid deny code):
+
+```bash
+bash cli/banana/scripts/run-dialogue-taxonomy-smoke.sh
+```
+
+Optional explicit native library path:
+
+```bash
+bash cli/banana/scripts/run-dialogue-taxonomy-smoke.sh out/v3-native/Debug/banana_native.dll
+```
+
 ## Local usage (no install)
 
 From `cli/banana`:
@@ -175,7 +268,10 @@ From `cli/banana`:
 python -m banana_cli --help
 python -m banana_cli k3h4 --help
 python -m banana_cli k3h4 sample --help
+python -m banana_cli k3h4 dialogue-sample --help
 python -m banana_cli k3h4 run --help
+python -m banana_cli k3h4 dialogue-run --help
+python -m banana_cli k3h4 dialogue-export --help
 python -m banana_cli k3h4 explain --help
 python -m banana_cli k3h4 export --help
 python -m banana_cli k3h4 doctor --help

--- a/cli/banana/banana_cli/main.py
+++ b/cli/banana/banana_cli/main.py
@@ -22,12 +22,40 @@ REQUIRED_PYTHON = (3, 10)
 CANONICAL_SCHEMA_RELATIVE = Path("src/typescript/api/coverage-denominator.json")
 RUN_OUTPUT_SCHEMA_RELATIVE = Path("cli/banana/schema/k3h4-run-output.v1.json")
 EXPORT_OUTPUT_SCHEMA_RELATIVE = Path("cli/banana/schema/k3h4-export-output.v1.json")
+DIALOGUE_RUN_INPUT_SCHEMA_RELATIVE = Path("cli/banana/schema/k3h4-dialogue-run-input.v1.json")
+DIALOGUE_RUN_OUTPUT_SCHEMA_RELATIVE = Path("cli/banana/schema/k3h4-dialogue-run-output.v1.json")
+DIALOGUE_EXPORT_OUTPUT_SCHEMA_RELATIVE = Path("cli/banana/schema/k3h4-dialogue-export-output.v1.json")
 SAMPLE_SCHEMA_VERSION = 1
 EXPLAIN_SCHEMA_VERSION = 1
 EXPORT_SCHEMA_VERSION = 1
+DIALOGUE_FIXTURE_SCHEMA_VERSION = 1
+DIALOGUE_EXPORT_SCHEMA_VERSION = 1
+HARD_BLOCK_DENY_REASON_MIN = 9100
+HARD_BLOCK_DENY_REASON_MAX = 9199
 DEFAULT_SAMPLE_PRESET = "baseline"
 RUN_FLOAT_PRECISION = 6
 NATIVE_K3H4_CONTRACT_OK = 0
+DIALOGUE_RUN_SYMBOL_CANDIDATES = (
+    "banana_native_v3_k3h4_run_dialogue_turn",
+    "banana_native_v3_k3h4_dialogue_run_turn",
+    "banana_native_v3_netcode_run_k3h4_dialogue_turn",
+)
+DIALOGUE_FIXTURE_FIELDS = (
+    "npc_id",
+    "quest_state_id",
+    "region_id",
+    "intent_id",
+    "policy_context",
+    "prior_memory_delta",
+)
+DIALOGUE_SAMPLE_PRESETS = (
+    "pilot-edda",
+    "hard-block-self-harm",
+)
+DIALOGUE_EXPORT_FORMATS = (
+    "json",
+    "csv",
+)
 VECTOR_INPUT_FIELDS = (
     "call_density",
     "quest_percent",
@@ -229,6 +257,52 @@ def _build_k3h4_sample_vector(*, rng: random.Random, dims: int, preset: str) -> 
         return base
 
     return base
+
+
+def _k3h4_dialogue_sample(args: argparse.Namespace) -> int:
+    rng = random.Random(args.seed)
+    fixture = _build_dialogue_fixture(rng=rng, preset=args.preset)
+    print(json.dumps(fixture, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+def _build_dialogue_fixture(*, rng: random.Random, preset: str) -> dict[str, object]:
+    if preset == "hard-block-self-harm":
+        return {
+            "intent_id": "REQUEST_SELF_HARM_INSTRUCTIONS",
+            "npc_id": "edda_gatekeeper",
+            "policy_context": {
+                "category": "self_harm",
+                "confidence_band": "high",
+                "severity": "critical",
+            },
+            "prior_memory_delta": {
+                "rapport_delta_q16": -3277,
+                "safety_flag_count": 2,
+                "trust_bucket": 1,
+            },
+            "quest_state_id": "castle_entry_writ_pending",
+            "region_id": "south_gate",
+            "schema_version": DIALOGUE_FIXTURE_SCHEMA_VERSION,
+        }
+
+    return {
+        "intent_id": "ASK_CASTLE_ENTRY",
+        "npc_id": "edda_gatekeeper",
+        "policy_context": {
+            "category": "game_world_violence",
+            "confidence_band": "low",
+            "severity": "moderate",
+        },
+        "prior_memory_delta": {
+            "rapport_delta_q16": rng.randint(0, 4096),
+            "safety_flag_count": 0,
+            "trust_bucket": rng.randint(2, 4),
+        },
+        "quest_state_id": "castle_entry_writ_pending",
+        "region_id": "south_gate",
+        "schema_version": DIALOGUE_FIXTURE_SCHEMA_VERSION,
+    }
 
 
 def _k3h4_run(args: argparse.Namespace) -> int:
@@ -467,8 +541,976 @@ def _validate_run_input_payload(payload: dict[str, object]) -> DoctorFinding | N
     return None
 
 
+def _load_dialogue_input_payload(args: argparse.Namespace) -> tuple[dict[str, object] | None, DoctorFinding | None]:
+    raw = ""
+    if args.input_file:
+        input_path = Path(args.input_file).expanduser()
+        if not input_path.is_absolute():
+            input_path = (Path.cwd() / input_path).resolve()
+        if not input_path.exists() or not input_path.is_file():
+            return None, DoctorFinding(
+                level="error",
+                check="dialogue_run_input",
+                error_code="BANANA_DIALOGUE_RUN_INPUT_FILE_NOT_FOUND",
+                message=f"Input file not found: {input_path}",
+                field_path="input_file",
+            )
+        try:
+            raw = input_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return None, DoctorFinding(
+                level="error",
+                check="dialogue_run_input",
+                error_code="BANANA_DIALOGUE_RUN_INPUT_FILE_READ_FAILED",
+                message=f"Failed to read input file: {exc}",
+                field_path="input_file",
+            )
+    else:
+        raw = sys.stdin.read()
+
+    if raw.strip() == "":
+        return None, DoctorFinding(
+            level="error",
+            check="dialogue_run_input",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_EMPTY",
+            message="No dialogue fixture JSON was provided via stdin or --input-file.",
+            field_path="stdin",
+        )
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, DoctorFinding(
+            level="error",
+            check="dialogue_run_input",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_JSON_INVALID",
+            message=f"Input is not valid JSON: {exc}",
+            field_path="stdin",
+        )
+
+    if not isinstance(payload, dict):
+        return None, DoctorFinding(
+            level="error",
+            check="dialogue_run_input",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_SHAPE_INVALID",
+            message="Input JSON must be an object.",
+            field_path="stdin",
+        )
+
+    return payload, None
+
+
+def _validate_dialogue_input_payload(payload: dict[str, object]) -> DoctorFinding | None:
+    schema_version = payload.get("schema_version")
+    if schema_version != DIALOGUE_FIXTURE_SCHEMA_VERSION:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input",
+            error_code="BANANA_DIALOGUE_RUN_SCHEMA_VERSION_MISMATCH",
+            message=(
+                f"Expected schema_version={DIALOGUE_FIXTURE_SCHEMA_VERSION}, found {schema_version!r}."
+            ),
+            field_path="schema_version",
+        )
+
+    expected = set(DIALOGUE_FIXTURE_FIELDS)
+    keys = set(payload.keys())
+    missing = sorted(expected - keys)
+    unknown = sorted(keys - (expected | {"schema_version"}))
+    if missing:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input",
+            error_code="BANANA_DIALOGUE_RUN_FIELDS_MISSING",
+            message=f"Missing required fields: {missing}",
+            field_path="fixture",
+        )
+    if unknown:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input",
+            error_code="BANANA_DIALOGUE_RUN_FIELDS_UNKNOWN",
+            message=f"Unknown fields are not allowed in V1: {unknown}",
+            field_path="fixture",
+        )
+
+    for id_field in ("npc_id", "quest_state_id", "region_id", "intent_id"):
+        value = payload.get(id_field)
+        if not isinstance(value, str) or value.strip() == "":
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_input",
+                error_code="BANANA_DIALOGUE_RUN_ID_FIELD_INVALID",
+                message=f"Field {id_field} must be a non-empty string.",
+                field_path=id_field,
+            )
+
+    policy_context = payload.get("policy_context")
+    if not isinstance(policy_context, dict):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input",
+            error_code="BANANA_DIALOGUE_RUN_POLICY_CONTEXT_INVALID",
+            message="Field policy_context must be a JSON object.",
+            field_path="policy_context",
+        )
+
+    required_policy_keys = {"category", "confidence_band", "severity"}
+    missing_policy = sorted(required_policy_keys - set(policy_context.keys()))
+    if missing_policy:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input",
+            error_code="BANANA_DIALOGUE_RUN_POLICY_CONTEXT_FIELDS_MISSING",
+            message=f"policy_context missing required fields: {missing_policy}",
+            field_path="policy_context",
+        )
+
+    for key in required_policy_keys:
+        value = policy_context.get(key)
+        if not isinstance(value, str) or value.strip() == "":
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_input",
+                error_code="BANANA_DIALOGUE_RUN_POLICY_CONTEXT_FIELD_INVALID",
+                message=f"policy_context.{key} must be a non-empty string.",
+                field_path=f"policy_context.{key}",
+            )
+
+    prior_memory_delta = payload.get("prior_memory_delta")
+    if not isinstance(prior_memory_delta, dict):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input",
+            error_code="BANANA_DIALOGUE_RUN_MEMORY_DELTA_INVALID",
+            message="Field prior_memory_delta must be a JSON object.",
+            field_path="prior_memory_delta",
+        )
+
+    return None
+
+
+def _validate_dialogue_run_input_payload_against_schema(
+    payload: dict[str, object], schema_path: Path
+) -> DoctorFinding | None:
+    if not schema_path.exists() or not schema_path.is_file():
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input_schema",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_NOT_FOUND",
+            message=f"Dialogue run input schema file not found: {schema_path}",
+            field_path="schema.path",
+        )
+
+    try:
+        schema_payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input_schema",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_UNREADABLE",
+            message=f"Dialogue run input schema could not be parsed: {exc}",
+            field_path="schema.path",
+        )
+
+    expected_version = schema_payload.get("schema_version")
+    if expected_version != DIALOGUE_FIXTURE_SCHEMA_VERSION:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input_schema",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_VERSION_UNSUPPORTED",
+            message=f"Expected dialogue run input schema version 1, found {expected_version!r}.",
+            field_path="schema.schema_version",
+        )
+
+    required_top_level = schema_payload.get("required_top_level", [])
+    if not isinstance(required_top_level, list):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input_schema",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_INVALID",
+            message="required_top_level must be an array in dialogue run input schema.",
+            field_path="schema.required_top_level",
+        )
+
+    for key in required_top_level:
+        if key not in payload:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_input_schema",
+                error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_VALIDATION_FAILED",
+                message=f"Dialogue run input is missing required top-level key {key!r}.",
+                field_path=f"input.{key}",
+            )
+
+    required_policy_context_keys = schema_payload.get("required_policy_context_keys", [])
+    if not isinstance(required_policy_context_keys, list):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input_schema",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_INVALID",
+            message="required_policy_context_keys must be an array in dialogue run input schema.",
+            field_path="schema.required_policy_context_keys",
+        )
+
+    policy_context = payload.get("policy_context")
+    if not isinstance(policy_context, dict):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input_schema",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_VALIDATION_FAILED",
+            message="Dialogue run input policy_context must be an object.",
+            field_path="input.policy_context",
+        )
+    for key in required_policy_context_keys:
+        if key not in policy_context:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_input_schema",
+                error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_VALIDATION_FAILED",
+                message=f"policy_context is missing required key {key!r}.",
+                field_path=f"input.policy_context.{key}",
+            )
+
+    required_prior_memory_delta_keys = schema_payload.get("required_prior_memory_delta_keys", [])
+    if not isinstance(required_prior_memory_delta_keys, list):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input_schema",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_INVALID",
+            message="required_prior_memory_delta_keys must be an array in dialogue run input schema.",
+            field_path="schema.required_prior_memory_delta_keys",
+        )
+
+    prior_memory_delta = payload.get("prior_memory_delta")
+    if not isinstance(prior_memory_delta, dict):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_input_schema",
+            error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_VALIDATION_FAILED",
+            message="Dialogue run input prior_memory_delta must be an object.",
+            field_path="input.prior_memory_delta",
+        )
+    for key in required_prior_memory_delta_keys:
+        if key not in prior_memory_delta:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_input_schema",
+                error_code="BANANA_DIALOGUE_RUN_INPUT_SCHEMA_VALIDATION_FAILED",
+                message=f"prior_memory_delta is missing required key {key!r}.",
+                field_path=f"input.prior_memory_delta.{key}",
+            )
+
+    return None
+
+
+def _validate_dialogue_run_output_payload(payload: dict[str, object], schema_path: Path) -> DoctorFinding | None:
+    if not schema_path.exists() or not schema_path.is_file():
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_NOT_FOUND",
+            message=f"Dialogue run output schema file not found: {schema_path}",
+            field_path="schema.path",
+        )
+
+    try:
+        schema_payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_UNREADABLE",
+            message=f"Dialogue run output schema could not be parsed: {exc}",
+            field_path="schema.path",
+        )
+
+    expected_version = schema_payload.get("schema_version")
+    if expected_version != DIALOGUE_FIXTURE_SCHEMA_VERSION:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_VERSION_UNSUPPORTED",
+            message=f"Expected dialogue run output schema version 1, found {expected_version!r}.",
+            field_path="schema.schema_version",
+        )
+
+    required_top_level = schema_payload.get("required_top_level", [])
+    if not isinstance(required_top_level, list):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_INVALID",
+            message="required_top_level must be an array in dialogue run output schema.",
+            field_path="schema.required_top_level",
+        )
+
+    for key in required_top_level:
+        if key not in payload:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_output_schema",
+                error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_VALIDATION_FAILED",
+                message=f"Dialogue run output is missing required top-level key {key!r}.",
+                field_path=f"output.{key}",
+            )
+
+    if payload.get("schema_version") != DIALOGUE_FIXTURE_SCHEMA_VERSION:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_VALIDATION_FAILED",
+            message=(
+                f"Dialogue run output schema_version must be {DIALOGUE_FIXTURE_SCHEMA_VERSION}, "
+                f"found {payload.get('schema_version')!r}."
+            ),
+            field_path="output.schema_version",
+        )
+
+    decision_metadata = payload.get("decision_metadata")
+    if not isinstance(decision_metadata, dict):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_VALIDATION_FAILED",
+            message="decision_metadata must be an object in dialogue run output.",
+            field_path="output.decision_metadata",
+        )
+    required_decision_metadata_keys = schema_payload.get("required_decision_metadata_keys", [])
+    if not isinstance(required_decision_metadata_keys, list):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_INVALID",
+            message="required_decision_metadata_keys must be an array in dialogue run output schema.",
+            field_path="schema.required_decision_metadata_keys",
+        )
+    for key in required_decision_metadata_keys:
+        if key not in decision_metadata:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_output_schema",
+                error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_VALIDATION_FAILED",
+                message=f"decision_metadata is missing required key {key!r}.",
+                field_path=f"output.decision_metadata.{key}",
+            )
+
+    mutation_flags = payload.get("mutation_flags")
+    if not isinstance(mutation_flags, dict):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_VALIDATION_FAILED",
+            message="mutation_flags must be an object in dialogue run output.",
+            field_path="output.mutation_flags",
+        )
+    required_mutation_flags_keys = schema_payload.get("required_mutation_flags_keys", [])
+    if not isinstance(required_mutation_flags_keys, list):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_INVALID",
+            message="required_mutation_flags_keys must be an array in dialogue run output schema.",
+            field_path="schema.required_mutation_flags_keys",
+        )
+    for key in required_mutation_flags_keys:
+        if key not in mutation_flags:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_output_schema",
+                error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_VALIDATION_FAILED",
+                message=f"mutation_flags is missing required key {key!r}.",
+                field_path=f"output.mutation_flags.{key}",
+            )
+
+    observability = payload.get("observability")
+    if not isinstance(observability, dict):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_VALIDATION_FAILED",
+            message="observability must be an object in dialogue run output.",
+            field_path="output.observability",
+        )
+    required_observability_keys = schema_payload.get("required_observability_keys", [])
+    if not isinstance(required_observability_keys, list):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_INVALID",
+            message="required_observability_keys must be an array in dialogue run output schema.",
+            field_path="schema.required_observability_keys",
+        )
+    for key in required_observability_keys:
+        if key not in observability:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_output_schema",
+                error_code="BANANA_DIALOGUE_RUN_OUTPUT_SCHEMA_VALIDATION_FAILED",
+                message=f"observability is missing required key {key!r}.",
+                field_path=f"output.observability.{key}",
+            )
+
+    response_policy_label = payload.get("decision_metadata", {}).get("response_policy")
+    deny_reason_code = payload.get("decision_metadata", {}).get("deny_reason_code")
+    mutation_flags = payload.get("mutation_flags", {})
+    memory_delta_applied = payload.get("memory_delta_applied")
+
+    if not _is_int_value(deny_reason_code):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_TAXONOMY_INVALID",
+            message="decision_metadata.deny_reason_code must be an integer.",
+            field_path="output.decision_metadata.deny_reason_code",
+        )
+
+    if not isinstance(response_policy_label, str) or response_policy_label.strip() == "":
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_TAXONOMY_INVALID",
+            message="decision_metadata.response_policy must be a non-empty string.",
+            field_path="output.decision_metadata.response_policy",
+        )
+
+    state_mutation_blocked = mutation_flags.get("state_mutation_blocked")
+    memory_write_blocked = mutation_flags.get("memory_write_blocked")
+    if not isinstance(state_mutation_blocked, bool) or not isinstance(memory_write_blocked, bool):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_run_output_schema",
+            error_code="BANANA_DIALOGUE_RUN_OUTPUT_TAXONOMY_INVALID",
+            message="mutation_flags.state_mutation_blocked and mutation_flags.memory_write_blocked must be booleans.",
+            field_path="output.mutation_flags",
+        )
+
+    if response_policy_label == "hard_block":
+        if deny_reason_code < HARD_BLOCK_DENY_REASON_MIN or deny_reason_code > HARD_BLOCK_DENY_REASON_MAX:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_output_schema",
+                error_code="BANANA_DIALOGUE_RUN_OUTPUT_TAXONOMY_INVALID",
+                message=(
+                    "hard_block response policy requires deny_reason_code in reserved range "
+                    f"{HARD_BLOCK_DENY_REASON_MIN}-{HARD_BLOCK_DENY_REASON_MAX}."
+                ),
+                field_path="output.decision_metadata.deny_reason_code",
+            )
+        if state_mutation_blocked is not True or memory_write_blocked is not True:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_output_schema",
+                error_code="BANANA_DIALOGUE_RUN_OUTPUT_TAXONOMY_INVALID",
+                message="hard_block response policy requires both mutation flags to be true.",
+                field_path="output.mutation_flags",
+            )
+        if not _is_int_value(memory_delta_applied) or memory_delta_applied != 0:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_output_schema",
+                error_code="BANANA_DIALOGUE_RUN_OUTPUT_TAXONOMY_INVALID",
+                message="hard_block response policy requires memory_delta_applied to be 0.",
+                field_path="output.memory_delta_applied",
+            )
+
+    if response_policy_label == "safe_redirect":
+        if HARD_BLOCK_DENY_REASON_MIN <= deny_reason_code <= HARD_BLOCK_DENY_REASON_MAX:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_output_schema",
+                error_code="BANANA_DIALOGUE_RUN_OUTPUT_TAXONOMY_INVALID",
+                message=(
+                    "safe_redirect response policy must not use hard_block reserved deny_reason_code range "
+                    f"{HARD_BLOCK_DENY_REASON_MIN}-{HARD_BLOCK_DENY_REASON_MAX}."
+                ),
+                field_path="output.decision_metadata.deny_reason_code",
+            )
+        if state_mutation_blocked is not True or memory_write_blocked is not True:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_run_output_schema",
+                error_code="BANANA_DIALOGUE_RUN_OUTPUT_TAXONOMY_INVALID",
+                message="safe_redirect response policy requires both mutation flags to be true.",
+                field_path="output.mutation_flags",
+            )
+
+    return None
+
+
+def _validate_dialogue_export_output_payload(payload: dict[str, object], schema_path: Path) -> DoctorFinding | None:
+    if not schema_path.exists() or not schema_path.is_file():
+        return DoctorFinding(
+            level="error",
+            check="dialogue_export_output_schema",
+            error_code="BANANA_DIALOGUE_EXPORT_OUTPUT_SCHEMA_NOT_FOUND",
+            message=f"Dialogue export output schema file not found: {schema_path}",
+            field_path="schema.path",
+        )
+
+    try:
+        schema_payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_export_output_schema",
+            error_code="BANANA_DIALOGUE_EXPORT_OUTPUT_SCHEMA_UNREADABLE",
+            message=f"Dialogue export output schema could not be parsed: {exc}",
+            field_path="schema.path",
+        )
+
+    expected_version = schema_payload.get("schema_version")
+    if expected_version != DIALOGUE_EXPORT_SCHEMA_VERSION:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_export_output_schema",
+            error_code="BANANA_DIALOGUE_EXPORT_OUTPUT_SCHEMA_VERSION_UNSUPPORTED",
+            message=f"Expected dialogue export output schema version 1, found {expected_version!r}.",
+            field_path="schema.schema_version",
+        )
+
+    required_top_level = schema_payload.get("required_top_level", [])
+    if not isinstance(required_top_level, list):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_export_output_schema",
+            error_code="BANANA_DIALOGUE_EXPORT_OUTPUT_SCHEMA_INVALID",
+            message="required_top_level must be an array in dialogue export output schema.",
+            field_path="schema.required_top_level",
+        )
+
+    for key in required_top_level:
+        if key not in payload:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_export_output_schema",
+                error_code="BANANA_DIALOGUE_EXPORT_OUTPUT_SCHEMA_VALIDATION_FAILED",
+                message=f"Dialogue export output is missing required top-level key {key!r}.",
+                field_path=f"output.{key}",
+            )
+
+    if payload.get("schema_version") != DIALOGUE_EXPORT_SCHEMA_VERSION:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_export_output_schema",
+            error_code="BANANA_DIALOGUE_EXPORT_OUTPUT_SCHEMA_VALIDATION_FAILED",
+            message=(
+                f"Dialogue export output schema_version must be {DIALOGUE_EXPORT_SCHEMA_VERSION}, "
+                f"found {payload.get('schema_version')!r}."
+            ),
+            field_path="output.schema_version",
+        )
+
+    turn_record = payload.get("turn_record")
+    if not isinstance(turn_record, dict):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_export_output_schema",
+            error_code="BANANA_DIALOGUE_EXPORT_OUTPUT_SCHEMA_VALIDATION_FAILED",
+            message="turn_record must be an object in dialogue export output.",
+            field_path="output.turn_record",
+        )
+
+    required_turn_record_keys = schema_payload.get("required_turn_record_keys", [])
+    if not isinstance(required_turn_record_keys, list):
+        return DoctorFinding(
+            level="error",
+            check="dialogue_export_output_schema",
+            error_code="BANANA_DIALOGUE_EXPORT_OUTPUT_SCHEMA_INVALID",
+            message="required_turn_record_keys must be an array in dialogue export output schema.",
+            field_path="schema.required_turn_record_keys",
+        )
+
+    for key in required_turn_record_keys:
+        if key not in turn_record:
+            return DoctorFinding(
+                level="error",
+                check="dialogue_export_output_schema",
+                error_code="BANANA_DIALOGUE_EXPORT_OUTPUT_SCHEMA_VALIDATION_FAILED",
+                message=f"turn_record is missing required key {key!r}.",
+                field_path=f"output.turn_record.{key}",
+            )
+
+    return None
+
+
+def _canonical_fixture_hash(payload: dict[str, object]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _resolve_dialogue_run_symbol(native: ctypes.CDLL):
+    for symbol_name in DIALOGUE_RUN_SYMBOL_CANDIDATES:
+        symbol = getattr(native, symbol_name, None)
+        if symbol is not None:
+            return symbol_name, symbol
+    return None, None
+
+
+def _as_c_text(value: object, max_len: int) -> bytes:
+    text = str(value) if value is not None else ""
+    encoded = text.encode("utf-8", errors="ignore")
+    return encoded[: max_len - 1]
+
+
+def _decode_c_text(value: bytes) -> str:
+    return bytes(value).split(b"\x00", 1)[0].decode("utf-8", errors="ignore")
+
+
+def _build_dialogue_turn_input(payload: dict[str, object]) -> "_DialogueTurnInput":
+    policy_context = payload.get("policy_context")
+    if not isinstance(policy_context, dict):
+        policy_context = {}
+
+    prior_memory_delta = payload.get("prior_memory_delta")
+    if not isinstance(prior_memory_delta, dict):
+        prior_memory_delta = {}
+
+    dialogue_input = _DialogueTurnInput()
+    dialogue_input.npc_id = _as_c_text(payload.get("npc_id", ""), 64)
+    dialogue_input.quest_state_id = _as_c_text(payload.get("quest_state_id", ""), 64)
+    dialogue_input.region_id = _as_c_text(payload.get("region_id", ""), 64)
+    dialogue_input.intent_id = _as_c_text(payload.get("intent_id", ""), 64)
+    dialogue_input.policy_category = _as_c_text(policy_context.get("category", ""), 64)
+    dialogue_input.policy_confidence_band = _as_c_text(policy_context.get("confidence_band", ""), 16)
+    dialogue_input.policy_severity = _as_c_text(policy_context.get("severity", ""), 16)
+    dialogue_input.prior_memory_trust_delta_q16 = int(prior_memory_delta.get("rapport_delta_q16", 0))
+    dialogue_input.prior_memory_hostility_delta_q16 = int(prior_memory_delta.get("safety_flag_count", 0)) * 1024
+    dialogue_input.prior_memory_helpfulness_delta_q16 = int(prior_memory_delta.get("trust_bucket", 0)) * 1024
+    dialogue_input.sequence_tick = int(payload.get("sequence_tick", 0))
+    return dialogue_input
+
+
+def _k3h4_dialogue_run(args: argparse.Namespace) -> int:
+    payload, input_error = _load_dialogue_input_payload(args)
+    if input_error is not None:
+        if args.strict:
+            _emit_error_envelope(input_error)
+        return 1
+
+    validation_error = _validate_dialogue_input_payload(payload)
+    if validation_error is not None:
+        if args.strict:
+            _emit_error_envelope(validation_error)
+        return 1
+
+    repo_root = _resolve_repo_root(Path.cwd().resolve())
+    input_schema_path = _resolve_schema_path(args, repo_root)
+    input_schema_error = _validate_dialogue_run_input_payload_against_schema(payload, input_schema_path)
+    if input_schema_error is not None:
+        if args.strict:
+            _emit_error_envelope(input_schema_error)
+        return 1
+
+    native_path, native_source, checked_paths = _resolve_native_library(args, repo_root)
+    if native_path is None:
+        finding = DoctorFinding(
+            level="error",
+            check="dialogue_run_native_library_resolution",
+            error_code="BANANA_DIALOGUE_RUN_NATIVE_LIB_NOT_FOUND",
+            message=(
+                "Unable to resolve Banana native library via --native-lib, BANANA_NATIVE_PATH, or autodiscovery."
+                f" Checked paths: {checked_paths}."
+            ),
+            field_path="native.library",
+        )
+        if args.strict:
+            _emit_error_envelope(finding)
+        return 1
+
+    try:
+        native = ctypes.CDLL(str(native_path))
+    except OSError as exc:
+        finding = DoctorFinding(
+            level="error",
+            check="dialogue_run_native_load",
+            error_code="BANANA_DIALOGUE_RUN_NATIVE_LOAD_FAILED",
+            message=f"Failed to load native library at {native_path}: {exc}",
+            field_path="native.library",
+        )
+        if args.strict:
+            _emit_error_envelope(finding)
+        return 1
+
+    symbol_name, symbol = _resolve_dialogue_run_symbol(native)
+    if symbol_name is None:
+        finding = DoctorFinding(
+            level="error",
+            check="dialogue_run_native_binding",
+            error_code="BANANA_DIALOGUE_RUN_SYMBOL_MISSING",
+            message=(
+                "Missing dialogue full-chain symbol in native library. "
+                f"Checked candidates: {list(DIALOGUE_RUN_SYMBOL_CANDIDATES)}"
+            ),
+            field_path="native.symbols",
+        )
+        if args.strict:
+            _emit_error_envelope(finding)
+        return 1
+
+    symbol.argtypes = [ctypes.POINTER(_DialogueTurnInput), ctypes.POINTER(_DialogueTurnOutput)]
+    symbol.restype = ctypes.c_int
+
+    dialogue_input = _build_dialogue_turn_input(payload)
+    dialogue_output = _DialogueTurnOutput()
+    status = int(symbol(ctypes.byref(dialogue_input), ctypes.byref(dialogue_output)))
+    if status != 0:
+        finding = DoctorFinding(
+            level="error",
+            check="dialogue_run_native_execute",
+            error_code="BANANA_DIALOGUE_RUN_NATIVE_CONTRACT_FAILURE",
+            message=f"{symbol_name} returned non-zero status {status}.",
+            field_path="native.execution",
+        )
+        if args.strict:
+            _emit_error_envelope(finding)
+        return 1
+
+    output_payload = {
+        "decision_metadata": {
+            "boundary_state": int(dialogue_output.boundary_state),
+            "deny_reason_code": int(dialogue_output.deny_reason_code),
+            "response_policy": _decode_c_text(dialogue_output.response_policy_label),
+            "route_cluster_id": int(dialogue_output.route_cluster_id),
+            "transition_id": int(dialogue_output.transition_id),
+        },
+        "fixture_hash": _canonical_fixture_hash(payload),
+        "memory_delta_applied": int(dialogue_output.memory_delta_applied),
+        "mutation_flags": {
+            "memory_write_blocked": bool(dialogue_output.memory_write_blocked),
+            "state_mutation_blocked": bool(dialogue_output.state_mutation_blocked),
+        },
+        "native_library_path": str(native_path),
+        "native_resolution_source": native_source,
+        "native_symbol": symbol_name,
+        "npc_line_candidate": _decode_c_text(dialogue_output.npc_line_candidate),
+        "observability": {
+            "abi_contract_version": int(dialogue_output.abi_contract_version),
+            "abi_crc32": int(dialogue_output.abi_crc32),
+            "abi_decode_path": int(dialogue_output.abi_decode_path),
+            "abi_payload_bytes": int(dialogue_output.abi_payload_bytes),
+            "abi_status": int(dialogue_output.abi_status),
+            "policy_action_selected": int(dialogue_output.policy_action_selected),
+            "policy_category": payload["policy_context"]["category"],
+            "policy_confidence_band": payload["policy_context"]["confidence_band"],
+            "policy_severity": payload["policy_context"]["severity"],
+            "selected_template_key": _decode_c_text(dialogue_output.selected_template_key),
+        },
+        "schema_version": DIALOGUE_FIXTURE_SCHEMA_VERSION,
+        "status": "executed",
+    }
+
+    output_schema_path = _resolve_dialogue_run_output_schema_path(args, repo_root)
+    output_schema_error = _validate_dialogue_run_output_payload(output_payload, output_schema_path)
+    if output_schema_error is not None:
+        if args.strict:
+            _emit_error_envelope(output_schema_error)
+        return 1
+
+    print(json.dumps(output_payload, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+def _k3h4_dialogue_export(args: argparse.Namespace) -> int:
+    payload, input_error = _load_dialogue_export_input_payload(args)
+    if input_error is not None:
+        if args.strict:
+            _emit_error_envelope(input_error)
+        return 1
+
+    validation_error = _validate_dialogue_export_input_payload(payload)
+    if validation_error is not None:
+        if args.strict:
+            _emit_error_envelope(validation_error)
+        return 1
+
+    repo_root = _resolve_repo_root(Path.cwd().resolve())
+    input_schema_path = _resolve_dialogue_export_input_schema_path(args, repo_root)
+    input_schema_error = _validate_dialogue_run_output_payload(payload, input_schema_path)
+    if input_schema_error is not None:
+        if args.strict:
+            _emit_error_envelope(input_schema_error)
+        return 1
+
+    export_payload = {
+        "artifact_type": "k3h4_dialogue_turn_export",
+        "export_hash": hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest(),
+        "schema_version": DIALOGUE_EXPORT_SCHEMA_VERSION,
+        "turn_record": payload,
+    }
+
+    output_schema_path = _resolve_export_schema_path(args, repo_root)
+    output_schema_error = _validate_dialogue_export_output_payload(export_payload, output_schema_path)
+    if output_schema_error is not None:
+        if args.strict:
+            _emit_error_envelope(output_schema_error)
+        return 1
+
+    artifact_text = (
+        json.dumps(export_payload, sort_keys=True, separators=(",", ":"))
+        if args.format == "json"
+        else _build_dialogue_export_csv(export_payload)
+    )
+    return _write_or_print_artifact(artifact_text, args.output_file)
+
+
+def _load_dialogue_export_input_payload(
+    args: argparse.Namespace,
+) -> tuple[dict[str, object] | None, DoctorFinding | None]:
+    raw = ""
+    if args.input_file:
+        input_path = Path(args.input_file).expanduser()
+        if not input_path.is_absolute():
+            input_path = (Path.cwd() / input_path).resolve()
+        if not input_path.exists() or not input_path.is_file():
+            return None, DoctorFinding(
+                level="error",
+                check="dialogue_export_input",
+                error_code="BANANA_DIALOGUE_EXPORT_INPUT_FILE_NOT_FOUND",
+                message=f"Input file not found: {input_path}",
+                field_path="input_file",
+            )
+        try:
+            raw = input_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return None, DoctorFinding(
+                level="error",
+                check="dialogue_export_input",
+                error_code="BANANA_DIALOGUE_EXPORT_INPUT_FILE_READ_FAILED",
+                message=f"Failed to read input file: {exc}",
+                field_path="input_file",
+            )
+    else:
+        raw = sys.stdin.read()
+
+    if raw.strip() == "":
+        return None, DoctorFinding(
+            level="error",
+            check="dialogue_export_input",
+            error_code="BANANA_DIALOGUE_EXPORT_INPUT_EMPTY",
+            message="No dialogue-run JSON was provided via stdin or --input-file.",
+            field_path="stdin",
+        )
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, DoctorFinding(
+            level="error",
+            check="dialogue_export_input",
+            error_code="BANANA_DIALOGUE_EXPORT_INPUT_JSON_INVALID",
+            message=f"Input is not valid JSON: {exc}",
+            field_path="stdin",
+        )
+
+    if not isinstance(payload, dict):
+        return None, DoctorFinding(
+            level="error",
+            check="dialogue_export_input",
+            error_code="BANANA_DIALOGUE_EXPORT_INPUT_SHAPE_INVALID",
+            message="Input JSON must be an object.",
+            field_path="stdin",
+        )
+
+    return payload, None
+
+
+def _validate_dialogue_export_input_payload(payload: dict[str, object]) -> DoctorFinding | None:
+    schema_version = payload.get("schema_version")
+    if schema_version != DIALOGUE_FIXTURE_SCHEMA_VERSION:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_export_input",
+            error_code="BANANA_DIALOGUE_EXPORT_SCHEMA_VERSION_MISMATCH",
+            message=(
+                f"Expected dialogue run schema_version={DIALOGUE_FIXTURE_SCHEMA_VERSION}, "
+                f"found {schema_version!r}."
+            ),
+            field_path="schema_version",
+        )
+
+    required_fields = {
+        "fixture_hash",
+        "native_library_path",
+        "native_resolution_source",
+        "native_symbol",
+        "status",
+    }
+    missing = sorted(required_fields - set(payload.keys()))
+    if missing:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_export_input",
+            error_code="BANANA_DIALOGUE_EXPORT_FIELDS_MISSING",
+            message=f"Dialogue run payload missing required fields: {missing}",
+            field_path="input",
+        )
+
+    if payload.get("status") not in {"preflight_ready", "executed"}:
+        return DoctorFinding(
+            level="error",
+            check="dialogue_export_input",
+            error_code="BANANA_DIALOGUE_EXPORT_STATUS_INVALID",
+            message="Dialogue run status must be one of: preflight_ready, executed.",
+            field_path="status",
+        )
+
+    return None
+
+
+def _build_dialogue_export_csv(export_payload: dict[str, object]) -> str:
+    output = io.StringIO()
+    writer = csv.writer(output, lineterminator="\n")
+
+    turn_record = export_payload.get("turn_record")
+    if not isinstance(turn_record, dict):
+        turn_record = {}
+
+    writer.writerow(
+        [
+            "artifact_type",
+            "schema_version",
+            "fixture_hash",
+            "status",
+            "native_symbol",
+            "native_resolution_source",
+            "native_library_path",
+            "export_hash",
+        ]
+    )
+    writer.writerow(
+        [
+            export_payload.get("artifact_type", ""),
+            export_payload.get("schema_version", ""),
+            turn_record.get("fixture_hash", ""),
+            turn_record.get("status", ""),
+            turn_record.get("native_symbol", ""),
+            turn_record.get("native_resolution_source", ""),
+            turn_record.get("native_library_path", ""),
+            export_payload.get("export_hash", ""),
+        ]
+    )
+    return output.getvalue()
+
+
 def _resolve_run_output_schema_path(args: argparse.Namespace, repo_root: Path) -> Path:
     requested = Path(args.schema_path).expanduser()
+    if requested.is_absolute():
+        return requested
+    return (repo_root / requested).resolve()
+
+
+def _resolve_dialogue_run_output_schema_path(args: argparse.Namespace, repo_root: Path) -> Path:
+    requested = Path(args.output_schema_path).expanduser()
+    if requested.is_absolute():
+        return requested
+    return (repo_root / requested).resolve()
+
+
+def _resolve_dialogue_export_input_schema_path(args: argparse.Namespace, repo_root: Path) -> Path:
+    requested = Path(args.input_schema_path).expanduser()
     if requested.is_absolute():
         return requested
     return (repo_root / requested).resolve()
@@ -734,6 +1776,45 @@ class _K3h4Output(ctypes.Structure):
         ("envelope_payload_bytes", ctypes.c_int32),
         ("envelope_payload_crc32", ctypes.c_int32),
         ("contract_status", ctypes.c_int32),
+    ]
+
+
+class _DialogueTurnInput(ctypes.Structure):
+    _fields_ = [
+        ("npc_id", ctypes.c_char * 64),
+        ("quest_state_id", ctypes.c_char * 64),
+        ("region_id", ctypes.c_char * 64),
+        ("intent_id", ctypes.c_char * 64),
+        ("policy_category", ctypes.c_char * 64),
+        ("policy_confidence_band", ctypes.c_char * 16),
+        ("policy_severity", ctypes.c_char * 16),
+        ("prior_memory_trust_delta_q16", ctypes.c_int32),
+        ("prior_memory_hostility_delta_q16", ctypes.c_int32),
+        ("prior_memory_helpfulness_delta_q16", ctypes.c_int32),
+        ("sequence_tick", ctypes.c_int32),
+    ]
+
+
+class _DialogueTurnOutput(ctypes.Structure):
+    _fields_ = [
+        ("schema_version", ctypes.c_int32),
+        ("route_cluster_id", ctypes.c_int32),
+        ("boundary_state", ctypes.c_int32),
+        ("transition_id", ctypes.c_int32),
+        ("response_policy", ctypes.c_int32),
+        ("deny_reason_code", ctypes.c_int32),
+        ("state_mutation_blocked", ctypes.c_int32),
+        ("memory_write_blocked", ctypes.c_int32),
+        ("memory_delta_applied", ctypes.c_int32),
+        ("policy_action_selected", ctypes.c_int32),
+        ("abi_decode_path", ctypes.c_int32),
+        ("abi_contract_version", ctypes.c_int32),
+        ("abi_payload_bytes", ctypes.c_int32),
+        ("abi_crc32", ctypes.c_int32),
+        ("abi_status", ctypes.c_int32),
+        ("response_policy_label", ctypes.c_char * 32),
+        ("npc_line_candidate", ctypes.c_char * 160),
+        ("selected_template_key", ctypes.c_char * 64),
     ]
 
 
@@ -1630,6 +2711,25 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     add_k3h4_subcommand(
+        "dialogue-sample",
+        "Generate deterministic single-turn dialogue fixture",
+        _k3h4_dialogue_sample,
+        configure=lambda cmd: (
+            cmd.add_argument(
+                "--seed",
+                type=int,
+                default=42,
+                help="Seed for deterministic dialogue fixture generation",
+            ),
+            cmd.add_argument(
+                "--preset",
+                choices=DIALOGUE_SAMPLE_PRESETS,
+                default="pilot-edda",
+                help="Fixture preset",
+            ),
+        ),
+    )
+    add_k3h4_subcommand(
         "run",
         "Execute K3H4 pipeline via native-direct ctypes",
         _k3h4_run,
@@ -1648,6 +2748,86 @@ def build_parser() -> argparse.ArgumentParser:
                 help=(
                     "Canonical run output schema path "
                     f"(default: {RUN_OUTPUT_SCHEMA_RELATIVE})"
+                ),
+            ),
+            cmd.add_argument(
+                "--strict",
+                action=argparse.BooleanOptionalAction,
+                default=True,
+                help="Emit machine-readable JSON error envelopes on stderr when checks fail",
+            ),
+        ),
+    )
+    add_k3h4_subcommand(
+        "dialogue-run",
+        "Preflight dialogue full-chain execution contract via native symbol binding",
+        _k3h4_dialogue_run,
+        configure=lambda cmd: (
+            cmd.add_argument(
+                "--input-file",
+                help="Optional dialogue fixture JSON file path; stdin remains the primary input path",
+            ),
+            cmd.add_argument(
+                "--native-lib",
+                help="Explicit native library path; highest precedence in resolution chain",
+            ),
+            cmd.add_argument(
+                "--schema-path",
+                default=str(DIALOGUE_RUN_INPUT_SCHEMA_RELATIVE),
+                help=(
+                    "Canonical dialogue-run input schema path "
+                    f"(default: {DIALOGUE_RUN_INPUT_SCHEMA_RELATIVE})"
+                ),
+            ),
+            cmd.add_argument(
+                "--output-schema-path",
+                default=str(DIALOGUE_RUN_OUTPUT_SCHEMA_RELATIVE),
+                help=(
+                    "Canonical dialogue-run output schema path "
+                    f"(default: {DIALOGUE_RUN_OUTPUT_SCHEMA_RELATIVE})"
+                ),
+            ),
+            cmd.add_argument(
+                "--strict",
+                action=argparse.BooleanOptionalAction,
+                default=True,
+                help="Emit machine-readable JSON error envelopes on stderr when checks fail",
+            ),
+        ),
+    )
+    add_k3h4_subcommand(
+        "dialogue-export",
+        "Export machine-consumable dialogue-turn artifacts",
+        _k3h4_dialogue_export,
+        configure=lambda cmd: (
+            cmd.add_argument(
+                "--input-file",
+                help="Optional dialogue-run JSON file path; stdin remains the primary input path",
+            ),
+            cmd.add_argument(
+                "--format",
+                choices=DIALOGUE_EXPORT_FORMATS,
+                default="json",
+                help="Artifact format to emit (default: json)",
+            ),
+            cmd.add_argument(
+                "--output-file",
+                help="Optional output file path; defaults to stdout",
+            ),
+            cmd.add_argument(
+                "--input-schema-path",
+                default=str(DIALOGUE_RUN_OUTPUT_SCHEMA_RELATIVE),
+                help=(
+                    "Canonical dialogue-export input schema path "
+                    f"(default: {DIALOGUE_RUN_OUTPUT_SCHEMA_RELATIVE})"
+                ),
+            ),
+            cmd.add_argument(
+                "--schema-path",
+                default=str(DIALOGUE_EXPORT_OUTPUT_SCHEMA_RELATIVE),
+                help=(
+                    "Canonical dialogue-export output schema path "
+                    f"(default: {DIALOGUE_EXPORT_OUTPUT_SCHEMA_RELATIVE})"
                 ),
             ),
             cmd.add_argument(

--- a/cli/banana/schema/k3h4-dialogue-export-output.v1.json
+++ b/cli/banana/schema/k3h4-dialogue-export-output.v1.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "description": "Canonical output contract for banana k3h4 dialogue-export (V1)",
+  "required_top_level": [
+    "artifact_type",
+    "export_hash",
+    "schema_version",
+    "turn_record"
+  ],
+  "required_turn_record_keys": [
+    "fixture_hash",
+    "native_library_path",
+    "native_resolution_source",
+    "native_symbol",
+    "status"
+  ]
+}

--- a/cli/banana/schema/k3h4-dialogue-run-input.v1.json
+++ b/cli/banana/schema/k3h4-dialogue-run-input.v1.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "description": "Canonical input contract for banana k3h4 dialogue-run (V1)",
+  "required_top_level": [
+    "intent_id",
+    "npc_id",
+    "policy_context",
+    "prior_memory_delta",
+    "quest_state_id",
+    "region_id",
+    "schema_version"
+  ],
+  "required_policy_context_keys": [
+    "category",
+    "confidence_band",
+    "severity"
+  ],
+  "required_prior_memory_delta_keys": [
+    "rapport_delta_q16",
+    "safety_flag_count",
+    "trust_bucket"
+  ]
+}

--- a/cli/banana/schema/k3h4-dialogue-run-output.v1.json
+++ b/cli/banana/schema/k3h4-dialogue-run-output.v1.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "description": "Canonical output contract for banana k3h4 dialogue-run (V1)",
+  "required_top_level": [
+    "decision_metadata",
+    "fixture_hash",
+    "memory_delta_applied",
+    "mutation_flags",
+    "native_library_path",
+    "native_resolution_source",
+    "native_symbol",
+    "npc_line_candidate",
+    "observability",
+    "schema_version",
+    "status"
+  ],
+  "required_decision_metadata_keys": [
+    "boundary_state",
+    "deny_reason_code",
+    "response_policy",
+    "route_cluster_id",
+    "transition_id"
+  ],
+  "required_mutation_flags_keys": [
+    "memory_write_blocked",
+    "state_mutation_blocked"
+  ],
+  "required_observability_keys": [
+    "abi_contract_version",
+    "abi_crc32",
+    "abi_decode_path",
+    "abi_payload_bytes",
+    "abi_status",
+    "policy_action_selected",
+    "policy_category",
+    "policy_confidence_band",
+    "policy_severity",
+    "selected_template_key"
+  ]
+}

--- a/cli/banana/scripts/run-dialogue-taxonomy-smoke.sh
+++ b/cli/banana/scripts/run-dialogue-taxonomy-smoke.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs local dialogue taxonomy smoke checks against the native library.
+# Exits non-zero if any expected pass/fail behavior regresses.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CLI_DIR="$REPO_ROOT/cli/banana"
+NATIVE_LIB_DEFAULT="$REPO_ROOT/out/v3-native/Debug/banana_native.dll"
+NATIVE_LIB_PATH="${1:-$NATIVE_LIB_DEFAULT}"
+
+if [[ ! -f "$NATIVE_LIB_PATH" ]]; then
+  echo "error: native library not found at $NATIVE_LIB_PATH" >&2
+  exit 1
+fi
+
+if ! command -v python >/dev/null 2>&1; then
+  echo "error: python is required but not found on PATH" >&2
+  exit 1
+fi
+
+run_cmd() {
+  (cd "$CLI_DIR" && "$@")
+}
+
+# 1) Standard dialogue path should pass.
+run_cmd python -m banana_cli k3h4 dialogue-sample --seed 11 --preset pilot-edda \
+  | run_cmd python -m banana_cli k3h4 dialogue-run --native-lib "$NATIVE_LIB_PATH" \
+  | run_cmd python -m banana_cli k3h4 dialogue-export --format json \
+  >/dev/null
+
+# 2) Hard-block preset should pass with reserved deny range.
+hard_block_json="$(run_cmd python -m banana_cli k3h4 dialogue-sample --seed 11 --preset hard-block-self-harm \
+  | run_cmd python -m banana_cli k3h4 dialogue-run --native-lib "$NATIVE_LIB_PATH")"
+
+printf '%s\n' "$hard_block_json" | run_cmd python -m banana_cli k3h4 dialogue-export --format json >/dev/null
+
+HARD_BLOCK_JSON="$hard_block_json" python - <<'PY'
+import json
+import os
+import sys
+
+payload = json.loads(os.environ["HARD_BLOCK_JSON"])
+metadata = payload.get("decision_metadata", {})
+policy = metadata.get("response_policy")
+code = metadata.get("deny_reason_code")
+
+if policy != "hard_block":
+    raise SystemExit(f"expected hard_block policy, got {policy!r}")
+if not isinstance(code, int) or not (9100 <= code <= 9199):
+    raise SystemExit(f"expected hard_block deny_reason_code in 9100..9199, got {code!r}")
+PY
+
+# 3) Invalid hard-block deny code must fail closed in dialogue-export.
+set +e
+printf '%s\n' "$hard_block_json" \
+  | python -c "import json,sys; p=json.load(sys.stdin); p['decision_metadata']['deny_reason_code']=42; print(json.dumps(p,separators=(',',':')))" \
+  | run_cmd python -m banana_cli k3h4 dialogue-export --format json >/dev/null 2>/dev/null
+status=$?
+set -e
+
+if [[ $status -eq 0 ]]; then
+  echo "error: expected dialogue-export to fail on invalid hard_block deny_reason_code" >&2
+  exit 1
+fi
+
+echo "dialogue taxonomy smoke: ok"

--- a/docs/k3h4-lambda-hypersphere-notes.md
+++ b/docs/k3h4-lambda-hypersphere-notes.md
@@ -89,3 +89,33 @@ This keeps the conceptual link to manifold harmonics while preserving determinis
 - Harmonic framing: useful analogy for representation and spectral structure.
 
 Together, these are complementary views of one K3H4 system rather than separate algorithms.
+
+## 7. Concept-to-contract mapping
+
+Use this map when reviewing runtime output or ABI traces.
+
+| Concept | Runtime contract surface | Why it matters |
+|---|---|---|
+| Fixed-point convergence | `RuntimeNetcodeK3h4Observability.convergence_status`, `iteration_count` | Shows whether repeated application of the operator reached a stable state. |
+| Hypersphere separation | `RuntimeNetcodeK3h4Radius.nearest_neighbor_distance_q16`, `inscribed_radius_q16` | Captures cluster separation and local scale for robust assignment. |
+| Radius-aware assignment | `RuntimeNetcodeWeightedVoronoiScore.distance_to_center_q16`, `weighted_score_q16`, `score_validity` | Encodes normalized or power-style cluster selection behavior. |
+| Spectral structure | `RuntimeNetcodeSpectralProxy.frequency_proxy_q16`, `amplitude_proxy_q16`, `spectral_state` | Provides a compact harmonic/spectral readout tied to cluster geometry. |
+| Transport integrity | Envelope `byte_order_tag`, `payload_crc32`, observability decode path | Prevents representation mismatches from silently corrupting geometry. |
+
+Primary reference: [modules/k3h4/native/src/runtime/netcode/k3h4/netcode_k3h4_metrics.h](modules/k3h4/native/src/runtime/netcode/k3h4/netcode_k3h4_metrics.h).
+
+## 8. Local verification checklist
+
+Use this short checklist before changing K3H4 clustering or export behavior.
+
+1. Build native target and run focused K3H4 tests.
+2. Confirm output envelope fields are stable (`contract_version`, `byte_order_tag`, CRC fields).
+3. Validate radius and weighted-score arrays are populated and deterministic for identical input.
+4. Confirm observability fields are present and internally consistent (`convergence_status`, `iteration_count`, decode path).
+5. If assignment family or spectral mode changes, verify both mode enums remain backward compatible.
+
+Helpful entry points:
+
+- [src/native/include/banana_native_v3.h](src/native/include/banana_native_v3.h)
+- [src/native/scaffold/native_entry.c](src/native/scaffold/native_entry.c)
+- [tests/native/CMakeLists.txt](tests/native/CMakeLists.txt)

--- a/modules/k3h4/CONTEXT.md
+++ b/modules/k3h4/CONTEXT.md
@@ -20,12 +20,83 @@ Define the K3H4 native core as a single module boundary with one public library 
 - K3H4 core module: The isolated native K3H4 implementation at modules/k3h4/native
 - Public module boundary: The only supported include and link surface for external consumers
 - One-shot migration: A single change that moves K3H4 core code and rewires all call sites
+- Dialogue routing artifact: Deterministic routing output (cluster ids, normalized scores, boundary state, transition hints) produced by K3H4 without mutating game state
+- State authority boundary: Separation where gameplay systems own quest/world mutations while K3H4 provides routing evidence only
+- Dialogue gate precedence: Deterministic conflict resolution order for stacked dialogue clusters where higher-priority gates always win
+- Dialogue response contract: The minimum deterministic payload that validators and phrasing layers consume to produce NPC dialogue safely
+- Dialogue cluster shard scope: Deterministic cluster scope key used to route dialogue through NPC/faction/quest/region-specific cluster neighborhoods with fallback
+- Dialogue boundary state: Normalized-score classification (`core`, `edge`, `outside`) that deterministically selects response mode versus transition routing
+- Dialogue fail-closed fallback: Deterministic deny response mode used when all candidate transitions are blocked by safety/canon gates
+- Dialogue memory delta: Bounded, quantized per-NPC state effects (not transcript text) used as routing features for subsequent dialogue turns
+- Dialogue routing envelope: Versioned ABI payload contract for dialogue cluster assignments with byte-order and integrity guards
+- Dialogue turn fixture: Minimal deterministic single-turn input bundle (`npc identity`, `quest state`, `intent`, `policy context`) used to exercise dialogue routing end-to-end
+- Dialogue generative loop: Deterministic local processing chain (`route -> template -> generative surface validation -> transition -> memory delta -> ABI envelope`) used for iteration and evidence capture
+- Dialogue canonical turn record: Stable JSON output for one dialogue turn containing routing decision metadata plus a renderable NPC line candidate
+- Dialogue hard-block mutation guard: Fail-closed policy override contract that emits deterministic fallback responses and blocks all state mutation when hard-block triggers
+- Dialogue CLI command family: K3H4-scoped CLI surface where dialogue iteration commands live under `banana k3h4` rather than a separate top-level namespace
+- Dialogue native full-chain entrypoint: Single native ABI call that executes the full deterministic dialogue chain for one turn fixture, with Python acting as transport/validation only
+- Dialogue fixture schema: Canonical JSON turn-fixture contract (`schema_version=1`) accepted via stdin or explicit input file for deterministic local replay
+- Dialogue fixture authority fields: Minimal turn-fixture field set (`npc_id`, `quest_state_id`, `region_id`, `intent_id`, structured `policy_context`, bounded `prior_memory_delta`) required for dialogue-run execution
+- Dialogue turn output contract: Canonical single-turn JSON record containing fixture hash, routing/transition decision metadata, mutation guard flags, bounded memory summary, renderable line candidate, and observability metadata
+- Dialogue fixture hash: Deterministic digest of canonicalized turn-fixture input used to prove byte-identical replay behavior
+- Dialogue mutation guard flags: Required output booleans (`state_mutation_blocked`, `memory_write_blocked`) that expose hard-block and safe-redirect mutation protection outcomes
+- Dialogue deterministic fallback set: Small authored fallback response set keyed by `policy category` and `npc_id`, with stable fixture-hash selection for replay-safe non-generic refusals/redirects
+- Dialogue canonical local loop: Standard contributor workflow (`dialogue-sample -> dialogue-run --strict -> dialogue-export -> replay parity check -> hard-block guard check`) for local generative iteration
+- Dialogue reason-code taxonomy: Deterministic meaning split where `hard_block` uses a reserved deny-code range and `safe_redirect` must remain outside that range
+- Dialogue taxonomy smoke script: One-command local regression check that exercises normal-pass, hard-block-pass, and fail-closed invalid-artifact scenarios against the native library
+- Dialogue phase gate: Story-level deterministic acceptance gate that must pass before advancing to the next dialogue runtime phase
+- Dialogue pilot slice: First constrained NPC/quest/region deployment used to prove deterministic routing before broad rollout
+- Policy classification authority: Hard precedence rule where content protection decisions can override normal dialogue routing
+- Response shaping: Severity-tiered policy behavior that selects allow, boundary pushback, refusal, or fail-closed fallback without relying on a giant banned-term list
+- Extreme policy category: High-risk class (`minor_safety`, `self_harm`, `real_world_violence`, `hate_or_slur_severe`) that always triggers hard-block fail-closed handling
+- Policy confidence boundary zone: Deterministic threshold band that uses neutral safe-redirect behavior for ambiguous high-risk classifications before escalating to hard-block
+- Policy mutation guardrail: Requirement that policy override paths cannot mutate quest state, routing memory, relationship state, or world/faction state
+- Violence domain split: Canonical distinction between fictional game-world violence and real-world violence for policy routing and severity evaluation
+- Prompt-attack policy cluster: High-priority policy family for jailbreak, instruction override, and hidden-rule extraction attempts that must not be treated as normal dialogue intent
+- Output policy validation: Reuse of the same policy cluster taxonomy on generated NPC lines to detect unsafe amplification, leakage, or canon-breaking output before emission
+- Lexical fast path: Small curated extreme-case hint layer that accelerates obvious detections but does not own canonical policy decisions
+- Policy override observability: Deterministic event metadata emitted for non-allow policy decisions so safety gates are auditable and regression-testable
+- Extreme-edge acceptance pack: Fixed set of high-risk and control scenarios used as hard gating evidence for policy override correctness
 
 ## Core invariants
 
 - Consumers link through one target: banana_k3h4_core
 - Consumers use only module-prefixed public includes
 - Module internals are not directly included by external code
+- Dialogue routing remains read-only with respect to quest/world state; K3H4 does not directly mutate gameplay state
+- Dialogue gate resolution is deterministic and short-circuited in this order: safety/canon, quest state, NPC/world legality, intent, personality/emotion, lore/style
+- Dialogue response contracts always include identity, selected-cluster stack, gate decision, fact allow/forbid sets, state transition id, response policy, and determinism hashes/versioning fields before any generator phrasing step
+- Dialogue routing resolves cluster scope through deterministic fallback (NPC+quest+region -> faction+quest+region -> faction+region -> global archetype) and records the selected scope in the response contract
+- Dialogue boundary thresholds are deterministic (`core <= 0.85`, `edge 0.85..1.15`, `outside > 1.15`) with fixed tie-break ordering and required boundary-state emission in response contracts
+- Denied transitions resolve via deterministic authored fallback templates (no new facts, no state mutation) and always emit fallback metadata plus deny reason codes in response contracts
+- Dialogue memory persists only capped delta fields with explicit TTL/range policies, a fixed entry budget per NPC, deterministic eviction, and no raw transcript persistence in routing memory
+- Dialogue routing decode is fail-closed: version/byte-order/size/CRC mismatch rejects the payload, and no partial decode may mutate runtime state
+- Dialogue roadmap delivery is phase-gated (routing, templates, generative surface, spectral transitions, bounded memory, ABI/export) with deterministic replay/safety checks required at each phase boundary
+- Dialogue local loop accepts only deterministic fixtures and must emit byte-identical canonical turn records for identical inputs
+- Dialogue hard-block handling is acceptance-gated to fail-closed deterministic fallback behavior with no quest/world/memory mutation
+- Dialogue local iteration commands are grouped under the K3H4 CLI namespace to preserve one operator path for native execution, diagnostics, and artifact export
+- Dialogue CLI execution uses one native full-chain entrypoint as the sole stage-order authority; Python orchestration cannot reorder or partially execute dialogue phases
+- Dialogue local replay input authority is canonical JSON (`schema_version=1`) with deterministic parsing from stdin or `--input-file`
+- Dialogue fixture policy input is structured categorical context with confidence hints; free-text policy directives are not authoritative fixture input
+- Dialogue local loop output authority is one canonical turn record that includes decision metadata (`route_cluster_id`, `boundary_state`, `transition_id`, `response_policy`, `deny_reason_code`) plus observability metadata (`policy_category`, `severity`, `confidence_band`, `action_selected`, `decode_path`, `abi_version`)
+- Dialogue output always includes a renderable `npc_line_candidate`; hard-block and fail-closed paths must emit deterministic fallback text rather than partial generated output
+- Dialogue hard-block and confidence-boundary responses must use deterministic fallback-set selection keyed by `policy category` and `npc_id`, with `fixture_hash` as the stable selector
+- Dialogue local workflow is fixed to `banana k3h4` command family and includes deterministic replay validation plus hard-block mutation-guard assertions as required acceptance evidence
+- Dialogue local workflow includes a one-command smoke gate (`bash cli/banana/scripts/run-dialogue-taxonomy-smoke.sh`) as the minimum end-to-end taxonomy validation pass before broader iteration
+- First pilot slice is fixed to one NPC, one quest-state flow, one region, and a bounded intent/safety set to minimize scope risk while proving deterministic routing and fallback behavior
+- Policy classification authority is above dialogue routing; `hard_block` always fail-closes to deterministic fallback behavior and bypasses free-form generation
+- Severity tiers govern response shaping: lower tiers may allow in-character boundary responses, while severe tiers refuse or fail-closed with deterministic safety metadata
+- Hard-block routing is reserved for extreme policy categories; profanity classes remain dialogue-relevant tone signals unless they escalate to targeted harassment
+- Policy confidence thresholds are deterministic: high confidence (`>=0.85`) hard-block fail-closed, boundary confidence (`0.65..0.85`) safe-redirect without unsafe continuation, lower confidence continues constrained dialogue with output validation
+- Safe-redirect and hard-block both enforce block-state-mutation and block-memory-write semantics; they differ only in deterministic response form
+- `hard_block` output taxonomy is deterministic: `deny_reason_code` must remain in reserved range `9100..9199`, both mutation-block flags must be true, and `memory_delta_applied` must be `0`
+- `safe_redirect` output taxonomy is deterministic: it must never use deny codes in reserved hard-block range `9100..9199`, while still enforcing both mutation-block flags
+- Game-world violence and real-world violence are separate policy clusters; real-world violence may policy-override into redirect or hard-block, while game-world violence remains dialogue-legal when contextualized as fictional combat
+- Prompt-attack policy handling never exposes hidden prompts, policy internals, or routing metadata; it either ignores the malicious instruction and continues safely or refuses deterministically outside the normal intent path
+- Input and output policy validation share one canonical cluster taxonomy; unsafe generated output never self-repairs recursively and instead degrades to a boring deterministic fallback under the same mutation guardrails
+- Lexical hints can short-circuit obvious extreme cases and feed classifier features, but semantic policy clusters remain the canonical policy authority over long-term behavior
+- Every policy override emits stable machine-readable metadata (category, severity, confidence band, selected action, deny reason code, mutation-block flags) for acceptance evidence and deterministic auditability
+- The extreme-edge acceptance pack is a hard gate with deterministic outcomes across six canonical scenarios: `minor_safety`, `self_harm`, `real_world_violence_targeted`, `hate_or_slur_severe`, `jailbreak_or_prompt_attack`, and `game_world_violence` control behavior
 
 ## Key seams
 

--- a/modules/k3h4/native/tests/k3h4/k3h4_dialogue_native_entry_turn_test.c
+++ b/modules/k3h4/native/tests/k3h4/k3h4_dialogue_native_entry_turn_test.c
@@ -1,0 +1,288 @@
+#include "banana_native_v3.h"
+
+#include "runtime/support/test_support.h"
+
+#include <string.h>
+
+static void fill_turn_input(
+    banana_native_v3_k3h4_dialogue_turn_input *out_input,
+    const char *intent_id,
+    const char *policy_category,
+    const char *confidence_band,
+    const char *severity)
+{
+    memset(out_input, 0, sizeof(*out_input));
+
+    strncpy(out_input->npc_id, "edda_gatekeeper", sizeof(out_input->npc_id) - 1);
+    strncpy(out_input->quest_state_id, "castle_entry_writ_pending", sizeof(out_input->quest_state_id) - 1);
+    strncpy(out_input->region_id, "south_gate", sizeof(out_input->region_id) - 1);
+    strncpy(out_input->intent_id, intent_id, sizeof(out_input->intent_id) - 1);
+
+    strncpy(out_input->policy_category, policy_category, sizeof(out_input->policy_category) - 1);
+    strncpy(out_input->policy_confidence_band, confidence_band, sizeof(out_input->policy_confidence_band) - 1);
+    strncpy(out_input->policy_severity, severity, sizeof(out_input->policy_severity) - 1);
+
+    out_input->prior_memory_trust_delta_q16 = 2048;
+    out_input->prior_memory_hostility_delta_q16 = 0;
+    out_input->prior_memory_helpfulness_delta_q16 = 1024;
+    out_input->sequence_tick = 11;
+}
+
+static void test_dialogue_turn_executes_and_emits_contract(void **state)
+{
+    banana_native_v3_k3h4_dialogue_turn_input input;
+    banana_native_v3_k3h4_dialogue_turn_output output;
+    int status;
+
+    (void)state;
+
+    fill_turn_input(
+        &input,
+        "ASK_CASTLE_ENTRY",
+        "game_world_violence",
+        "low",
+        "moderate");
+    memset(&output, 0, sizeof(output));
+
+    status = banana_native_v3_k3h4_run_dialogue_turn(&input, &output);
+
+    BANANA_TEST_ASSERT_INT_EQ(status, BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK, "dialogue turn should execute");
+    BANANA_TEST_ASSERT_INT_EQ(output.schema_version, 1, "schema version should be 1");
+    BANANA_TEST_ASSERT_INT_EQ(output.abi_status, 0, "ABI status should report success");
+    BANANA_TEST_ASSERT_INT_EQ(output.abi_contract_version, 1, "ABI contract version should be 1");
+    BANANA_TEST_ASSERT_TRUE(output.route_cluster_id > 0, "route cluster id should be populated");
+    BANANA_TEST_ASSERT_TRUE(output.transition_id > 0, "transition id should be populated");
+    BANANA_TEST_ASSERT_TRUE(strlen(output.npc_line_candidate) > 0, "npc line candidate should be emitted");
+    BANANA_TEST_ASSERT_TRUE(strlen(output.response_policy_label) > 0, "response policy label should be emitted");
+}
+
+static void test_dialogue_turn_is_deterministic_for_identical_inputs(void **state)
+{
+    banana_native_v3_k3h4_dialogue_turn_input input;
+    banana_native_v3_k3h4_dialogue_turn_output output_a;
+    banana_native_v3_k3h4_dialogue_turn_output output_b;
+
+    (void)state;
+
+    fill_turn_input(
+        &input,
+        "ASK_DIRECTIONS",
+        "game_world_violence",
+        "low",
+        "moderate");
+
+    memset(&output_a, 0, sizeof(output_a));
+    memset(&output_b, 0, sizeof(output_b));
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_v3_k3h4_run_dialogue_turn(&input, &output_a),
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK,
+        "first deterministic run should succeed");
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_v3_k3h4_run_dialogue_turn(&input, &output_b),
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK,
+        "second deterministic run should succeed");
+
+    BANANA_TEST_ASSERT_TRUE(
+        memcmp(&output_a, &output_b, sizeof(output_a)) == 0,
+        "identical input should produce byte-identical output");
+}
+
+static void test_dialogue_turn_hard_block_sets_mutation_guards(void **state)
+{
+    banana_native_v3_k3h4_dialogue_turn_input input;
+    banana_native_v3_k3h4_dialogue_turn_output output;
+
+    (void)state;
+
+    fill_turn_input(
+        &input,
+        "REQUEST_SELF_HARM_INSTRUCTIONS",
+        "self_harm",
+        "high",
+        "critical");
+    memset(&output, 0, sizeof(output));
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_v3_k3h4_run_dialogue_turn(&input, &output),
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK,
+        "hard-block run should still return deterministic success envelope");
+
+    BANANA_TEST_ASSERT_STR_EQ(output.response_policy_label, "hard_block", "hard-block label should be emitted");
+    BANANA_TEST_ASSERT_INT_EQ(output.state_mutation_blocked, 1, "hard-block should set state mutation guard");
+    BANANA_TEST_ASSERT_INT_EQ(output.memory_write_blocked, 1, "hard-block should set memory write guard");
+    BANANA_TEST_ASSERT_INT_EQ(output.memory_delta_applied, 0, "hard-block should prevent memory delta write");
+    BANANA_TEST_ASSERT_TRUE(strlen(output.npc_line_candidate) > 0, "hard-block should emit deterministic fallback line");
+}
+
+static void test_dialogue_turn_boundary_confidence_maps_to_safe_redirect(void **state)
+{
+    banana_native_v3_k3h4_dialogue_turn_input input;
+    banana_native_v3_k3h4_dialogue_turn_output output;
+
+    (void)state;
+
+    fill_turn_input(
+        &input,
+        "REQUEST_SELF_HARM_INSTRUCTIONS",
+        "self_harm",
+        "boundary",
+        "critical");
+    memset(&output, 0, sizeof(output));
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_v3_k3h4_run_dialogue_turn(&input, &output),
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK,
+        "boundary confidence run should succeed");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        output.policy_action_selected,
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_SAFE_REDIRECT,
+        "boundary confidence hard-block category should map to safe redirect");
+    BANANA_TEST_ASSERT_STR_EQ(output.response_policy_label, "safe_redirect", "safe-redirect label should be emitted");
+    BANANA_TEST_ASSERT_INT_EQ(output.state_mutation_blocked, 1, "safe-redirect should set state mutation guard");
+    BANANA_TEST_ASSERT_INT_EQ(output.memory_write_blocked, 1, "safe-redirect should set memory write guard");
+    BANANA_TEST_ASSERT_INT_EQ(output.memory_delta_applied, 0, "safe-redirect should prevent memory delta write");
+}
+
+static void test_dialogue_turn_jailbreak_category_maps_to_safe_redirect(void **state)
+{
+    banana_native_v3_k3h4_dialogue_turn_input input;
+    banana_native_v3_k3h4_dialogue_turn_output output;
+
+    (void)state;
+
+    fill_turn_input(
+        &input,
+        "ASK_DIRECTIONS",
+        "jailbreak_or_prompt_attack",
+        "low",
+        "moderate");
+    memset(&output, 0, sizeof(output));
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_v3_k3h4_run_dialogue_turn(&input, &output),
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK,
+        "jailbreak category run should succeed");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        output.policy_action_selected,
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_SAFE_REDIRECT,
+        "jailbreak category should map to safe redirect regardless of confidence");
+    BANANA_TEST_ASSERT_STR_EQ(output.response_policy_label, "safe_redirect", "safe-redirect label should be emitted");
+    BANANA_TEST_ASSERT_INT_EQ(output.state_mutation_blocked, 1, "safe-redirect should set state mutation guard");
+    BANANA_TEST_ASSERT_INT_EQ(output.memory_write_blocked, 1, "safe-redirect should set memory write guard");
+}
+
+static void test_dialogue_turn_hard_block_category_low_confidence_allows(void **state)
+{
+    banana_native_v3_k3h4_dialogue_turn_input input;
+    banana_native_v3_k3h4_dialogue_turn_output output;
+
+    (void)state;
+
+    fill_turn_input(
+        &input,
+        "ASK_CASTLE_ENTRY",
+        "self_harm",
+        "low",
+        "critical");
+    memset(&output, 0, sizeof(output));
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_v3_k3h4_run_dialogue_turn(&input, &output),
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK,
+        "low confidence hard-block category run should succeed");
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        output.policy_action_selected,
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_ALLOW,
+        "low confidence hard-block category should map to allow");
+    BANANA_TEST_ASSERT_INT_EQ(output.state_mutation_blocked, 0, "allow branch should not block state mutation");
+    BANANA_TEST_ASSERT_INT_EQ(output.memory_write_blocked, 0, "allow branch should not block memory write");
+    BANANA_TEST_ASSERT_TRUE(
+        strcmp(output.response_policy_label, "hard_block") != 0 && strcmp(output.response_policy_label, "safe_redirect") != 0,
+        "allow branch should not emit hard-block or safe-redirect label");
+}
+
+static void test_dialogue_turn_hard_block_uses_reserved_reason_code_range(void **state)
+{
+    banana_native_v3_k3h4_dialogue_turn_input input_a;
+    banana_native_v3_k3h4_dialogue_turn_input input_b;
+    banana_native_v3_k3h4_dialogue_turn_output output_a;
+    banana_native_v3_k3h4_dialogue_turn_output output_b;
+
+    (void)state;
+
+    fill_turn_input(
+        &input_a,
+        "REQUEST_SELF_HARM_INSTRUCTIONS",
+        "self_harm",
+        "high",
+        "critical");
+    fill_turn_input(
+        &input_b,
+        "ASK_DIRECTIONS",
+        "self_harm",
+        "high",
+        "critical");
+    memset(&output_a, 0, sizeof(output_a));
+    memset(&output_b, 0, sizeof(output_b));
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_v3_k3h4_run_dialogue_turn(&input_a, &output_a),
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK,
+        "hard-block run A should succeed");
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_v3_k3h4_run_dialogue_turn(&input_b, &output_b),
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK,
+        "hard-block run B should succeed");
+
+    BANANA_TEST_ASSERT_STR_EQ(output_a.response_policy_label, "hard_block", "hard-block label should be emitted");
+    BANANA_TEST_ASSERT_TRUE(
+        output_a.deny_reason_code >= 9100 && output_a.deny_reason_code <= 9199,
+        "hard-block deny reason code should be in reserved 9100-9199 range");
+    BANANA_TEST_ASSERT_TRUE(
+        output_b.deny_reason_code >= 9100 && output_b.deny_reason_code <= 9199,
+        "hard-block deny reason code should be in reserved 9100-9199 range for repeated category");
+    BANANA_TEST_ASSERT_INT_EQ(
+        output_a.deny_reason_code,
+        output_b.deny_reason_code,
+        "hard-block deny reason code should be category-stable regardless of intent for same category");
+}
+
+static void test_dialogue_turn_safe_redirect_does_not_use_reserved_hard_block_range(void **state)
+{
+    banana_native_v3_k3h4_dialogue_turn_input input;
+    banana_native_v3_k3h4_dialogue_turn_output output;
+
+    (void)state;
+
+    fill_turn_input(
+        &input,
+        "REQUEST_SELF_HARM_INSTRUCTIONS",
+        "self_harm",
+        "boundary",
+        "critical");
+    memset(&output, 0, sizeof(output));
+
+    BANANA_TEST_ASSERT_INT_EQ(
+        banana_native_v3_k3h4_run_dialogue_turn(&input, &output),
+        BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK,
+        "safe-redirect boundary run should succeed");
+
+    BANANA_TEST_ASSERT_STR_EQ(output.response_policy_label, "safe_redirect", "safe-redirect label should be emitted");
+    BANANA_TEST_ASSERT_TRUE(
+        output.deny_reason_code < 9100 || output.deny_reason_code > 9199,
+        "safe-redirect deny reason code should not collide with hard-block reserved range");
+}
+
+BANANA_TEST_MAIN(
+    BANANA_TEST_CASE(test_dialogue_turn_executes_and_emits_contract),
+    BANANA_TEST_CASE(test_dialogue_turn_is_deterministic_for_identical_inputs),
+    BANANA_TEST_CASE(test_dialogue_turn_hard_block_sets_mutation_guards),
+    BANANA_TEST_CASE(test_dialogue_turn_boundary_confidence_maps_to_safe_redirect),
+    BANANA_TEST_CASE(test_dialogue_turn_jailbreak_category_maps_to_safe_redirect),
+    BANANA_TEST_CASE(test_dialogue_turn_hard_block_category_low_confidence_allows),
+    BANANA_TEST_CASE(test_dialogue_turn_hard_block_uses_reserved_reason_code_range),
+    BANANA_TEST_CASE(test_dialogue_turn_safe_redirect_does_not_use_reserved_hard_block_range))

--- a/src/native/include/banana_native_v3.h
+++ b/src/native/include/banana_native_v3.h
@@ -259,6 +259,53 @@ typedef struct banana_native_v3_netcode_contract_envelope_header {
 	int32_t payload_crc32;
 } banana_native_v3_netcode_contract_envelope_header;
 
+typedef enum banana_native_v3_k3h4_dialogue_policy_action {
+	BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_ALLOW = 0,
+	BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_SAFE_REDIRECT = 1,
+	BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_HARD_BLOCK = 2,
+} banana_native_v3_k3h4_dialogue_policy_action;
+
+typedef enum banana_native_v3_k3h4_dialogue_turn_status {
+	BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK = 0,
+	BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_INVALID_ARGUMENT = -4001,
+	BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_EXECUTION_FAILED = -4002,
+} banana_native_v3_k3h4_dialogue_turn_status;
+
+typedef struct banana_native_v3_k3h4_dialogue_turn_input {
+	char npc_id[64];
+	char quest_state_id[64];
+	char region_id[64];
+	char intent_id[64];
+	char policy_category[64];
+	char policy_confidence_band[16];
+	char policy_severity[16];
+	int32_t prior_memory_trust_delta_q16;
+	int32_t prior_memory_hostility_delta_q16;
+	int32_t prior_memory_helpfulness_delta_q16;
+	int32_t sequence_tick;
+} banana_native_v3_k3h4_dialogue_turn_input;
+
+typedef struct banana_native_v3_k3h4_dialogue_turn_output {
+	int32_t schema_version;
+	int32_t route_cluster_id;
+	int32_t boundary_state;
+	int32_t transition_id;
+	int32_t response_policy;
+	int32_t deny_reason_code;
+	int32_t state_mutation_blocked;
+	int32_t memory_write_blocked;
+	int32_t memory_delta_applied;
+	int32_t policy_action_selected;
+	int32_t abi_decode_path;
+	int32_t abi_contract_version;
+	int32_t abi_payload_bytes;
+	int32_t abi_crc32;
+	int32_t abi_status;
+	char response_policy_label[32];
+	char npc_line_candidate[160];
+	char selected_template_key[64];
+} banana_native_v3_k3h4_dialogue_turn_output;
+
 BANANA_NATIVE_V3_EXPORT int banana_native_v3_abi_version(void);
 BANANA_NATIVE_V3_EXPORT int banana_native_v3_ping(void);
 BANANA_NATIVE_V3_EXPORT int banana_native_v3_pgbouncer_available(void);
@@ -288,6 +335,9 @@ BANANA_NATIVE_V3_EXPORT int banana_native_v3_netcode_build_vector(const banana_n
 						   banana_native_v3_netcode_vector_output *out_output);
 BANANA_NATIVE_V3_EXPORT int banana_native_v3_netcode_build_k3h4(const banana_native_v3_netcode_vector_input *signal_input,
 							banana_native_v3_netcode_k3h4_output *out_output);
+BANANA_NATIVE_V3_EXPORT int banana_native_v3_k3h4_run_dialogue_turn(
+	const banana_native_v3_k3h4_dialogue_turn_input *turn_input,
+	banana_native_v3_k3h4_dialogue_turn_output *out_output);
 BANANA_NATIVE_V3_EXPORT int banana_native_v3_launch_gate_policy_resolve(const char *mode_label,
 												 banana_launch_gate_policy *out_policy);
 BANANA_NATIVE_V3_EXPORT int banana_native_v3_launch_gate_decide(const char *mode_label,

--- a/src/native/scaffold/native_entry.c
+++ b/src/native/scaffold/native_entry.c
@@ -1,4 +1,10 @@
 #include "banana_native_v3.h"
+#include "k3h4/k3h4_dialogue_abi_envelope.h"
+#include "k3h4/k3h4_dialogue_cluster_router.h"
+#include "k3h4/k3h4_dialogue_generative_surface_layer.h"
+#include "k3h4/k3h4_dialogue_memory_delta_store.h"
+#include "k3h4/k3h4_dialogue_spectral_transition_graph.h"
+#include "k3h4/k3h4_dialogue_template_layer.h"
 #include "k3h4/k3h4_metrics_orchestration_layer.h"
 #include "k3h4/k3h4_native_orchestrator.h"
 #include "runtime/engine/engine_aux_abi.h"
@@ -15,6 +21,221 @@ static char s_pgbouncer_connection_uri[512];
 static char s_pgbouncer_pool_mode[32] = "transaction";
 static int s_pgbouncer_default_pool_size = 20;
 static int s_world_initialized = 0;
+static BananaK3h4DialogueMemoryStore s_dialogue_memory_store;
+static int s_dialogue_memory_initialized = 0;
+
+static void copy_text(char *target, size_t target_size, const char *source)
+{
+	if (!target || target_size == 0)
+		return;
+
+	if (!source)
+	{
+		target[0] = '\0';
+		return;
+	}
+
+	strncpy(target, source, target_size - 1);
+	target[target_size - 1] = '\0';
+}
+
+static uint32_t hash_text_seed(uint32_t seed, const char *text)
+{
+	uint32_t hash = seed;
+	const unsigned char *cursor = (const unsigned char *)text;
+
+	if (!cursor)
+		return hash;
+
+	while (*cursor)
+	{
+		hash ^= (uint32_t)(*cursor);
+		hash *= 16777619u;
+		cursor += 1;
+	}
+
+	return hash;
+}
+
+static uint32_t hash_text(const char *text)
+{
+	return hash_text_seed(2166136261u, text);
+}
+
+static int text_contains(const char *text, const char *token)
+{
+	if (!text || !token || token[0] == '\0')
+		return 0;
+	return strstr(text, token) != NULL;
+}
+
+static BananaK3h4DialogueIntent parse_dialogue_intent(const char *intent_id)
+{
+	if (!intent_id)
+		return BANANA_K3H4_DIALOGUE_INTENT_UNKNOWN;
+
+	if (strcmp(intent_id, "ASK_CASTLE_ENTRY") == 0)
+		return BANANA_K3H4_DIALOGUE_INTENT_ASK_CASTLE_ENTRY;
+	if (strcmp(intent_id, "ASK_DIRECTIONS") == 0)
+		return BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS;
+	if (strcmp(intent_id, "INSULT") == 0)
+		return BANANA_K3H4_DIALOGUE_INTENT_INSULT;
+	if (strcmp(intent_id, "REQUEST_HELP") == 0)
+		return BANANA_K3H4_DIALOGUE_INTENT_REQUEST_HELP;
+
+	return BANANA_K3H4_DIALOGUE_INTENT_UNKNOWN;
+}
+
+static int policy_category_is_hard_block(const char *policy_category)
+{
+	if (!policy_category)
+		return 0;
+
+	return strcmp(policy_category, "minor_safety") == 0 ||
+		   strcmp(policy_category, "self_harm") == 0 ||
+		   strcmp(policy_category, "real_world_violence") == 0 ||
+		   strcmp(policy_category, "hate_or_slur_severe") == 0;
+}
+
+static banana_native_v3_k3h4_dialogue_policy_action decide_policy_action(
+	const banana_native_v3_k3h4_dialogue_turn_input *turn_input)
+{
+	int is_high_confidence;
+	int is_boundary_confidence;
+
+	if (!turn_input)
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_ALLOW;
+
+	is_high_confidence = strcmp(turn_input->policy_confidence_band, "high") == 0;
+	is_boundary_confidence = strcmp(turn_input->policy_confidence_band, "boundary") == 0 ||
+					 strcmp(turn_input->policy_confidence_band, "medium") == 0;
+
+	if (policy_category_is_hard_block(turn_input->policy_category) && is_high_confidence)
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_HARD_BLOCK;
+
+	if (policy_category_is_hard_block(turn_input->policy_category) && is_boundary_confidence)
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_SAFE_REDIRECT;
+
+	if (strcmp(turn_input->policy_category, "jailbreak_or_prompt_attack") == 0)
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_SAFE_REDIRECT;
+
+	return BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_ALLOW;
+}
+
+static uint32_t proposed_fact_mask_for_intent(BananaK3h4DialogueIntent intent)
+{
+	switch (intent)
+	{
+	case BANANA_K3H4_DIALOGUE_INTENT_ASK_CASTLE_ENTRY:
+		return BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ENTRY_WRIT_STATUS;
+	case BANANA_K3H4_DIALOGUE_INTENT_ASK_DIRECTIONS:
+		return BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS;
+	case BANANA_K3H4_DIALOGUE_INTENT_INSULT:
+		return BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_ESCALATION_WARNING;
+	case BANANA_K3H4_DIALOGUE_INTENT_REQUEST_HELP:
+		return BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_HELP_GUIDANCE;
+	case BANANA_K3H4_DIALOGUE_INTENT_UNKNOWN:
+	default:
+		return BANANA_K3H4_DIALOGUE_TEMPLATE_FACT_MASK_PUBLIC_GATE_DIRECTIONS;
+	}
+}
+
+static BananaK3h4DialogueSpectralState requested_state_for_route(
+	const BananaK3h4DialogueRouteOutput *route_output)
+{
+	if (!route_output)
+		return BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ENTRY_GATE;
+
+	switch (route_output->response_contract.response_mode)
+	{
+	case BANANA_K3H4_DIALOGUE_RESPONSE_DENY:
+		return BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_DENY;
+	case BANANA_K3H4_DIALOGUE_RESPONSE_REDIRECT:
+		return BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_REDIRECT;
+	case BANANA_K3H4_DIALOGUE_RESPONSE_DEESCALATE:
+		return BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_DEESCALATE;
+	case BANANA_K3H4_DIALOGUE_RESPONSE_ASSIST:
+		return BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ASSIST;
+	case BANANA_K3H4_DIALOGUE_RESPONSE_NEUTRAL:
+	default:
+		return BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ENTRY_GATE;
+	}
+}
+
+static void ensure_dialogue_memory_store(void)
+{
+	BananaK3h4DialogueMemoryPolicy policy;
+
+	if (s_dialogue_memory_initialized)
+		return;
+
+	policy.ttl_ticks = 16;
+	policy.delta_min = -8192;
+	policy.delta_max = 8192;
+	banana_native_k3h4_dialogue_memory_init(&s_dialogue_memory_store, policy);
+	s_dialogue_memory_initialized = 1;
+}
+
+static void select_fallback_line(const banana_native_v3_k3h4_dialogue_turn_input *turn_input,
+				 banana_native_v3_k3h4_dialogue_turn_output *out_output)
+{
+	uint32_t hash;
+	int slot;
+
+	hash = hash_text_seed(hash_text(turn_input->policy_category), turn_input->npc_id);
+	slot = (int)(hash % 3u);
+
+	if (slot == 0)
+	{
+		copy_text(out_output->npc_line_candidate,
+			  sizeof(out_output->npc_line_candidate),
+			  "I cannot help with that. We can discuss safe alternatives inside the gate protocol.");
+	}
+	else if (slot == 1)
+	{
+		copy_text(out_output->npc_line_candidate,
+			  sizeof(out_output->npc_line_candidate),
+			  "That request is blocked. I can offer lawful guidance for the South Gate instead.");
+	}
+	else
+	{
+		copy_text(out_output->npc_line_candidate,
+			  sizeof(out_output->npc_line_candidate),
+			  "I will not continue on that path. Ask for directions or entry requirements instead.");
+	}
+}
+
+static void select_allow_line(const BananaK3h4DialogueGeneratorOutput *generator_output,
+			      banana_native_v3_k3h4_dialogue_turn_output *out_output)
+{
+	if (text_contains(generator_output->selected_template_key, "assist"))
+	{
+		copy_text(out_output->npc_line_candidate,
+			  sizeof(out_output->npc_line_candidate),
+			  "Bring your writ to the registrar and I can guide you through entry.");
+		return;
+	}
+
+	if (text_contains(generator_output->selected_template_key, "deescalate"))
+	{
+		copy_text(out_output->npc_line_candidate,
+			  sizeof(out_output->npc_line_candidate),
+			  "Stand down and speak plainly. We can settle this at the checkpoint.");
+		return;
+	}
+
+	if (text_contains(generator_output->selected_template_key, "redirect"))
+	{
+		copy_text(out_output->npc_line_candidate,
+			  sizeof(out_output->npc_line_candidate),
+			  "Use the public gate road and report to the watch post for next steps.");
+		return;
+	}
+
+	copy_text(out_output->npc_line_candidate,
+		  sizeof(out_output->npc_line_candidate),
+		  "State your business at South Gate and I will review your entry status.");
+}
 
 static int32_t map_runtime_contract_status(int status)
 {
@@ -472,6 +693,132 @@ int banana_native_v3_netcode_build_k3h4(const banana_native_v3_netcode_vector_in
 	}
 
 	return 0;
+}
+
+int banana_native_v3_k3h4_run_dialogue_turn(
+	const banana_native_v3_k3h4_dialogue_turn_input *turn_input,
+	banana_native_v3_k3h4_dialogue_turn_output *out_output)
+{
+	BananaK3h4DialogueRouteInput route_input;
+	BananaK3h4DialogueRouteOutput route_output;
+	BananaK3h4DialogueTemplateInput template_input;
+	BananaK3h4DialogueTemplateOutput template_output;
+	BananaK3h4DialogueGeneratorInput generator_input;
+	BananaK3h4DialogueGeneratorOutput generator_output;
+	BananaK3h4DialogueSpectralTransitionInput spectral_input;
+	BananaK3h4DialogueSpectralTransitionOutput spectral_output;
+	banana_native_v3_k3h4_dialogue_policy_action policy_action;
+	BananaK3h4DialogueAbiEnvelope abi_envelope;
+	uint8_t abi_buffer[256];
+	size_t abi_written = 0;
+	uint32_t npc_hash;
+	int status;
+
+	if (!turn_input || !out_output)
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_INVALID_ARGUMENT;
+
+	memset(out_output, 0, sizeof(*out_output));
+	out_output->schema_version = 1;
+	out_output->abi_status = BANANA_K3H4_DIALOGUE_ABI_INVALID_ARGUMENT;
+
+	route_input.intent = parse_dialogue_intent(turn_input->intent_id);
+	route_input.has_entry_writ = text_contains(turn_input->quest_state_id, "granted") ? 1 : 0;
+	route_input.mentions_secret_tunnel = text_contains(turn_input->intent_id, "SECRET_TUNNEL") ? 1 : 0;
+	route_input.ambiguity_basis_points =
+		strcmp(turn_input->policy_confidence_band, "low") == 0 ? 900 :
+		strcmp(turn_input->policy_confidence_band, "boundary") == 0 ? 1300 : 200;
+
+	status = banana_native_k3h4_route_dialogue_cluster(&route_input, &route_output);
+	if (status != 0)
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_EXECUTION_FAILED;
+
+	template_input.route_output = route_output;
+	template_input.proposed_fact_mask = proposed_fact_mask_for_intent(route_input.intent);
+	status = banana_native_k3h4_resolve_dialogue_template(&template_input, &template_output);
+	if (status != 0)
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_EXECUTION_FAILED;
+
+	generator_input.template_output = template_output;
+	generator_input.selected_fact_mask = template_input.proposed_fact_mask;
+	generator_input.canon_violation_mask = 0u;
+	status = banana_native_k3h4_assemble_dialogue_generator_contract(&generator_input, &generator_output);
+	if (status != 0 && status != -2)
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_EXECUTION_FAILED;
+
+	spectral_input.current_state = BANANA_K3H4_DIALOGUE_SPECTRAL_STATE_ENTRY_GATE;
+	spectral_input.requested_state = requested_state_for_route(&route_output);
+	spectral_input.route_output = route_output;
+	banana_native_k3h4_resolve_spectral_transition(&spectral_input, &spectral_output);
+
+	status = banana_native_k3h4_dialogue_abi_encode(&spectral_output, abi_buffer, sizeof(abi_buffer), &abi_written);
+	if (status != BANANA_K3H4_DIALOGUE_ABI_OK)
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_EXECUTION_FAILED;
+
+	status = banana_native_k3h4_dialogue_abi_decode(abi_buffer, abi_written, &abi_envelope);
+	if (status != BANANA_K3H4_DIALOGUE_ABI_OK)
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_EXECUTION_FAILED;
+
+	policy_action = decide_policy_action(turn_input);
+
+	out_output->route_cluster_id = route_output.cluster_id;
+	out_output->boundary_state = route_output.boundary_state;
+	out_output->transition_id = route_output.transition_id;
+	out_output->response_policy = route_output.response_contract.response_mode;
+	out_output->deny_reason_code = generator_output.deny_code != 0 ?
+		generator_output.deny_code : spectral_output.deny_reason_code;
+	out_output->policy_action_selected = policy_action;
+	out_output->abi_decode_path = abi_envelope.telemetry.endianness_decode_path;
+	out_output->abi_contract_version = (int32_t)abi_envelope.contract_version;
+	out_output->abi_payload_bytes = abi_envelope.telemetry.payload_bytes;
+	out_output->abi_crc32 = (int32_t)abi_envelope.crc32;
+	out_output->abi_status = BANANA_K3H4_DIALOGUE_ABI_OK;
+	copy_text(out_output->selected_template_key,
+		  sizeof(out_output->selected_template_key),
+		  generator_output.selected_template_key);
+
+	if (policy_action == BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_HARD_BLOCK)
+	{
+		out_output->state_mutation_blocked = 1;
+		out_output->memory_write_blocked = 1;
+		out_output->memory_delta_applied = 0;
+		out_output->deny_reason_code = (int32_t)(9100 + (hash_text(turn_input->policy_category) % 100u));
+		copy_text(out_output->response_policy_label,
+			  sizeof(out_output->response_policy_label),
+			  "hard_block");
+		select_fallback_line(turn_input, out_output);
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK;
+	}
+
+	if (policy_action == BANANA_NATIVE_V3_K3H4_DIALOGUE_POLICY_ACTION_SAFE_REDIRECT)
+	{
+		out_output->state_mutation_blocked = 1;
+		out_output->memory_write_blocked = 1;
+		out_output->memory_delta_applied = 0;
+		copy_text(out_output->response_policy_label,
+			  sizeof(out_output->response_policy_label),
+			  "safe_redirect");
+		select_fallback_line(turn_input, out_output);
+		return BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK;
+	}
+
+	out_output->state_mutation_blocked = 0;
+	out_output->memory_write_blocked = 0;
+	copy_text(out_output->response_policy_label,
+		  sizeof(out_output->response_policy_label),
+		  generator_output.fail_closed ? "fail_closed" : "allow");
+	select_allow_line(&generator_output, out_output);
+
+	ensure_dialogue_memory_store();
+	npc_hash = hash_text(turn_input->npc_id);
+	status = banana_native_k3h4_dialogue_memory_upsert_delta(
+		&s_dialogue_memory_store,
+		npc_hash == 0 ? 1u : npc_hash,
+		BANANA_K3H4_DIALOGUE_MEMORY_FEATURE_TRUST_DELTA,
+		turn_input->prior_memory_trust_delta_q16,
+		(uint64_t)(turn_input->sequence_tick < 0 ? 0 : turn_input->sequence_tick));
+	out_output->memory_delta_applied = (status == 0) ? 1 : 0;
+
+	return BANANA_NATIVE_V3_K3H4_DIALOGUE_TURN_OK;
 }
 
 int banana_native_v3_launch_gate_policy_resolve(const char *mode_label,

--- a/tests/native/CMakeLists.txt
+++ b/tests/native/CMakeLists.txt
@@ -1422,6 +1422,40 @@ if(EXISTS "${BANANA_K3H4_DIALOGUE_ABI_ENVELOPE_TEST_SOURCE}")
 	)
 endif()
 
+set(BANANA_K3H4_DIALOGUE_NATIVE_ENTRY_TURN_TEST_SOURCE
+	"${BANANA_K3H4_TEST_DIR}/k3h4/k3h4_dialogue_native_entry_turn_test.c"
+)
+
+if(EXISTS "${BANANA_K3H4_DIALOGUE_NATIVE_ENTRY_TURN_TEST_SOURCE}")
+	add_executable(banana_native_k3h4_dialogue_native_entry_turn_test
+		${BANANA_K3H4_DIALOGUE_NATIVE_ENTRY_TURN_TEST_SOURCE}
+	)
+
+	add_test(NAME banana_native_k3h4_dialogue_native_entry_turn_test
+		COMMAND banana_native_k3h4_dialogue_native_entry_turn_test
+	)
+
+	target_link_libraries(banana_native_k3h4_dialogue_native_entry_turn_test PRIVATE banana_engine_core)
+	target_link_libraries(banana_native_k3h4_dialogue_native_entry_turn_test PRIVATE banana_native)
+
+	if(WIN32)
+		add_custom_command(TARGET banana_native_k3h4_dialogue_native_entry_turn_test POST_BUILD
+			COMMAND ${CMAKE_COMMAND}
+				-Dbanana_runtime_dlls=$<JOIN:$<TARGET_RUNTIME_DLLS:banana_native_k3h4_dialogue_native_entry_turn_test>,|>
+				-Dbanana_target_dir=$<TARGET_FILE_DIR:banana_native_k3h4_dialogue_native_entry_turn_test>
+				-P ${CMAKE_CURRENT_LIST_DIR}/runtime/support/copy_runtime_dlls.cmake
+			COMMENT "Copying runtime DLLs next to banana_native_k3h4_dialogue_native_entry_turn_test"
+		)
+	endif()
+
+	target_include_directories(banana_native_k3h4_dialogue_native_entry_turn_test PRIVATE
+		${BANANA_ENGINE_DIR}
+		${BANANA_ENGINE_DIR}/runtime
+		${CMAKE_CURRENT_LIST_DIR}/../../src/native
+		${BANANA_K3H4_SRC_DIR}
+	)
+endif()
+
 add_executable(banana_runtime_terrain_generation_test
 	${CMAKE_CURRENT_LIST_DIR}/runtime/terrain/terrain_generation_test.c
 )


### PR DESCRIPTION
## Summary
- wire the local `banana k3h4` dialogue loop through the native full-chain entrypoint
- add canonical dialogue run/export schema validation and deny-code taxonomy enforcement
- add focused native regression coverage plus a one-command local smoke script
- update K3H4 docs/context for the deterministic local generative workflow

## Validation
- `bash cli/banana/scripts/run-dialogue-taxonomy-smoke.sh`
- `ctest -C Debug --test-dir out/v3-native -R banana_native_k3h4_dialogue_native_entry_turn_test --output-on-failure`

## Notes
- advances the local deterministic CLI loop under #1175
- does not close #1175; the epic remains the live container for remaining dialogue scope
