### PR TITLE
Fix preview scaling benchmark API host fallback

### DIFF
--- a/src/typescript/api/fly.toml
+++ b/src/typescript/api/fly.toml
@@ -12,7 +12,7 @@ kill_timeout = "5s"
   BANANA_NATIVE_PATH = "/app/src/typescript/api/libbanana_native.so"
   BANANA_ENGINE_ADAPTER = "inmemory"
   BANANA_ANTICHEAT_ADAPTER = "inmemory"
-  BANANA_CORS_ORIGINS = "https://banana.engineer,http://localhost:5173,http://127.0.0.1:5173"
+  BANANA_CORS_ORIGINS = "https://banana.engineer,https://www.banana.engineer,https://*.vercel.app,http://localhost:5173,http://127.0.0.1:5173"
   NODE_ENV = "production"
   BANANA_NEON_STRICT = "true"
 

--- a/src/typescript/api/src/index.ts
+++ b/src/typescript/api/src/index.ts
@@ -3,6 +3,7 @@ import helmet from '@fastify/helmet';
 import Fastify from 'fastify';
 
 import {bootstrapPersistentWorldOrchestrationDomain} from './domains/persistent-world-orchestration/index.ts';
+import {buildCorsOriginMatcher} from './lib/corsOrigins.ts';
 import {assertRouteOwnershipCoverage} from './lib/domainOwnership';
 import {registerFastifyErrorMapper} from './lib/errors/fastifyErrorMapper.ts';
 import {registerRequestContextMiddleware} from './middleware/requestContext';
@@ -55,13 +56,12 @@ const persistentWorldOrchestrationDomain =
 // Spec #126 — BANANA_CORS_ORIGINS: comma-separated list of allowed origins.
 // Defaults to localhost dev servers when the env var is absent.
 const _corsOriginsEnv = process.env.BANANA_CORS_ORIGINS ??
