### PR TITLE
Fix preview frontend blocked by API CORS

### DIFF
--- a/src/typescript/api/fly.toml
+++ b/src/typescript/api/fly.toml
@@ -12,7 +12,7 @@ kill_timeout = "5s"
   BANANA_NATIVE_PATH = "/app/src/typescript/api/libbanana_native.so"
   BANANA_ENGINE_ADAPTER = "inmemory"
   BANANA_ANTICHEAT_ADAPTER = "inmemory"
-  BANANA_CORS_ORIGINS = "https://banana.engineer,http://localhost:5173,http://127.0.0.1:5173"
+  BANANA_CORS_ORIGINS = "https://banana.engineer,https://www.banana.engineer,https://*.vercel.app,http://localhost:5173,http://127.0.0.1:5173"
   NODE_ENV = "production"
   BANANA_NEON_STRICT = "true"
 

--- a/src/typescript/api/src/index.ts
+++ b/src/typescript/api/src/index.ts
@@ -3,6 +3,7 @@ import helmet from '@fastify/helmet';
 import Fastify from 'fastify';
 
 import {bootstrapPersistentWorldOrchestrationDomain} from './domains/persistent-world-orchestration/index.ts';
+import {buildCorsOriginMatcher} from './lib/corsOrigins.ts';
 import {assertRouteOwnershipCoverage} from './lib/domainOwnership';
 import {registerFastifyErrorMapper} from './lib/errors/fastifyErrorMapper.ts';
 import {registerRequestContextMiddleware} from './middleware/requestContext';
@@ -55,13 +56,12 @@ const persistentWorldOrchestrationDomain =
 // Spec #126 — BANANA_CORS_ORIGINS: comma-separated list of allowed origins.
 // Defaults to localhost dev servers when the env var is absent.
 const _corsOriginsEnv = process.env.BANANA_CORS_ORIGINS ??
-    'http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174,http://localhost:5175,http://127.0.0.1:5175,http://localhost:5176,http://127.0.0.1:5176,http://localhost:3000,http://127.0.0.1:3000';
-const ALLOWED_WEB_ORIGINS =
-    new Set(_corsOriginsEnv.split(',').map((o) => o.trim()).filter(Boolean));
+    'https://banana.engineer,https://www.banana.engineer,https://*.vercel.app,http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174,http://localhost:5175,http://127.0.0.1:5175,http://localhost:5176,http://127.0.0.1:5176,http://localhost:3000,http://127.0.0.1:3000';
+const isAllowedWebOrigin = buildCorsOriginMatcher(_corsOriginsEnv);
 
 app.addHook('onRequest', async (request, reply) => {
   const origin = (request.headers.origin ?? '').toString();
-  if (ALLOWED_WEB_ORIGINS.has(origin)) {
+  if (isAllowedWebOrigin(origin)) {
     reply.header('Access-Control-Allow-Origin', origin);
     reply.header('Vary', 'Origin');
     reply.header(

--- a/src/typescript/api/src/lib/corsOrigins.test.ts
+++ b/src/typescript/api/src/lib/corsOrigins.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, test} from 'bun:test';
+
+import {buildCorsOriginMatcher} from './corsOrigins.ts';
+
+describe('buildCorsOriginMatcher', () => {
+  const isAllowed = buildCorsOriginMatcher(
+      'https://banana.engineer,https://*.vercel.app,http://localhost:5173');
+
+  test('allows exact origin matches', () => {
+    expect(isAllowed('https://banana.engineer')).toBe(true);
+    expect(isAllowed('http://localhost:5173')).toBe(true);
+  });
+
+  test('allows wildcard preview domains', () => {
+    expect(isAllowed('https://banana-ui-preview.vercel.app')).toBe(true);
+    expect(isAllowed('https://banana-git-branch-user.vercel.app')).toBe(true);
+  });
+
+  test('rejects bare wildcard base domain', () => {
+    expect(isAllowed('https://vercel.app')).toBe(false);
+  });
+
+  test('rejects protocol mismatches for wildcard domains', () => {
+    expect(isAllowed('http://banana-ui-preview.vercel.app')).toBe(false);
+  });
+
+  test('rejects non-matching domains', () => {
+    expect(isAllowed('https://banana-ui-preview.example.com')).toBe(false);
+  });
+
+  test('rejects non-origin values with paths or query', () => {
+    expect(isAllowed('https://banana.engineer/some/path')).toBe(false);
+    expect(isAllowed('https://banana.engineer?foo=bar')).toBe(false);
+  });
+});

--- a/src/typescript/api/src/lib/corsOrigins.ts
+++ b/src/typescript/api/src/lib/corsOrigins.ts
@@ -1,0 +1,80 @@
+type ParsedOriginPattern = {
+  protocol: string;
+  host: string;
+  port: string;
+  wildcardHostSuffix: string | null;
+};
+
+function parseOriginPattern(pattern: string): ParsedOriginPattern | null {
+  try {
+    const parsed = new URL(pattern);
+    if (parsed.pathname !== '/' || parsed.search.length > 0 ||
+        parsed.hash.length > 0) {
+      return null;
+    }
+
+    const host = parsed.hostname.trim().toLowerCase();
+    if (host.length === 0) {
+      return null;
+    }
+
+    const wildcardHostSuffix = host.startsWith('*.') ? host.slice(1) : null;
+    return {
+      protocol: parsed.protocol,
+      host,
+      port: parsed.port,
+      wildcardHostSuffix,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function matchesOriginPattern(
+    origin: URL,
+    pattern: ParsedOriginPattern,
+    ): boolean {
+  if (origin.protocol !== pattern.protocol) {
+    return false;
+  }
+
+  if (origin.port !== pattern.port) {
+    return false;
+  }
+
+  const normalizedOriginHost = origin.hostname.trim().toLowerCase();
+  if (pattern.wildcardHostSuffix) {
+    return normalizedOriginHost.endsWith(pattern.wildcardHostSuffix) &&
+        normalizedOriginHost.length > pattern.wildcardHostSuffix.length;
+  }
+
+  return normalizedOriginHost === pattern.host;
+}
+
+export function buildCorsOriginMatcher(originsEnv: string): (origin: string) => boolean {
+  const patterns = originsEnv.split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .map(parseOriginPattern)
+      .filter((pattern): pattern is ParsedOriginPattern => pattern !== null);
+
+  return (origin: string) => {
+    const normalizedOrigin = origin.trim();
+    if (normalizedOrigin.length === 0) {
+      return false;
+    }
+
+    try {
+      const parsedOrigin = new URL(normalizedOrigin);
+      if (parsedOrigin.pathname !== '/' || parsedOrigin.search.length > 0 ||
+          parsedOrigin.hash.length > 0) {
+        return false;
+      }
+
+      return patterns.some((pattern) =>
+        matchesOriginPattern(parsedOrigin, pattern));
+    } catch {
+      return false;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated API CORS origin matcher that supports explicit origins and wildcard subdomain patterns
- allow Vercel preview domains (https://*.vercel.app) in default API CORS settings
- update Fly API env defaults to include preview and production web origins
- add focused unit tests for CORS wildcard/exact matching behavior

## Validation
- bun test src/lib/corsOrigins.test.ts
- task: API: smoke (v3)

Closes #1150