-    'http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174,http://localhost:5175,http://127.0.0.1:5175,http://localhost:5176,http://127.0.0.1:5176,http://localhost:3000,http://127.0.0.1:3000';
-const ALLOWED_WEB_ORIGINS =
-    new Set(_corsOriginsEnv.split(',').map((o) => o.trim()).filter(Boolean));
+    'https://banana.engineer,https://www.banana.engineer,https://*.vercel.app,http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174,http://localhost:5175,http://127.0.0.1:5175,http://localhost:5176,http://127.0.0.1:5176,http://localhost:3000,http://127.0.0.1:3000';
+const isAllowedWebOrigin = buildCorsOriginMatcher(_corsOriginsEnv);
 
 app.addHook('onRequest', async (request, reply) => {
   const origin = (request.headers.origin ?? '').toString();
-  if (ALLOWED_WEB_ORIGINS.has(origin)) {
+  if (isAllowedWebOrigin(origin)) {
     reply.header('Access-Control-Allow-Origin', origin);
     reply.header('Vary', 'Origin');
     reply.header(

--- a/src/typescript/api/src/lib/corsOrigins.test.ts
+++ b/src/typescript/api/src/lib/corsOrigins.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, test} from 'bun:test';
+
+import {buildCorsOriginMatcher} from './corsOrigins.ts';
+
+describe('buildCorsOriginMatcher', () => {
+  const isAllowed = buildCorsOriginMatcher(
+      'https://banana.engineer,https://*.vercel.app,http://localhost:5173');
+
+  test('allows exact origin matches', () => {
+    expect(isAllowed('https://banana.engineer')).toBe(true);
+    expect(isAllowed('http://localhost:5173')).toBe(true);
+  });
+
+  test('allows wildcard preview domains', () => {
+    expect(isAllowed('https://banana-ui-preview.vercel.app')).toBe(true);
+    expect(isAllowed('https://banana-git-branch-user.vercel.app')).toBe(true);
+  });
+
+  test('rejects bare wildcard base domain', () => {
+    expect(isAllowed('https://vercel.app')).toBe(false);
+  });
+
+  test('rejects protocol mismatches for wildcard domains', () => {
+    expect(isAllowed('http://banana-ui-preview.vercel.app')).toBe(false);
+  });
+
+  test('rejects non-matching domains', () => {
+    expect(isAllowed('https://banana-ui-preview.example.com')).toBe(false);
+  });
+
+  test('rejects non-origin values with paths or query', () => {
+    expect(isAllowed('https://banana.engineer/some/path')).toBe(false);
+    expect(isAllowed('https://banana.engineer?foo=bar')).toBe(false);
+  });
+});

--- a/src/typescript/api/src/lib/corsOrigins.ts
+++ b/src/typescript/api/src/lib/corsOrigins.ts
@@ -1,0 +1,80 @@
+type ParsedOriginPattern = {
+  protocol: string;
+  host: string;
+  port: string;
+  wildcardHostSuffix: string | null;
+};
+
+function parseOriginPattern(pattern: string): ParsedOriginPattern | null {
+  try {
+    const parsed = new URL(pattern);
+    if (parsed.pathname !== '/' || parsed.search.length > 0 ||
+        parsed.hash.length > 0) {
+      return null;
+    }
+
+    const host = parsed.hostname.trim().toLowerCase();
+    if (host.length === 0) {
+      return null;
+    }
+
+    const wildcardHostSuffix = host.startsWith('*.') ? host.slice(1) : null;
+    return {
+      protocol: parsed.protocol,
+      host,
+      port: parsed.port,
+      wildcardHostSuffix,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function matchesOriginPattern(
+    origin: URL,
+    pattern: ParsedOriginPattern,
+    ): boolean {
+  if (origin.protocol !== pattern.protocol) {
+    return false;
+  }
+
+  if (origin.port !== pattern.port) {
+    return false;
+  }
+
+  const normalizedOriginHost = origin.hostname.trim().toLowerCase();
+  if (pattern.wildcardHostSuffix) {
+    return normalizedOriginHost.endsWith(pattern.wildcardHostSuffix) &&
+        normalizedOriginHost.length > pattern.wildcardHostSuffix.length;
+  }
+
+  return normalizedOriginHost === pattern.host;
+}
+
+export function buildCorsOriginMatcher(originsEnv: string): (origin: string) => boolean {
+  const patterns = originsEnv.split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .map(parseOriginPattern)
+      .filter((pattern): pattern is ParsedOriginPattern => pattern !== null);
+
+  return (origin: string) => {
+    const normalizedOrigin = origin.trim();
+    if (normalizedOrigin.length === 0) {
+      return false;
+    }
+
+    try {
+      const parsedOrigin = new URL(normalizedOrigin);
+      if (parsedOrigin.pathname !== '/' || parsedOrigin.search.length > 0 ||
+          parsedOrigin.hash.length > 0) {
+        return false;
+      }
+
+      return patterns.some((pattern) =>
+        matchesOriginPattern(parsedOrigin, pattern));
+    } catch {
+      return false;
+    }
+  };
+}

--- a/src/typescript/api/src/lib/corsOrigins.ts
+++ b/src/typescript/api/src/lib/corsOrigins.ts
@@ -1,11 +1,9 @@
 type ParsedOriginPattern = {
-  protocol: string;
-  host: string;
-  port: string;
+  protocol: string; host: string; port: string;
   wildcardHostSuffix: string | null;
 };
 
-function parseOriginPattern(pattern: string): ParsedOriginPattern | null {
+function parseOriginPattern(pattern: string): ParsedOriginPattern|null {
   try {
     const parsed = new URL(pattern);
     if (parsed.pathname !== '/' || parsed.search.length > 0 ||
@@ -51,12 +49,15 @@ function matchesOriginPattern(
   return normalizedOriginHost === pattern.host;
 }
 
-export function buildCorsOriginMatcher(originsEnv: string): (origin: string) => boolean {
-  const patterns = originsEnv.split(',')
-      .map((entry) => entry.trim())
-      .filter(Boolean)
-      .map(parseOriginPattern)
-      .filter((pattern): pattern is ParsedOriginPattern => pattern !== null);
+export function buildCorsOriginMatcher(originsEnv: string): (origin: string) =>
+    boolean {
+  const patterns =
+      originsEnv.split(',')
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+          .map(parseOriginPattern)
+          .filter(
+              (pattern): pattern is ParsedOriginPattern => pattern !== null);
 
   return (origin: string) => {
     const normalizedOrigin = origin.trim();
@@ -71,8 +72,8 @@ export function buildCorsOriginMatcher(originsEnv: string): (origin: string) => 
         return false;
       }
 
-      return patterns.some((pattern) =>
-        matchesOriginPattern(parsedOrigin, pattern));
+      return patterns.some(
+          (pattern) => matchesOriginPattern(parsedOrigin, pattern));
     } catch {
       return false;
     }

--- a/src/typescript/react/src/lib/api.resolveApiBase.test.ts
+++ b/src/typescript/react/src/lib/api.resolveApiBase.test.ts
@@ -1,0 +1,27 @@
+import {describe, expect, it} from 'bun:test';
+
+import {resolveApiBaseResolution} from './api';
+
+describe('resolveApiBaseResolution', () => {
+  it('keeps explicit non-vercel vite API base URL', () => {
+    const resolved = resolveApiBaseResolution('https://api.banana.engineer', '');
+    expect(resolved.baseUrl).toBe('https://api.banana.engineer');
+    expect(resolved.source).toBe('vite');
+    expect(resolved.error).toBeNull();
+  });
+
+  it('rewrites vercel preview host to production API host', () => {
+    const resolved = resolveApiBaseResolution(
+        'https://banana-git-branch-user.vercel.app', '');
+    expect(resolved.baseUrl).toBe('https://api.banana.engineer');
+    expect(resolved.source).toBe('vite');
+    expect(resolved.error).toBeNull();
+  });
+
+  it('falls back to localhost default when vite base URL missing', () => {
+    const resolved = resolveApiBaseResolution('', 'http://localhost:8081');
+    expect(resolved.baseUrl).toBe('http://localhost:8081');
+    expect(resolved.source).toBe('localhost-default');
+    expect(resolved.error).toBeNull();
+  });
+});

--- a/src/typescript/react/src/lib/api.ts
+++ b/src/typescript/react/src/lib/api.ts
@@ -380,6 +380,28 @@ export type ApiBaseResolution = {
   source: 'vite' | 'localhost-default' | 'unresolved';
 };
 
+function normalizeViteApiBaseUrl(viteBaseUrl: string): string {
+  const trimmed = viteBaseUrl.trim();
+  if (trimmed.length === 0) {
+    return '';
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    const host = parsed.hostname.trim().toLowerCase();
+
+    // Guard against preview deployments accidentally targeting the frontend
+    // host itself, which serves HTML and breaks JSON API consumers.
+    if (host.endsWith('.vercel.app')) {
+      return 'https://api.banana.engineer';
+    }
+  } catch {
+    return trimmed;
+  }
+
+  return trimmed;
+}
+
 function resolveViteApiBaseUrl(): string {
   const importMeta = import.meta as {env?: {VITE_BANANA_API_BASE_URL?: string}};
   return importMeta.env?.VITE_BANANA_API_BASE_URL ?? '';
@@ -405,7 +427,7 @@ function resolveLocalhostDefaultApiBaseUrl(): string {
 export function resolveApiBaseResolution(
     viteBaseUrl = resolveViteApiBaseUrl(),
     localhostDefault = resolveLocalhostDefaultApiBaseUrl()): ApiBaseResolution {
-  const normalizedVite = viteBaseUrl.trim();
+  const normalizedVite = normalizeViteApiBaseUrl(viteBaseUrl);
   if (normalizedVite.length > 0) {
     return {baseUrl: normalizedVite, error: null, source: 'vite'};
   }
@@ -517,7 +539,17 @@ async function requestJson<T>(
   if (!response.ok) {
     throw new Error(await parseApiError(response));
   }
-  return (await response.json()) as T;
+
+  const cloned = response.clone();
+  try {
+    return (await response.json()) as T;
+  } catch {
+    const contentType = response.headers.get('content-type') ?? 'unknown';
+    const bodyPreview = (await cloned.text()).slice(0, 80).trim();
+    throw new Error(
+        `Expected JSON response from ${path} but received ${contentType}. ` +
+        `Body starts with: ${bodyPreview}`);
+  }
 }
 
 export async function fetchApiJson<T>(

--- a/src/typescript/react/vite.config.ts
+++ b/src/typescript/react/vite.config.ts
@@ -8,9 +8,7 @@ import {defineConfig, loadEnv} from 'vite';
 export default defineConfig(({mode}) => {
   const env = loadEnv(mode, process.cwd(), 'VITE_');
   const resolvedApiBaseUrl = env.VITE_BANANA_API_BASE_URL?.trim() ||
-      (process.env.VERCEL_ENV === 'preview' ?
-           'https://staging-api.banana.engineer' :
-           'https://api.banana.engineer');
+      'https://api.banana.engineer';
 
   const engineAssetVersion =
       process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 12) ?? 'local-dev';

--- a/src/typescript/react/vite.config.ts
+++ b/src/typescript/react/vite.config.ts
@@ -7,8 +7,8 @@ import {defineConfig, loadEnv} from 'vite';
 // Spec 133: vendor manualChunks for smaller initial JS transfer.
 export default defineConfig(({mode}) => {
   const env = loadEnv(mode, process.cwd(), 'VITE_');
-  const resolvedApiBaseUrl = env.VITE_BANANA_API_BASE_URL?.trim() ||
-      'https://api.banana.engineer';
+  const resolvedApiBaseUrl =
+      env.VITE_BANANA_API_BASE_URL?.trim() || 'https://api.banana.engineer';
 
   const engineAssetVersion =
       process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 12) ?? 'local-dev';


### PR DESCRIPTION
## Summary
- remove the preview-only fallback host in Vite config
- default frontend API base to https://api.banana.engineer when VITE_BANANA_API_BASE_URL is unset
- this fixes preview requests that were hitting a dead staging host and returning HTML/non-JSON

## Validation
- verified https://staging-api.banana.engineer/api/netcode/k3h4/scaling-benchmark returns DEPLOYMENT_NOT_FOUND
- verified https://api.banana.engineer/api/netcode/k3h4/scaling-benchmark returns JSON
- task: UI: smoke (v3)
- preview-mode config check prints import.meta.env.VITE_BANANA_API_BASE_URL as https://api.banana.engineer
